### PR TITLE
feat: gate calibrations that bind to built main programs

### DIFF
--- a/src/braket/experimental/autoqasm/__init__.py
+++ b/src/braket/experimental/autoqasm/__init__.py
@@ -40,7 +40,7 @@ The Python code above outputs the following OpenQASM program:
     result[1] = measure __qubits__[1];
 """
 
-from .api import calibration, gate, main, subroutine  # noqa: F401
+from .api import gate, main, pulse_sequence, subroutine  # noqa: F401
 from .instructions import QubitIdentifierType as Qubit  # noqa: F401
 from .program import Program, build_program, verbatim  # noqa: F401
 from .transpiler import transpiler  # noqa: F401

--- a/src/braket/experimental/autoqasm/__init__.py
+++ b/src/braket/experimental/autoqasm/__init__.py
@@ -40,7 +40,7 @@ The Python code above outputs the following OpenQASM program:
     result[1] = measure __qubits__[1];
 """
 
-from .api import gate, main, subroutine  # noqa: F401
+from .api import calibration, gate, main, subroutine  # noqa: F401
 from .instructions import QubitIdentifierType as Qubit  # noqa: F401
 from .program import Program, build_program, verbatim  # noqa: F401
 from .transpiler import transpiler  # noqa: F401

--- a/src/braket/experimental/autoqasm/__init__.py
+++ b/src/braket/experimental/autoqasm/__init__.py
@@ -40,7 +40,7 @@ The Python code above outputs the following OpenQASM program:
     result[1] = measure __qubits__[1];
 """
 
-from .api import gate, main, pulse_sequence, subroutine  # noqa: F401
+from .api import gate, gate_calibration, main, subroutine  # noqa: F401
 from .instructions import QubitIdentifierType as Qubit  # noqa: F401
 from .program import Program, build_program, verbatim  # noqa: F401
 from .transpiler import transpiler  # noqa: F401

--- a/src/braket/experimental/autoqasm/api.py
+++ b/src/braket/experimental/autoqasm/api.py
@@ -34,7 +34,8 @@ from braket.experimental.autoqasm.autograph.impl.api_core import (
     is_autograph_artifact,
 )
 from braket.experimental.autoqasm.autograph.tf_utils import tf_decorator
-from braket.experimental.autoqasm.instructions import QubitIdentifierType as Qubit
+from braket.experimental.autoqasm.instructions.qubits import QubitIdentifierType as Qubit
+from braket.experimental.autoqasm.instructions.qubits import is_qubit_identifier_type
 from braket.experimental.autoqasm.program.gate_calibrations import GateCalibration
 
 
@@ -101,7 +102,7 @@ def calibration(
         angles (Union[float, Iterable[float]]): The angles at which the gate calibration is
                 defined. Defaults to [].
     """
-    if isinstance(qubits, Qubit):
+    if is_qubit_identifier_type(qubits):
         qubits = [qubits]
     if isinstance(angles, float):
         angles = [angles]

--- a/src/braket/experimental/autoqasm/api.py
+++ b/src/braket/experimental/autoqasm/api.py
@@ -90,7 +90,7 @@ def gate(*args) -> Callable[[Any], None]:
     return _function_wrapper(args, _convert_gate)
 
 
-def gate_calibration(*args, implements: Callable, **kwargs) -> Callable[None, GateCalibration]:
+def gate_calibration(*args, implements: Callable, **kwargs) -> Callable[[], GateCalibration]:
     """A decorator that register the decorated function as a gate calibration definition. The
     decorated function is added to a main program using `with_calibrations` method of the main
     program. The fixed values of qubits or angles that the calibration is implemented against
@@ -101,7 +101,7 @@ def gate_calibration(*args, implements: Callable, **kwargs) -> Callable[None, Ga
         implements (Callable): Gate function.
 
     Returns:
-        Callable[, GateCalibration]: A callable to be added to a main program using
+        Callable[[], GateCalibration]: A callable to be added to a main program using
         `with_calibrations` method of the main program.
     """
     converter_args = {"gate_function": implements, **kwargs}

--- a/src/braket/experimental/autoqasm/api.py
+++ b/src/braket/experimental/autoqasm/api.py
@@ -633,7 +633,7 @@ def _validate_calibration_args(
                 f'Parameter "{qubit_arg.name}" must have a type of aq.Qubit.'
             )
         if qubit_arg.name in func_args_names and qubit_arg.name not in [
-            var.name for var in func_args.angles
+            var.name for var in func_args.qubits
         ]:
             raise errors.ParameterTypeError(
                 f'Parameter "{qubit_arg.name}" must have a type hint of aq.Qubit.'

--- a/src/braket/experimental/autoqasm/api.py
+++ b/src/braket/experimental/autoqasm/api.py
@@ -90,15 +90,19 @@ def gate(*args) -> Callable[[Any], None]:
     return _function_wrapper(args, _convert_gate)
 
 
-def gate_calibration(*args, implements: Callable, **kwargs):
+def gate_calibration(*args, implements: Callable, **kwargs) -> Callable[None, GateCalibration]:
     """A decorator that register the decorated function as a gate calibration definition. The
-    decorated function is added to a main program using `with_calibrations` method of the main.
-    main program.
+    decorated function is added to a main program using `with_calibrations` method of the main
+    program. The fixed values of qubits or angles that the calibration is implemented against
+    are supplied as kwargs. The name of the kwargs must match the args of the gate function it
+    implements.
 
     Args:
         implements (Callable): Gate function.
-        kwargs (Union[Qubit, float]): The fixed value of qubits or angles that the calibration is
-            implemented against. The name of the kwargs must match the args of the gate function.
+
+    Returns:
+        Callable[, GateCalibration]: A callable to be added to a main program using
+        `with_calibrations` method of the main program.
     """
     converter_args = {"gate_function": implements, **kwargs}
 
@@ -495,7 +499,7 @@ def _wrap_for_oqpy_gate(
         options (converter.ConversionOptions): Converter options.
 
     Returns:
-        Callable: The modified function for use with oqpy.gate.
+        Callable[...,]: The modified function for use with oqpy.gate.
     """
 
     def _func(*args: Any) -> None:
@@ -512,7 +516,7 @@ def _get_gate_args(f: Callable) -> aq_program.GateArgs:
 
     Returns:
         aq_program.GateArgs: Object representing a list of qubit and angle arguments for
-            a gate definition.
+        a gate definition.
     """
     gate_args = aq_program.GateArgs()
     sig = inspect.signature(f)
@@ -552,7 +556,6 @@ def _convert_calibration(
         args (List[Any]): Arguments passed to the program when called.
         kwargs (Dict[str, Any]): Keyword arguments passed to the program when called.
         gate_function (Callable): The gate function which calibration is being defined.
-        decorator_kwargs: Keyword arguments passed to the calibration decorator.
 
     Returns:
         GateCalibration: Object representing the calibration definition.
@@ -599,7 +602,7 @@ def _convert_calibration(
         gate_function=gate_function,
         qubits=gate_calibration_qubits,
         angles=gate_calibration_angles,
-        oqpy_program=program_conversion_context.get_oqpy_program(),
+        program=program_conversion_context.make_program(),
     )
 
 

--- a/src/braket/experimental/autoqasm/api.py
+++ b/src/braket/experimental/autoqasm/api.py
@@ -98,7 +98,7 @@ def pulse_sequence(*args, **kwargs):
         return main(*args, **kwargs)
 
 
-def _calibration(*, implements: Callable, **kwargs):
+def _calibration(*args, implements: Callable, **kwargs):
     """A decorator that register the decorated function as a calibration definition of a gate
     in this `GateCalibrations` object.
 
@@ -111,10 +111,7 @@ def _calibration(*, implements: Callable, **kwargs):
     """
     converter_args = {"gate_function": implements, **kwargs}
 
-    def _function_with_params(f: Callable) -> Callable[[Any], aq_program.Program]:
-        return _function_wrapper(f, _convert_calibration, converter_args)
-
-    return _function_with_params
+    return _function_wrapper(args, _convert_calibration, converter_args)
 
 
 def _function_wrapper(

--- a/src/braket/experimental/autoqasm/api.py
+++ b/src/braket/experimental/autoqasm/api.py
@@ -36,7 +36,7 @@ from braket.experimental.autoqasm.autograph.impl.api_core import (
 )
 from braket.experimental.autoqasm.autograph.tf_utils import tf_decorator
 from braket.experimental.autoqasm.instructions.qubits import QubitIdentifierType as Qubit
-from braket.experimental.autoqasm.instructions.qubits import _qubit, is_qubit_identifier_type
+from braket.experimental.autoqasm.instructions.qubits import is_qubit_identifier_type
 from braket.experimental.autoqasm.program.gate_calibrations import GateCalibration
 
 
@@ -574,7 +574,7 @@ def _convert_calibration(
 
     fixed_valued_qubits = [decorator_kwargs[name] for name in decorator_qubit_names]
     fixed_valued_angles = [decorator_kwargs[name] for name in decorator_angle_names]
-    variable_qubits = [_qubit(q.name) for q in func_args.qubits]
+    variable_qubits = [oqpy.Qubit(name=q.name) for q in func_args.qubits]
     variable_angles = [oqpy.FloatVar(name=a.name) for a in func_args.angles]
     qubits = fixed_valued_qubits + variable_qubits
     angles = fixed_valued_angles + variable_angles
@@ -630,7 +630,13 @@ def _validate_calibration_args(
             decorator_args[qubit_arg.name]
         ):
             raise errors.ParameterTypeError(
-                f'Parameter "{qubit_arg.name}" must have a type hint of float.'
+                f'Parameter "{qubit_arg.name}" must have a type of aq.Qubit.'
+            )
+        if qubit_arg.name in func_args_names and qubit_arg.name not in [
+            var.name for var in func_args.angles
+        ]:
+            raise errors.ParameterTypeError(
+                f'Parameter "{qubit_arg.name}" must have a type hint of aq.Qubit.'
             )
 
     for angle_arg in gate_args.angles:
@@ -638,7 +644,7 @@ def _validate_calibration_args(
             decorator_args[angle_arg.name], float
         ):
             raise errors.ParameterTypeError(
-                f'Parameter "{angle_arg.name}" must have a type hint of float.'
+                f'Parameter "{angle_arg.name}" must have a type of float.'
             )
         if angle_arg.name in func_args_names and angle_arg.name not in [
             var.name for var in func_args.angles

--- a/src/braket/experimental/autoqasm/api.py
+++ b/src/braket/experimental/autoqasm/api.py
@@ -34,6 +34,7 @@ from braket.experimental.autoqasm.autograph.impl.api_core import (
     is_autograph_artifact,
 )
 from braket.experimental.autoqasm.autograph.tf_utils import tf_decorator
+from braket.experimental.autoqasm.program.gate_calibrations import GateCalibrations
 
 
 def main(*args, num_qubits: Optional[int] = None) -> Callable[[Any], aq_program.Program]:
@@ -158,6 +159,10 @@ def _convert_main(
         )
 
     with aq_program.build_program(user_config) as program_conversion_context:
+        # register calibration definitions
+        gate_calibrations = kwargs.pop("gate_calibrations", GateCalibrations())
+        gate_calibrations._register_to_program_context(program_conversion_context)
+
         # Process the program
         aq_transpiler.converted_call(f, args, kwargs, options=options)
 

--- a/src/braket/experimental/autoqasm/api.py
+++ b/src/braket/experimental/autoqasm/api.py
@@ -90,24 +90,15 @@ def gate(*args) -> Callable[[Any], None]:
     return _function_wrapper(args, _convert_gate)
 
 
-def pulse_sequence(*args, **kwargs):
-    if "implements" in kwargs:
-        assert len(args) == 0, "Cannot specify both `implements` and positional arguments."
-        return _calibration(**kwargs)
-    else:
-        return main(*args, **kwargs)
-
-
-def _calibration(*args, implements: Callable, **kwargs):
-    """A decorator that register the decorated function as a calibration definition of a gate
-    in this `GateCalibrations` object.
+def gate_calibration(*args, implements: Callable, **kwargs):
+    """A decorator that register the decorated function as a gate calibration definition. The
+    decorated function is added to a main program using `with_calibrations` method of the main.
+    main program.
 
     Args:
-        gate_name (str): Name of the gate
-        qubits (Union[Qubit,Iterable[Qubit]]): The qubits on which the gate calibration is
-            defined.
-        angles (Union[float, Iterable[float]]): The angles at which the gate calibration is
-                defined. Defaults to [].
+        implements (Callable): Gate function.
+        kwargs (Union[Qubit, float]): The fixed value of qubits or angles that the calibration is
+            implemented against. The name of the kwargs must match the args of the gate function.
     """
     converter_args = {"gate_function": implements, **kwargs}
 

--- a/src/braket/experimental/autoqasm/errors.py
+++ b/src/braket/experimental/autoqasm/errors.py
@@ -41,6 +41,10 @@ class InvalidGateDefinition(AutoQasmError):
     """Gate definition does not meet the necessary requirements."""
 
 
+class InvalidCalibrationDefinition(AutoQasmError):
+    """Calibration definition does not meet the necessary requirements."""
+
+
 class UnknownQubitCountError(AutoQasmError):
     """Missing declaration for the number of qubits."""
 

--- a/src/braket/experimental/autoqasm/instructions/qubits.py
+++ b/src/braket/experimental/autoqasm/instructions/qubits.py
@@ -22,7 +22,7 @@ from openpulse.printer import dumps
 
 from braket.experimental.autoqasm import constants, errors, program
 
-QubitIdentifierType = Union[int, oqpy._ClassicalVar, oqpy.base.OQPyExpression, str]
+QubitIdentifierType = Union[int, oqpy._ClassicalVar, oqpy.base.OQPyExpression, str, oqpy.Qubit]
 
 
 def is_qubit_identifier_type(qubit: Any) -> bool:

--- a/src/braket/experimental/autoqasm/program/gate_calibrations.py
+++ b/src/braket/experimental/autoqasm/program/gate_calibrations.py
@@ -16,9 +16,8 @@ from __future__ import annotations
 
 from typing import Callable, Iterable
 
-import oqpy
-
 from braket.experimental.autoqasm.instructions.qubits import QubitIdentifierType as Qubit
+from braket.experimental.autoqasm.program import Program
 
 
 class GateCalibration:
@@ -27,17 +26,18 @@ class GateCalibration:
         gate_function: Callable,
         qubits: Iterable[Qubit],
         angles: Iterable[float],
-        oqpy_program: oqpy.Program,
+        program: Program,
     ):
-        """_summary_
+        """Definition of a gate calibration, including pulse instructions and the qubits, angles
+        and the gate it implements.
 
         Args:
             gate_function (Callable): The gate function which calibration is defined.
-            qubits (Tuple[Qubit]): The qubits on which the gate calibration is defined.
-            angles (Tuple[float]): The angles at which the gate calibration is defined.
-            calibration_callable (oqpy.Program): _description_
+            qubits (Iterable[Qubit]): The qubits on which the gate calibration is defined.
+            angles (Iterable[float]): The angles at which the gate calibration is defined.
+            program (Program): Calibration instructions as an AutoQASM program.
         """
         self.gate_function = gate_function
         self.qubits = qubits
         self.angles = angles
-        self.oqpy_program = oqpy_program
+        self.program = program

--- a/src/braket/experimental/autoqasm/program/gate_calibrations.py
+++ b/src/braket/experimental/autoqasm/program/gate_calibrations.py
@@ -14,41 +14,38 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, Tuple
+from typing import Callable, Tuple
 
-import braket
 from braket.experimental.autoqasm import program as aq_program
+from braket.experimental.autoqasm.instructions.qubits import QubitIdentifierType as Qubit
 from braket.pulse import PulseSequence
 
-if TYPE_CHECKING:
-    from braket.experimental.autoqasm import Qubit
 
-
-class GateCalibrations:
-    # TODO: Possibly inherits from BDK GateCalibrations
-    """
-    A set of gate calibrations.
-    """
-
-    def __init__(self):
-        self._calibrations = {}
-
-    def register(self, gate_name: str, qubits: Tuple[Qubit], angles: Tuple[float] = ()):
-        """A decorator that register the decorated function as a calibration definition of a gate
-        in this `GateCalibrations` object.
+class GateCalibration:
+    def __init__(
+        self,
+        gate_name: str,
+        qubits: Tuple[Qubit],
+        angles: Tuple[float],
+        calibration_callable: Callable,
+    ):
+        """_summary_
 
         Args:
-            gate_name (str): Name of the gate
+            gate_name (str): Name of the gate.
             qubits (Tuple[Qubit]): The qubits on which the gate calibration is defined.
             angles (Tuple[float], optional): The angles at which the gate calibration is defined.
-                Defaults to ().
+            calibration_callable (Callable): _description_
         """
+        self.gate_name = gate_name
+        self.qubits = qubits
+        self.angles = angles
+        self.calibration_callable = calibration_callable
 
-        def wrapper(f: Callable):
-            self._calibrations[(gate_name, qubits, angles)] = f
-            return f
-
-        return wrapper
+    def _to_oqpy_program(self) -> PulseSequence:
+        with aq_program.build_program() as program_conversion_context:
+            self._register_to_program_context(program_conversion_context)
+        return program_conversion_context.get_oqpy_program()
 
     def _register_to_program_context(
         self, program_conversion_context: aq_program.ProgramConversionContext
@@ -59,28 +56,7 @@ class GateCalibrations:
             program_conversion_context (aq_program.ProgramConversionContext): The program context
                 to register the gate calibrations.
         """
-        for calibration_target, calibration_callable in self.calibrations.items():
-            gate_name, qubits, angles = calibration_target
-            with program_conversion_context.calibration_definition(gate_name, qubits, angles):
-                calibration_callable()
-
-    def export(self) -> braket.circuits.GateCalibrations:
-        """[WIP] Export to `device.run` compatible object
-
-        Returns:
-            braket.circuits.GateCalibrations:
-        """
-        # TODO: compete this part by making it compatible with device.run
-        exported_calibrations = {}
-        for calibration_target, calibration_callable in self.calibrations.items():
-            with aq_program.build_program(aq_program.UserConfig()) as program_conversion_context:
-                gate_name, qubits, angles = calibration_target
-                with program_conversion_context.calibration_definition(gate_name, qubits, angles):
-                    pulse_sequence = PulseSequence()
-                    pulse_sequence._program = calibration_callable()._oqpy_program
-                    exported_calibrations[calibration_target] = pulse_sequence
-        return braket.circuits.GateCalibrations(exported_calibrations)
-
-    @property
-    def calibrations(self):
-        return self._calibrations
+        with program_conversion_context.calibration_definition(
+            self.gate_name, self.qubits, self.angles
+        ):
+            self.calibration_callable()

--- a/src/braket/experimental/autoqasm/program/gate_calibrations.py
+++ b/src/braket/experimental/autoqasm/program/gate_calibrations.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Callable, Iterable
 
 import oqpy
 
@@ -24,7 +24,7 @@ from braket.experimental.autoqasm.instructions.qubits import QubitIdentifierType
 class GateCalibration:
     def __init__(
         self,
-        gate_name: str,
+        gate_function: Callable,
         qubits: Iterable[Qubit],
         angles: Iterable[float],
         oqpy_program: oqpy.Program,
@@ -32,12 +32,12 @@ class GateCalibration:
         """_summary_
 
         Args:
-            gate_name (str): Name of the gate.
+            gate_function (Callable): The gate function which calibration is defined.
             qubits (Tuple[Qubit]): The qubits on which the gate calibration is defined.
             angles (Tuple[float]): The angles at which the gate calibration is defined.
             calibration_callable (oqpy.Program): _description_
         """
-        self.gate_name = gate_name
+        self.gate_function = gate_function
         self.qubits = qubits
         self.angles = angles
         self.oqpy_program = oqpy_program

--- a/src/braket/experimental/autoqasm/program/gate_calibrations.py
+++ b/src/braket/experimental/autoqasm/program/gate_calibrations.py
@@ -14,49 +14,30 @@
 
 from __future__ import annotations
 
-from typing import Callable, Tuple
+from typing import Iterable
 
-from braket.experimental.autoqasm import program as aq_program
+import oqpy
+
 from braket.experimental.autoqasm.instructions.qubits import QubitIdentifierType as Qubit
-from braket.pulse import PulseSequence
 
 
 class GateCalibration:
     def __init__(
         self,
         gate_name: str,
-        qubits: Tuple[Qubit],
-        angles: Tuple[float],
-        calibration_callable: Callable,
+        qubits: Iterable[Qubit],
+        angles: Iterable[float],
+        oqpy_program: oqpy.Program,
     ):
         """_summary_
 
         Args:
             gate_name (str): Name of the gate.
             qubits (Tuple[Qubit]): The qubits on which the gate calibration is defined.
-            angles (Tuple[float], optional): The angles at which the gate calibration is defined.
-            calibration_callable (Callable): _description_
+            angles (Tuple[float]): The angles at which the gate calibration is defined.
+            calibration_callable (oqpy.Program): _description_
         """
         self.gate_name = gate_name
         self.qubits = qubits
         self.angles = angles
-        self.calibration_callable = calibration_callable
-
-    def _to_oqpy_program(self) -> PulseSequence:
-        with aq_program.build_program() as program_conversion_context:
-            self._register_to_program_context(program_conversion_context)
-        return program_conversion_context.get_oqpy_program()
-
-    def _register_to_program_context(
-        self, program_conversion_context: aq_program.ProgramConversionContext
-    ) -> None:
-        """Register the gate calibrations to a program conversion_context.
-
-        Args:
-            program_conversion_context (aq_program.ProgramConversionContext): The program context
-                to register the gate calibrations.
-        """
-        with program_conversion_context.calibration_definition(
-            self.gate_name, self.qubits, self.angles
-        ):
-            self.calibration_callable()
+        self.oqpy_program = oqpy_program

--- a/src/braket/experimental/autoqasm/program/gate_calibrations.py
+++ b/src/braket/experimental/autoqasm/program/gate_calibrations.py
@@ -1,0 +1,86 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable, Tuple
+
+import braket
+from braket.experimental.autoqasm import program as aq_program
+from braket.pulse import PulseSequence
+
+if TYPE_CHECKING:
+    from braket.experimental.autoqasm import Qubit
+
+
+class GateCalibrations:
+    # TODO: Possibly inherits from BDK GateCalibrations
+    """
+    A set of gate calibrations.
+    """
+
+    def __init__(self):
+        self._calibrations = {}
+
+    def register(self, gate_name: str, qubits: Tuple[Qubit], angles: Tuple[float] = ()):
+        """A decorator that register the decorated function as a calibration definition of a gate
+        in this `GateCalibrations` object.
+
+        Args:
+            gate_name (str): Name of the gate
+            qubits (Tuple[Qubit]): The qubits on which the gate calibration is defined.
+            angles (Tuple[float], optional): The angles at which the gate calibration is defined.
+                Defaults to ().
+        """
+
+        def wrapper(f: Callable):
+            self._calibrations[(gate_name, qubits, angles)] = f
+            return f
+
+        return wrapper
+
+    def _register_to_program_context(
+        self, program_conversion_context: aq_program.ProgramConversionContext
+    ) -> None:
+        """Register the gate calibrations to a program conversion_context.
+
+        Args:
+            program_conversion_context (aq_program.ProgramConversionContext): The program context
+                to register the gate calibrations.
+        """
+        for calibration_target, calibration_callable in self.calibrations.items():
+            gate_name, qubits, angles = calibration_target
+            with program_conversion_context.calibration_definition(gate_name, qubits, angles):
+                calibration_callable()
+
+    def export(self) -> braket.circuits.GateCalibrations:
+        """[WIP] Export to `device.run` compatible object
+
+        Returns:
+            braket.circuits.GateCalibrations:
+        """
+        # TODO: compete this part by making it compatible with device.run
+        exported_calibrations = {}
+        for calibration_target, calibration_callable in self.calibrations.items():
+            with aq_program.build_program(aq_program.UserConfig()) as program_conversion_context:
+                gate_name, qubits, angles = calibration_target
+                with program_conversion_context.calibration_definition(gate_name, qubits, angles):
+                    pulse_sequence = PulseSequence()
+                    pulse_sequence._program = calibration_callable()._oqpy_program
+                    exported_calibrations[calibration_target] = pulse_sequence
+        return braket.circuits.GateCalibrations(exported_calibrations)
+
+    @property
+    def calibrations(self):
+        return self._calibrations

--- a/src/braket/experimental/autoqasm/program/program.py
+++ b/src/braket/experimental/autoqasm/program/program.py
@@ -89,11 +89,16 @@ class Program(SerializableProgram):
         self._oqpy_program = oqpy_program
         self._has_pulse_control = has_pulse_control
 
-    def bind_calibrations(self, gate_calibrations: Union[Callable, List[Callable]]) -> Program:
-        """Binds the gate calibrations to the program.
+    def with_calibrations(self, gate_calibrations: Union[Callable, List[Callable]]) -> Program:
+        """Add the gate calibrations to the program. The calibration added program is returned
+        as a new object. The original program is not modified.
 
         Args:
-            gate_calibrations (Union[Callable, List[Callable]]): The gate calibrations to bind.
+            gate_calibrations (Union[Callable, List[Callable]]): The gate calibrations to add to
+                the main program. Calibration are passed as callable without evaluation.
+
+        Returns:
+            Program: The program with gate calibrations added.
         """
         if isinstance(gate_calibrations, Callable):
             gate_calibrations = [gate_calibrations]

--- a/src/braket/experimental/autoqasm/program/program.py
+++ b/src/braket/experimental/autoqasm/program/program.py
@@ -18,7 +18,7 @@ import contextlib
 import threading
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, Iterable, List, Optional, Union
 
 import oqpy.base
 
@@ -99,7 +99,7 @@ class Program:
 
         combined_oqpy_program = oqpy.Program()
         for gc in gate_calibrations:
-            combined_oqpy_program += gc._to_oqpy_program()
+            combined_oqpy_program += gc.oqpy_program
         self._oqpy_program = combined_oqpy_program + self._oqpy_program
         return self
 
@@ -354,7 +354,7 @@ class ProgramConversionContext:
 
     @contextlib.contextmanager
     def calibration_definition(
-        self, gate_name: str, qubits: Tuple[Qubit], angles: Tuple[float]
+        self, gate_name: str, qubits: Iterable[Qubit], angles: Iterable[float]
     ) -> None:
         """Sets the program conversion context into a calibration definition context.
 

--- a/src/braket/experimental/autoqasm/program/program.py
+++ b/src/braket/experimental/autoqasm/program/program.py
@@ -107,8 +107,8 @@ class Program(SerializableProgram):
         combined_oqpy_program = oqpy.Program()
         for gc in gate_calibrations:
             combined_oqpy_program += gc().program._oqpy_program
-        self._oqpy_program = combined_oqpy_program + self._oqpy_program
-        return self
+        combined_oqpy_program += self._oqpy_program
+        return Program(combined_oqpy_program, self._has_pulse_control)
 
     def to_ir(
         self,

--- a/src/braket/experimental/autoqasm/program/program.py
+++ b/src/braket/experimental/autoqasm/program/program.py
@@ -106,7 +106,7 @@ class Program(SerializableProgram):
 
         combined_oqpy_program = oqpy.Program()
         for gc in gate_calibrations:
-            combined_oqpy_program += gc().oqpy_program
+            combined_oqpy_program += gc().program._oqpy_program
         self._oqpy_program = combined_oqpy_program + self._oqpy_program
         return self
 
@@ -376,8 +376,8 @@ class ProgramConversionContext:
 
         Args:
             gate_name (str): The name of the gate being defined.
-            qubits (Tuple[Qubit]): The list of qubits to the gate.
-            angles (Tuple[float]): The angles at which the gate calibration is defined.
+            qubits (Iterable[Qubit]): The list of qubits to the gate.
+            angles (Iterable[float]): The angles at which the gate calibration is defined.
         """
         try:
             qubits = [_qubit(q) for q in qubits]

--- a/src/braket/experimental/autoqasm/pulse/pulse.py
+++ b/src/braket/experimental/autoqasm/pulse/pulse.py
@@ -15,6 +15,7 @@
 """Pulse instructions that apply to frames or qubits.
 """
 
+import re
 from typing import List, Union
 
 import oqpy
@@ -50,6 +51,26 @@ def _pulse_instruction(name: str, frame: Frame, *args) -> None:
     else:
         with oqpy.Cal(pulse_sequence._program):
             getattr(pulse_sequence, name)(frame, *args)
+
+
+def _physical_qubit_to_braket_qubit(qids: List[str]) -> QubitSet:
+    """Convert a physical qubit label to a QubitSet.
+
+    Args:
+        qids (List[str]): Physical qubit labels.
+
+    Returns:
+        QubitSet: Represent physical qubits.
+    """
+    braket_qubits = []
+    for qid in qids:
+        if not (isinstance(qid, str) and re.match(r"\$\d+", qid)):
+            raise ValueError(
+                f"invalid physical qubit label: '{qid}'. Physical qubit must be labeled as a string"
+                "with `$` followed by an integer. For example: `$1`."
+            )
+        braket_qubits.append(int(qid[1:]))
+    return QubitSet(braket_qubits)
 
 
 def set_frequency(frame: Frame, frequency: float) -> None:
@@ -136,7 +157,7 @@ def delay(
     if not isinstance(qubits_or_frames, List):
         qubits_or_frames = [qubits_or_frames]
     if all(is_qubit_identifier_type(q) for q in qubits_or_frames):
-        qubits_or_frames = QubitSet(qubits_or_frames)
+        qubits_or_frames = _physical_qubit_to_braket_qubit(qubits_or_frames)
     _pulse_instruction("delay", qubits_or_frames, duration)
 
 
@@ -154,5 +175,5 @@ def barrier(
     if not isinstance(qubits_or_frames, List):
         qubits_or_frames = [qubits_or_frames]
     if all(is_qubit_identifier_type(q) for q in qubits_or_frames):
-        qubits_or_frames = QubitSet(qubits_or_frames)
+        qubits_or_frames = _physical_qubit_to_braket_qubit(qubits_or_frames)
     _pulse_instruction("barrier", qubits_or_frames)

--- a/test/unit_tests/braket/experimental/autoqasm/test_api.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_api.py
@@ -16,13 +16,16 @@ generating OpenQASM, and in turn verifying the OpenQASM by running against
 the local simulator.
 """
 
+import textwrap
+
 import pytest
 
 import braket.experimental.autoqasm as aq
 from braket.default_simulator import StateVectorSimulator
 from braket.devices.local_simulator import LocalSimulator
-from braket.experimental.autoqasm import errors
+from braket.experimental.autoqasm import errors, pulse
 from braket.experimental.autoqasm.instructions import cnot, h, measure, x
+from braket.experimental.autoqasm.program.gate_calibrations import GateCalibrations
 from braket.tasks.local_quantum_task import LocalQuantumTask
 
 
@@ -917,3 +920,39 @@ def test_main_from_main():
 
     with pytest.raises(errors.AutoQasmTypeError):
         main()
+
+
+def test_gate_calibrations():
+    """test multiple gate calibrations"""
+    gate_calibrations = GateCalibrations()
+
+    @gate_calibrations.register("h", (0,))
+    def cal_1():
+        pulse.barrier(0)
+
+    @gate_calibrations.register("h", (1,))
+    def cal_2():
+        pulse.delay(1, 0.123)
+
+    @aq.main
+    def my_program():
+        h(0)
+        h(1)
+
+    expected = textwrap.dedent(
+        """
+        OPENQASM 3.0;
+        defcalgrammar "openpulse";
+        qubit[2] __qubits__;
+        defcal h __qubits__[0] {
+            barrier $0;
+        }
+        defcal h __qubits__[1] {
+            delay[123.0ms] $1;
+        }
+        h __qubits__[0];
+        h __qubits__[1];
+        """
+    ).strip()
+    qasm = my_program(gate_calibrations=gate_calibrations).to_ir()
+    assert qasm == expected

--- a/test/unit_tests/braket/experimental/autoqasm/test_gate_calibrations.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_gate_calibrations.py
@@ -27,11 +27,11 @@ def test_gate_calibrations_fixed_args():
 
     @aq.gate_calibration(implements=h, target="$0")
     def cal_1():
-        pulse.barrier(0)
+        pulse.barrier("$0")
 
     @aq.gate_calibration(implements=rx, target="$1", angle=1.789)
     def cal_2():
-        pulse.delay(1, 0.123)
+        pulse.delay("$1", 0.123)
 
     @aq.main
     def my_program():
@@ -60,7 +60,7 @@ def test_gate_calibrations_variable_args():
 
     @aq.gate_calibration(implements=rx, target="$1")
     def cal_1(angle: float):
-        pulse.delay(1, angle)
+        pulse.delay("$1", angle)
 
     @aq.main
     def my_program():
@@ -84,7 +84,7 @@ def test_gate_calibrations_invalid_args():
 
     @aq.gate_calibration(implements=rx, target="$1", foo=0)
     def cal_1(angle: float):
-        pulse.delay(1, angle)
+        pulse.delay("$1", angle)
 
     @aq.main
     def my_program():
@@ -99,23 +99,23 @@ def test_gate_calibrations_invalid_type():
 
     @aq.gate_calibration(implements=rx, target=0.123)
     def cal_1(angle: float):
-        pulse.delay(1, angle)
+        pulse.delay("$1", angle)
 
     @aq.gate_calibration(implements=rx, target={"foo": "bar"})
     def cal_2(angle: float):
-        pulse.delay(1, angle)
+        pulse.delay("$1", angle)
 
     @aq.gate_calibration(implements=rx, target=0, angle="$0")
     def cal_3():
-        pulse.delay(1, 0.123)
+        pulse.delay("$1", 0.123)
 
     @aq.gate_calibration(implements=rx, target=0)
     def cal_4(angle: aq.Qubit):
-        pulse.delay(1, angle)
+        pulse.delay("$1", angle)
 
     @aq.gate_calibration(implements=rx)
     def cal_5(target: float, angle: aq.Qubit):
-        pulse.delay(0, angle)
+        pulse.delay("$0", angle)
 
     @aq.main
     def my_program():
@@ -131,11 +131,11 @@ def test_gate_calibrations_insufficient_args():
 
     @aq.gate_calibration(implements=rx, target="$1")
     def cal_1():
-        pulse.delay(1, 0.123)
+        pulse.delay("$1", 0.123)
 
     @aq.gate_calibration(implements=rx)
     def cal_2(angle: float):
-        pulse.delay(1, angle)
+        pulse.delay("$1", angle)
 
     @aq.main
     def my_program():
@@ -153,7 +153,7 @@ def test_gate_calibrations_duplicated_args():
 
     @aq.gate_calibration(implements=rx, target="$1", angle=0.123)
     def cal_1(angle: float):
-        pulse.delay(1, angle)
+        pulse.delay("$1", angle)
 
     @aq.main
     def my_program():
@@ -169,7 +169,7 @@ def test_gate_calibrations_invalid_instructions():
     @aq.gate_calibration(implements=rx, target="$1")
     def cal_1(angle: float):
         h(0)
-        pulse.delay(1, angle)
+        pulse.delay("$1", angle)
 
     @aq.main
     def my_program():
@@ -184,7 +184,7 @@ def test_gate_calibrations_bind_calibrations_not_inplace():
 
     @aq.gate_calibration(implements=rx, target="$1")
     def cal_1(angle: float):
-        pulse.delay(1, angle)
+        pulse.delay("$1", angle)
 
     @aq.main
     def my_program_1():
@@ -208,8 +208,8 @@ def test_gate_calibrations_with_gate_definition():
 
     @aq.gate_calibration(implements=my_gate, q="$0")
     def cal_1(a: float):
-        pulse.barrier(0)
-        pulse.delay(0, a)
+        pulse.barrier("$0")
+        pulse.delay("$0", a)
 
     @aq.main
     def my_program():

--- a/test/unit_tests/braket/experimental/autoqasm/test_gate_calibrations.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_gate_calibrations.py
@@ -187,16 +187,15 @@ def test_gate_calibrations_bind_calibrations_not_inplace():
         pulse.delay("$1", angle)
 
     @aq.main
-    def my_program_1():
+    def my_program():
         rx("$1", 1.0)
 
-    @aq.main
-    def my_program_2():
-        rx("$1", 1.0)
+    program_1 = my_program()
+    _ = program_1.with_calibrations(cal_1)
 
-    _ = my_program_1().with_calibrations(cal_1)
+    program_2 = my_program()
 
-    assert my_program_1().to_ir() == my_program_2().to_ir()
+    assert program_1.to_ir() == program_2.to_ir()
 
 
 def test_gate_calibrations_with_gate_definition():

--- a/test/unit_tests/braket/experimental/autoqasm/test_gate_calibrations.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_gate_calibrations.py
@@ -50,5 +50,5 @@ def test_gate_calibrations():
         h __qubits__[1];
         """
     ).strip()
-    qasm = my_program().bind_calibrations([cal_1, cal_2]).to_ir()
+    qasm = my_program().bind_calibrations([cal_1(), cal_2()]).to_ir()
     assert qasm == expected

--- a/test/unit_tests/braket/experimental/autoqasm/test_gate_calibrations.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_gate_calibrations.py
@@ -69,7 +69,7 @@ def test_gate_calibrations_variable_args():
     expected = textwrap.dedent(
         """
         OPENQASM 3.0;
-        defcal rx(float[64] angle) $1 {
+        defcal rx(angle[32] angle) $1 {
             delay[angle * 1s] $1;
         }
         rx(1.0) $1;
@@ -221,7 +221,7 @@ def test_gate_calibrations_with_gate_definition():
         gate my_gate(a) q {
             h q;
         }
-        defcal my_gate(float[64] a) $0 {
+        defcal my_gate(angle[32] a) $0 {
             barrier $0;
             delay[a * 1s] $0;
         }

--- a/test/unit_tests/braket/experimental/autoqasm/test_gate_calibrations.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_gate_calibrations.py
@@ -113,11 +113,15 @@ def test_gate_calibrations_invalid_type():
     def cal_4(angle: aq.Qubit):
         pulse.delay(1, angle)
 
+    @aq.pulse_sequence(implements=rx)
+    def cal_5(target: float, angle: aq.Qubit):
+        pulse.delay(0, angle)
+
     @aq.main
     def my_program():
         rx("$1", 1.0)
 
-    for cal in [cal_1, cal_2, cal_3, cal_4]:
+    for cal in [cal_1, cal_2, cal_3, cal_4, cal_5]:
         with pytest.raises(errors.ParameterTypeError):
             _ = my_program().bind_calibrations(cal)
 

--- a/test/unit_tests/braket/experimental/autoqasm/test_gate_calibrations.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_gate_calibrations.py
@@ -15,40 +15,209 @@
 
 import textwrap
 
+import pytest
+
 import braket.experimental.autoqasm as aq
-from braket.experimental.autoqasm import pulse
-from braket.experimental.autoqasm.instructions import h
+from braket.experimental.autoqasm import errors, pulse
+from braket.experimental.autoqasm.instructions import h, rx
 
 
-def test_gate_calibrations():
-    """test multiple gate calibrations"""
+def test_gate_calibrations_fixed_args():
+    """test gate calibrations with fixed args"""
 
-    @aq.calibration("h", (0,))
+    @aq.pulse_sequence(implements=h, target="$0")
     def cal_1():
         pulse.barrier(0)
 
-    @aq.calibration("h", (1,))
+    @aq.pulse_sequence(implements=rx, target="$1", angle=1.789)
     def cal_2():
         pulse.delay(1, 0.123)
 
     @aq.main
     def my_program():
-        h(0)
-        h(1)
+        h("$0")
+        rx("$1", 1.0)
 
     expected = textwrap.dedent(
         """
         OPENQASM 3.0;
-        defcal h __qubits__[0] {
+        defcal h $0 {
             barrier $0;
         }
-        defcal h __qubits__[1] {
+        defcal rx(1.789) $1 {
             delay[123.0ms] $1;
         }
-        qubit[2] __qubits__;
-        h __qubits__[0];
-        h __qubits__[1];
+        h $0;
+        rx(1.0) $1;
         """
     ).strip()
-    qasm = my_program().bind_calibrations([cal_1(), cal_2()]).to_ir()
+    qasm = my_program().bind_calibrations([cal_1, cal_2]).to_ir()
+    assert qasm == expected
+
+
+def test_gate_calibrations_variable_args():
+    """test gate calibrations with variable args"""
+
+    @aq.pulse_sequence(implements=rx, target="$1")
+    def cal_1(angle: float):
+        pulse.delay(1, angle)
+
+    @aq.main
+    def my_program():
+        rx("$1", 1.0)
+
+    expected = textwrap.dedent(
+        """
+        OPENQASM 3.0;
+        defcal rx(float[64] angle) $1 {
+            delay[angle * 1s] $1;
+        }
+        rx(1.0) $1;
+        """
+    ).strip()
+    qasm = my_program().bind_calibrations(cal_1).to_ir()
+    assert qasm == expected
+
+
+def test_gate_calibrations_invalid_args():
+    """test gate calibrations with invalid args"""
+
+    @aq.pulse_sequence(implements=rx, target="$1", foo=0)
+    def cal_1(angle: float):
+        pulse.delay(1, angle)
+
+    @aq.main
+    def my_program():
+        rx("$1", 1.0)
+
+    with pytest.raises(errors.InvalidCalibrationDefinition):
+        _ = my_program().bind_calibrations(cal_1)
+
+
+def test_gate_calibrations_insufficient_args():
+    """test gate calibrations with insufficient args"""
+
+    @aq.pulse_sequence(implements=rx, target="$1")
+    def cal_1():
+        pulse.delay(1, 0.123)
+
+    @aq.pulse_sequence(implements=rx)
+    def cal_2(angle: float):
+        pulse.delay(1, angle)
+
+    @aq.main
+    def my_program():
+        rx("$1", 1.0)
+
+    with pytest.raises(errors.InvalidCalibrationDefinition):
+        _ = my_program().bind_calibrations(cal_1)
+
+    with pytest.raises(errors.InvalidCalibrationDefinition):
+        _ = my_program().bind_calibrations(cal_2)
+
+
+def test_gate_calibrations_duplicated_args():
+    """test gate calibrations with duplicated args"""
+
+    @aq.pulse_sequence(implements=rx, target="$1", angle=0.123)
+    def cal_1(angle: float):
+        pulse.delay(1, angle)
+
+    @aq.main
+    def my_program():
+        rx("$1", 1.0)
+
+    with pytest.raises(errors.InvalidCalibrationDefinition):
+        _ = my_program().bind_calibrations(cal_1)
+
+
+def test_gate_calibrations_invalid_instructions():
+    """test gate calibrations with invalid instructions that are not pulse"""
+
+    @aq.pulse_sequence(implements=rx, target="$1")
+    def cal_1(angle: float):
+        h(0)
+        pulse.delay(1, angle)
+
+    @aq.main
+    def my_program():
+        rx("$1", 1.0)
+
+    with pytest.raises(errors.InvalidCalibrationDefinition):
+        _ = my_program().bind_calibrations(cal_1)
+
+
+def test_gate_calibrations_bind_calibrations_not_inplace():
+    """test that bind_calibrations does not modify the original program"""
+
+    @aq.pulse_sequence(implements=rx, target="$1")
+    def cal_1(angle: float):
+        pulse.delay(1, angle)
+
+    @aq.main
+    def my_program_1():
+        rx("$1", 1.0)
+
+    @aq.main
+    def my_program_2():
+        rx("$1", 1.0)
+
+    _ = my_program_1().bind_calibrations(cal_1)
+
+    assert my_program_1().to_ir() == my_program_2().to_ir()
+
+
+def test_gate_calibrations_with_gate_definition():
+    """test gate calibrations on gate defined by aq.gate"""
+
+    @aq.gate
+    def my_gate(q: aq.Qubit, a: float):
+        h(q)
+
+    @aq.pulse_sequence(implements=my_gate, q="$0")
+    def cal_1(a: float):
+        pulse.barrier(0)
+        pulse.delay(0, a)
+
+    @aq.main
+    def my_program():
+        my_gate(2, 0.123)
+
+    expected = textwrap.dedent(
+        """
+        OPENQASM 3.0;
+        gate my_gate(a) q {
+            h q;
+        }
+        defcal my_gate(float[64] a) $0 {
+            barrier $0;
+            delay[a * 1s] $0;
+        }
+        qubit[3] __qubits__;
+        my_gate(0.123) __qubits__[2];
+        """
+    ).strip()
+    qasm = my_program().bind_calibrations(cal_1).to_ir()
+    assert qasm == expected
+
+
+def test_pulse_sequence_without_implements_kwargs():
+    """test pulse_sequence without an `implements` kwargs"""
+
+    @aq.pulse_sequence
+    def my_pulse_sequence(a: float):
+        pulse.barrier(0)
+        pulse.delay(0, a)
+
+    expected = textwrap.dedent(
+        """
+        OPENQASM 3.0;
+        defcalgrammar "openpulse";
+        cal {
+            barrier $0;
+            delay[123.0ms] $0;
+        }
+        """
+    ).strip()
+    qasm = my_pulse_sequence(0.123).to_ir()
     assert qasm == expected

--- a/test/unit_tests/braket/experimental/autoqasm/test_gate_calibrations.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_gate_calibrations.py
@@ -80,7 +80,7 @@ def test_gate_calibrations_variable_args():
 
 
 def test_gate_calibrations_invalid_args():
-    """test gate calibrations with invalid args"""
+    """test gate calibrations with invalid args name"""
 
     @aq.pulse_sequence(implements=rx, target="$1", foo=0)
     def cal_1(angle: float):
@@ -92,6 +92,34 @@ def test_gate_calibrations_invalid_args():
 
     with pytest.raises(errors.InvalidCalibrationDefinition):
         _ = my_program().bind_calibrations(cal_1)
+
+
+def test_gate_calibrations_invalid_type():
+    """test gate calibrations with invalid args type"""
+
+    @aq.pulse_sequence(implements=rx, target=0.123)
+    def cal_1(angle: float):
+        pulse.delay(1, angle)
+
+    @aq.pulse_sequence(implements=rx, target={"foo": "bar"})
+    def cal_2(angle: float):
+        pulse.delay(1, angle)
+
+    @aq.pulse_sequence(implements=rx, target=0, angle="$0")
+    def cal_3():
+        pulse.delay(1, 0.123)
+
+    @aq.pulse_sequence(implements=rx, target=0)
+    def cal_4(angle: aq.Qubit):
+        pulse.delay(1, angle)
+
+    @aq.main
+    def my_program():
+        rx("$1", 1.0)
+
+    for cal in [cal_1, cal_2, cal_3, cal_4]:
+        with pytest.raises(errors.ParameterTypeError):
+            _ = my_program().bind_calibrations(cal)
 
 
 def test_gate_calibrations_insufficient_args():

--- a/test/unit_tests/braket/experimental/autoqasm/test_gate_calibrations.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_gate_calibrations.py
@@ -25,11 +25,11 @@ from braket.experimental.autoqasm.instructions import h, rx
 def test_gate_calibrations_fixed_args():
     """test gate calibrations with fixed args"""
 
-    @aq.pulse_sequence(implements=h, target="$0")
+    @aq.gate_calibration(implements=h, target="$0")
     def cal_1():
         pulse.barrier(0)
 
-    @aq.pulse_sequence(implements=rx, target="$1", angle=1.789)
+    @aq.gate_calibration(implements=rx, target="$1", angle=1.789)
     def cal_2():
         pulse.delay(1, 0.123)
 
@@ -51,14 +51,14 @@ def test_gate_calibrations_fixed_args():
         rx(1.0) $1;
         """
     ).strip()
-    qasm = my_program().bind_calibrations([cal_1, cal_2]).to_ir()
+    qasm = my_program().with_calibrations([cal_1, cal_2]).to_ir()
     assert qasm == expected
 
 
 def test_gate_calibrations_variable_args():
     """test gate calibrations with variable args"""
 
-    @aq.pulse_sequence(implements=rx, target="$1")
+    @aq.gate_calibration(implements=rx, target="$1")
     def cal_1(angle: float):
         pulse.delay(1, angle)
 
@@ -75,14 +75,14 @@ def test_gate_calibrations_variable_args():
         rx(1.0) $1;
         """
     ).strip()
-    qasm = my_program().bind_calibrations(cal_1).to_ir()
+    qasm = my_program().with_calibrations(cal_1).to_ir()
     assert qasm == expected
 
 
 def test_gate_calibrations_invalid_args():
     """test gate calibrations with invalid args name"""
 
-    @aq.pulse_sequence(implements=rx, target="$1", foo=0)
+    @aq.gate_calibration(implements=rx, target="$1", foo=0)
     def cal_1(angle: float):
         pulse.delay(1, angle)
 
@@ -91,29 +91,29 @@ def test_gate_calibrations_invalid_args():
         rx("$1", 1.0)
 
     with pytest.raises(errors.InvalidCalibrationDefinition):
-        _ = my_program().bind_calibrations(cal_1)
+        _ = my_program().with_calibrations(cal_1)
 
 
 def test_gate_calibrations_invalid_type():
     """test gate calibrations with invalid args type"""
 
-    @aq.pulse_sequence(implements=rx, target=0.123)
+    @aq.gate_calibration(implements=rx, target=0.123)
     def cal_1(angle: float):
         pulse.delay(1, angle)
 
-    @aq.pulse_sequence(implements=rx, target={"foo": "bar"})
+    @aq.gate_calibration(implements=rx, target={"foo": "bar"})
     def cal_2(angle: float):
         pulse.delay(1, angle)
 
-    @aq.pulse_sequence(implements=rx, target=0, angle="$0")
+    @aq.gate_calibration(implements=rx, target=0, angle="$0")
     def cal_3():
         pulse.delay(1, 0.123)
 
-    @aq.pulse_sequence(implements=rx, target=0)
+    @aq.gate_calibration(implements=rx, target=0)
     def cal_4(angle: aq.Qubit):
         pulse.delay(1, angle)
 
-    @aq.pulse_sequence(implements=rx)
+    @aq.gate_calibration(implements=rx)
     def cal_5(target: float, angle: aq.Qubit):
         pulse.delay(0, angle)
 
@@ -123,17 +123,17 @@ def test_gate_calibrations_invalid_type():
 
     for cal in [cal_1, cal_2, cal_3, cal_4, cal_5]:
         with pytest.raises(errors.ParameterTypeError):
-            _ = my_program().bind_calibrations(cal)
+            _ = my_program().with_calibrations(cal)
 
 
 def test_gate_calibrations_insufficient_args():
     """test gate calibrations with insufficient args"""
 
-    @aq.pulse_sequence(implements=rx, target="$1")
+    @aq.gate_calibration(implements=rx, target="$1")
     def cal_1():
         pulse.delay(1, 0.123)
 
-    @aq.pulse_sequence(implements=rx)
+    @aq.gate_calibration(implements=rx)
     def cal_2(angle: float):
         pulse.delay(1, angle)
 
@@ -142,16 +142,16 @@ def test_gate_calibrations_insufficient_args():
         rx("$1", 1.0)
 
     with pytest.raises(errors.InvalidCalibrationDefinition):
-        _ = my_program().bind_calibrations(cal_1)
+        _ = my_program().with_calibrations(cal_1)
 
     with pytest.raises(errors.InvalidCalibrationDefinition):
-        _ = my_program().bind_calibrations(cal_2)
+        _ = my_program().with_calibrations(cal_2)
 
 
 def test_gate_calibrations_duplicated_args():
     """test gate calibrations with duplicated args"""
 
-    @aq.pulse_sequence(implements=rx, target="$1", angle=0.123)
+    @aq.gate_calibration(implements=rx, target="$1", angle=0.123)
     def cal_1(angle: float):
         pulse.delay(1, angle)
 
@@ -160,13 +160,13 @@ def test_gate_calibrations_duplicated_args():
         rx("$1", 1.0)
 
     with pytest.raises(errors.InvalidCalibrationDefinition):
-        _ = my_program().bind_calibrations(cal_1)
+        _ = my_program().with_calibrations(cal_1)
 
 
 def test_gate_calibrations_invalid_instructions():
     """test gate calibrations with invalid instructions that are not pulse"""
 
-    @aq.pulse_sequence(implements=rx, target="$1")
+    @aq.gate_calibration(implements=rx, target="$1")
     def cal_1(angle: float):
         h(0)
         pulse.delay(1, angle)
@@ -176,13 +176,13 @@ def test_gate_calibrations_invalid_instructions():
         rx("$1", 1.0)
 
     with pytest.raises(errors.InvalidCalibrationDefinition):
-        _ = my_program().bind_calibrations(cal_1)
+        _ = my_program().with_calibrations(cal_1)
 
 
 def test_gate_calibrations_bind_calibrations_not_inplace():
     """test that bind_calibrations does not modify the original program"""
 
-    @aq.pulse_sequence(implements=rx, target="$1")
+    @aq.gate_calibration(implements=rx, target="$1")
     def cal_1(angle: float):
         pulse.delay(1, angle)
 
@@ -194,7 +194,7 @@ def test_gate_calibrations_bind_calibrations_not_inplace():
     def my_program_2():
         rx("$1", 1.0)
 
-    _ = my_program_1().bind_calibrations(cal_1)
+    _ = my_program_1().with_calibrations(cal_1)
 
     assert my_program_1().to_ir() == my_program_2().to_ir()
 
@@ -206,7 +206,7 @@ def test_gate_calibrations_with_gate_definition():
     def my_gate(q: aq.Qubit, a: float):
         h(q)
 
-    @aq.pulse_sequence(implements=my_gate, q="$0")
+    @aq.gate_calibration(implements=my_gate, q="$0")
     def cal_1(a: float):
         pulse.barrier(0)
         pulse.delay(0, a)
@@ -229,27 +229,5 @@ def test_gate_calibrations_with_gate_definition():
         my_gate(0.123) __qubits__[2];
         """
     ).strip()
-    qasm = my_program().bind_calibrations(cal_1).to_ir()
-    assert qasm == expected
-
-
-def test_pulse_sequence_without_implements_kwargs():
-    """test pulse_sequence without an `implements` kwargs"""
-
-    @aq.pulse_sequence
-    def my_pulse_sequence(a: float):
-        pulse.barrier(0)
-        pulse.delay(0, a)
-
-    expected = textwrap.dedent(
-        """
-        OPENQASM 3.0;
-        defcalgrammar "openpulse";
-        cal {
-            barrier $0;
-            delay[123.0ms] $0;
-        }
-        """
-    ).strip()
-    qasm = my_pulse_sequence(0.123).to_ir()
+    qasm = my_program().with_calibrations(cal_1).to_ir()
     assert qasm == expected

--- a/test/unit_tests/braket/experimental/autoqasm/test_gate_calibrations.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_gate_calibrations.py
@@ -1,0 +1,54 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+"""Tests for the pulse control module."""
+
+import textwrap
+
+import braket.experimental.autoqasm as aq
+from braket.experimental.autoqasm import pulse
+from braket.experimental.autoqasm.instructions import h
+
+
+def test_gate_calibrations():
+    """test multiple gate calibrations"""
+
+    @aq.calibration("h", (0,))
+    def cal_1():
+        pulse.barrier(0)
+
+    @aq.calibration("h", (1,))
+    def cal_2():
+        pulse.delay(1, 0.123)
+
+    @aq.main
+    def my_program():
+        h(0)
+        h(1)
+
+    expected = textwrap.dedent(
+        """
+        OPENQASM 3.0;
+        defcal h __qubits__[0] {
+            barrier $0;
+        }
+        defcal h __qubits__[1] {
+            delay[123.0ms] $1;
+        }
+        qubit[2] __qubits__;
+        h __qubits__[0];
+        h __qubits__[1];
+        """
+    ).strip()
+    qasm = my_program().bind_calibrations([cal_1, cal_2]).to_ir()
+    assert qasm == expected

--- a/test/unit_tests/braket/experimental/autoqasm/test_pulse.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_pulse.py
@@ -73,8 +73,8 @@ def test_merge_cal_box() -> None:
 
     @aq.main
     def my_program():
-        barrier(0)
-        delay([3, 4], 0.34)
+        barrier("$0")
+        delay(["$3", "$4"], 0.34)
 
     expected = textwrap.dedent(
         """
@@ -123,8 +123,8 @@ def test_merge_cal_box() -> None:
             [0.12],
             "\ncal {\n    set_scale(predefined_frame_1, 0.12);\n}",
         ),
-        (delay, 3, [0.34], "\ncal {\n    delay[340.0ms] $3;\n}"),
-        (delay, [3, 4], [0.34], "\ncal {\n    delay[340.0ms] $3, $4;\n}"),
+        (delay, "$3", [0.34], "\ncal {\n    delay[340.0ms] $3;\n}"),
+        (delay, ["$3", "$4"], [0.34], "\ncal {\n    delay[340.0ms] $3, $4;\n}"),
         (
             delay,
             FRAME1,
@@ -137,8 +137,8 @@ def test_merge_cal_box() -> None:
             [0.34],
             "\ncal {\n    delay[340.0ms] predefined_frame_1, predefined_frame_2;\n}",
         ),
-        (barrier, 3, [], "\ncal {\n    barrier $3;\n}"),
-        (barrier, [3, 4], [], "\ncal {\n    barrier $3, $4;\n}"),
+        (barrier, "$3", [], "\ncal {\n    barrier $3;\n}"),
+        (barrier, ["$3", "$4"], [], "\ncal {\n    barrier $3, $4;\n}"),
         (barrier, FRAME1, [], "\ncal {\n    barrier predefined_frame_1;\n}"),
         (
             barrier,
@@ -164,3 +164,19 @@ def test_pulse_control(instruction, qubits_or_frames, params, expected_qasm) -> 
         instruction(qubits_or_frames, *params)
 
     assert expected_qasm in program_conversion_context.make_program().to_ir()
+
+
+@pytest.mark.parametrize(
+    "instruction,qubits_or_frames,params",
+    [
+        (barrier, "1", []),
+        (barrier, 1, []),
+        (barrier, ["1", "2"], []),
+        (barrier, [1, 2], []),
+    ],
+)
+def test_pulse_control_invalid_physical_qubit(instruction, qubits_or_frames, params) -> None:
+    """Test pulse control operations with invalid lables for physical qubits."""
+    with pytest.raises(ValueError):
+        with aq.build_program():
+            instruction(qubits_or_frames, *params)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/orgs/amazon-braket/projects/2/views/6?pane=issue&itemId=35379372

*Description of changes:*
- Implement `@aq.gate_calibration` decorator
- The decorator takes an `implements` kwargs`, acting as a defcal. The body of defcal can only have pulse operations
- Users can attach gate calibrations to a main program with `my_program.with_calibrations([cal_1, cal_2])`. The attachment returns new program object and does not modify the original program.

*Example* 
```
@aq.gate_calibration(implements=rx, target="$1")
def cal_1(angle: float):
    pulse.delay(1, angle)

@aq.main
def my_program():
    rx("$1", 1.0)

prog = my_program()
prog.bind_calibrations([cal_1])
```

*Note:*
Support of variable qubit is low. Currently, qubits for defcal can be passed as a fixed value or a variable. But no pulse instruction can accept a variable qubit, because we use BDK for pulse instructions which does not accept qubits with names. In the code snippet below, `cal_1` and `cal_2` works but not `cal_3`. 
```
@aq.pulse_sequence(implements=h, target="$1")
def cal_1():
    pulse.delay(1, 0.123)

@aq.pulse_sequence(implements=h)
def cal_2(target: aq.Qubit):
    pulse.delay(0, 0.123)

@aq.pulse_sequence(implements=h)
def cal_3(target: aq.Qubit):
    pulse.delay(target, 0.123)
```


*Testing done:*
tox

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
