### PR TITLE
feature: device-specific gate validation for autoqasm programs

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -28,4 +28,4 @@ jobs:
     - name: Run code format checks
       run: |
         black --check . --extend-exclude=src/braket/experimental/autoqasm/autograph
-        flake8 --enable-extensions=BCS src/braket/experimental/autoqasm
+        flake8 --enable-extensions=BCS src

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -44,6 +44,7 @@ jobs:
         jupyter nbconvert --to html --execute --ExecutePreprocessor.kernel_name=python3 ./examples/autoqasm/1_Getting_started_with_AutoQASM.ipynb
         jupyter nbconvert --to html --execute --ExecutePreprocessor.kernel_name=python3 ./examples/autoqasm/2_Expressing_classical_control_flow.ipynb
         jupyter nbconvert --to html --execute --ExecutePreprocessor.kernel_name=python3 ./examples/autoqasm/3_Iterative_phase_estimation.ipynb
+        jupyter nbconvert --to html --execute --ExecutePreprocessor.kernel_name=python3 ./examples/autoqasm/4_Native_programming.ipynb
     - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
       if: ${{ strategy.job-index }} == 0

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -44,7 +44,6 @@ jobs:
         jupyter nbconvert --to html --execute --ExecutePreprocessor.kernel_name=python3 ./examples/autoqasm/1_Getting_started_with_AutoQASM.ipynb
         jupyter nbconvert --to html --execute --ExecutePreprocessor.kernel_name=python3 ./examples/autoqasm/2_Expressing_classical_control_flow.ipynb
         jupyter nbconvert --to html --execute --ExecutePreprocessor.kernel_name=python3 ./examples/autoqasm/3_Iterative_phase_estimation.ipynb
-        jupyter nbconvert --to html --execute --ExecutePreprocessor.kernel_name=python3 ./examples/autoqasm/4_Native_programming.ipynb
     - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
       if: ${{ strategy.job-index }} == 0

--- a/examples/autoqasm/4_Native_programming.ipynb
+++ b/examples/autoqasm/4_Native_programming.ipynb
@@ -7,7 +7,9 @@
    "source": [
     "# Native programming\n",
     "\n",
-    "TODO: introductory text for the notebook"
+    "In order to execute a program on a quantum computer, each qubit in the program must be mapped to a physical qubit on the device, and each operation must be mapped to one or more \"native gates\", that is, gates that are natively implemented by the hardware. While this can be handled automatically by a compiler, a quantum software developer or researcher may want to be able to control these mappings explicitly. We refer to this low-level programming as \"native programming\".\n",
+    "\n",
+    "This notebook provides a demonstration of the native programming features of AutoQASM by targeting a simple two-qubit circuit to physical qubits and native gates of an IonQ quantum computer, which is available through Amazon Braket. "
    ]
   },
   {
@@ -23,8 +25,7 @@
     "\n",
     "# AWS imports: Import Braket SDK modules\n",
     "from braket.devices import Devices\n",
-    "import braket.experimental.autoqasm as aq\n",
-    "from braket.experimental.autoqasm.instructions import h, cnot, measure"
+    "import braket.experimental.autoqasm as aq"
    ]
   },
   {
@@ -32,7 +33,7 @@
    "id": "5dd374f2",
    "metadata": {},
    "source": [
-    "TODO: introduce Bell state, why native programming might be important"
+    "The circuit we will use for this demonstration is a program which creates and measures a Bell state on two qubits. Here, we write this program at the typical level of abstraction, which is hardware-agnostic. We use integers `0` and `1` to specify qubit indices, and we use the built-in `h` and `cnot` instructions from the AutoQASM `instructions` module."
    ]
   },
   {
@@ -56,6 +57,9 @@
     }
    ],
    "source": [
+    "from braket.experimental.autoqasm.instructions import h, cnot, measure\n",
+    "\n",
+    "\n",
     "@aq.main\n",
     "def bell_state():\n",
     "    h(0)\n",
@@ -72,7 +76,9 @@
    "id": "9ff3d255",
    "metadata": {},
    "source": [
-    "TODO: explain why verbatim and physical qubits"
+    "As seen in the generated OpenQASM program, this produces a program that uses a two-qubit register `__qubits__` and the built-in `h` and `cnot` gates. At runtime, the compiler will automatically map this to two physical qubits, and will compile the `h` and `cnot` instructions to an equivalent sequence of gates which are native to the target device.\n",
+    "\n",
+    "In the native programming scenario, however, the developer wants full control over the physical qubit mappings and conversion to native gates. We can take advantage of two features of AutoQASM to enable this. First, we replace the integers `0` and `1`, which specify virtual qubit indices, with the strings `\"$0\"` and `\"$1\"`, which specify physical qubits. Second, we wrap the gates inside a `verbatim` block (using the `aq.verbatim()` context), which instructs the compiler to avoid modifying anything inside the block."
    ]
   },
   {
@@ -115,9 +121,13 @@
    "id": "a9182030",
    "metadata": {},
    "source": [
-    "TODO: but what if I want to target this to a specific device? introduce `device` param\n",
+    "This program now targets physical qubits, and the gates will not be modified by the compiler.\n",
     "\n",
-    "and try it here - but it doesn't work!"
+    "## Device-specific validation\n",
+    "\n",
+    "Bypassing the mapping and compilation is only the first step of native programming. Because native programming is intended for targeting a program to a specific device, we need to specify the target device in the AutoQASM program. We can accomplish this by adding a `device` argument to the `@aq.main` decorator, passing the ARN of the Amazon Braket device (or, optionally, a `braket.devices.device.Device` object) that we want to target.\n",
+    "\n",
+    "Here we modify the program to target the `Devices.IonQ.Aria1` device. When building this program, AutoQASM will validate that (among other things) the contents of any `verbatim` blocks respect the native gate set and connectivity of the target device. "
    ]
   },
   {
@@ -154,7 +164,11 @@
    "id": "3ef34c2d",
    "metadata": {},
    "source": [
-    "TODO: introduce idea of custom gate definition, what we're doing here, explain what is in ionq_gates.py and how you could implement your own library of native gate implementations for any device."
+    "The validation error indicates that we cannot use `h` and `cnot` inside a `verbatim` block for this device. Instead, we must express our program in terms of the native gates of the device: `gpi`, `gpi2`, and `ms`.\n",
+    "\n",
+    "## Custom gate definitions using `@aq.gate`\n",
+    "\n",
+    "In order to do this, we can use the `@aq.gate` decorator in AutoQASM to define custom gates, which we implement in terms of this native gate set. In the Python script `ionq_gates.py`, we define custom implementations of the `h` and `cnot` gates which are built on top of the `gpi`, `gpi2`, and `ms` gates."
    ]
   },
   {
@@ -253,11 +267,6 @@
        "\n",
        "\n",
        "<span class=\"nd\">@aq</span><span class=\"o\">.</span><span class=\"n\">gate</span>\n",
-       "<span class=\"k\">def</span> <span class=\"nf\">x</span><span class=\"p\">(</span><span class=\"n\">q</span><span class=\"p\">:</span> <span class=\"n\">aq</span><span class=\"o\">.</span><span class=\"n\">Qubit</span><span class=\"p\">):</span>\n",
-       "    <span class=\"n\">gpi</span><span class=\"p\">(</span><span class=\"n\">q</span><span class=\"p\">,</span> <span class=\"mi\">0</span><span class=\"p\">)</span>\n",
-       "\n",
-       "\n",
-       "<span class=\"nd\">@aq</span><span class=\"o\">.</span><span class=\"n\">gate</span>\n",
        "<span class=\"k\">def</span> <span class=\"nf\">u</span><span class=\"p\">(</span><span class=\"n\">q</span><span class=\"p\">:</span> <span class=\"n\">aq</span><span class=\"o\">.</span><span class=\"n\">Qubit</span><span class=\"p\">,</span> <span class=\"n\">a</span><span class=\"p\">:</span> <span class=\"nb\">float</span><span class=\"p\">,</span> <span class=\"n\">b</span><span class=\"p\">:</span> <span class=\"nb\">float</span><span class=\"p\">,</span> <span class=\"n\">c</span><span class=\"p\">:</span> <span class=\"nb\">float</span><span class=\"p\">):</span>\n",
        "    <span class=\"n\">gpi2</span><span class=\"p\">(</span><span class=\"n\">q</span><span class=\"p\">,</span> <span class=\"n\">a</span><span class=\"p\">)</span>\n",
        "    <span class=\"n\">gpi</span><span class=\"p\">(</span><span class=\"n\">q</span><span class=\"p\">,</span> <span class=\"n\">b</span><span class=\"p\">)</span>\n",
@@ -297,11 +306,6 @@
        "\n",
        "\n",
        "\\PY{n+nd}{@aq}\\PY{o}{.}\\PY{n}{gate}\n",
-       "\\PY{k}{def} \\PY{n+nf}{x}\\PY{p}{(}\\PY{n}{q}\\PY{p}{:} \\PY{n}{aq}\\PY{o}{.}\\PY{n}{Qubit}\\PY{p}{)}\\PY{p}{:}\n",
-       "    \\PY{n}{gpi}\\PY{p}{(}\\PY{n}{q}\\PY{p}{,} \\PY{l+m+mi}{0}\\PY{p}{)}\n",
-       "\n",
-       "\n",
-       "\\PY{n+nd}{@aq}\\PY{o}{.}\\PY{n}{gate}\n",
        "\\PY{k}{def} \\PY{n+nf}{u}\\PY{p}{(}\\PY{n}{q}\\PY{p}{:} \\PY{n}{aq}\\PY{o}{.}\\PY{n}{Qubit}\\PY{p}{,} \\PY{n}{a}\\PY{p}{:} \\PY{n+nb}{float}\\PY{p}{,} \\PY{n}{b}\\PY{p}{:} \\PY{n+nb}{float}\\PY{p}{,} \\PY{n}{c}\\PY{p}{:} \\PY{n+nb}{float}\\PY{p}{)}\\PY{p}{:}\n",
        "    \\PY{n}{gpi2}\\PY{p}{(}\\PY{n}{q}\\PY{p}{,} \\PY{n}{a}\\PY{p}{)}\n",
        "    \\PY{n}{gpi}\\PY{p}{(}\\PY{n}{q}\\PY{p}{,} \\PY{n}{b}\\PY{p}{)}\n",
@@ -336,11 +340,6 @@
        "@aq.gate\n",
        "def h(q: aq.Qubit):\n",
        "    gpi2(q, np.pi / 2)\n",
-       "    gpi(q, 0)\n",
-       "\n",
-       "\n",
-       "@aq.gate\n",
-       "def x(q: aq.Qubit):\n",
        "    gpi(q, 0)\n",
        "\n",
        "\n",
@@ -384,7 +383,7 @@
    "id": "5ef522c8",
    "metadata": {},
    "source": [
-    "TODO: now I can write the same program again, and it works!"
+    "We can now use these definitions of the `h` and `cnot` gates in our device-targeted program."
    ]
   },
   {
@@ -449,12 +448,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ba0be720",
+   "metadata": {},
+   "source": [
+    "The device-specific validation now passes, and the program is successfully built. We can see that the generated OpenQASM program contains `gate` definitions for `h`, `u`, `ry`, `rx`, and `cnot`, which correspond to the `@aq.gate` definitions in `ionq_gates.py`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "fa2c2c9e",
    "metadata": {},
    "source": [
     "## Summary\n",
     "\n",
-    "TODO: summarize what we did!"
+    "In this notebook, we demonstrated several aspects of native programming using a two-qubit example program. We showed how to modify a program to use physical qubits instead of virtual qubits. We introduced the usage of `verbatim` blocks via the `aq.verbatim()` context, and we demonstrated the device-specific targeting functionality provided by AutoQASM. Finally, we demonstrated the definition of custom gates using the `@aq.gate` decorator, and we used these gate definitions to implement our example program purely in terms of the native gates of the target device."
    ]
   }
  ],

--- a/examples/autoqasm/4_Native_programming.ipynb
+++ b/examples/autoqasm/4_Native_programming.ipynb
@@ -1,0 +1,482 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5f4d0289",
+   "metadata": {},
+   "source": [
+    "# Native programming\n",
+    "\n",
+    "TODO: introductory text for the notebook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "954638fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# general imports\n",
+    "import numpy as np\n",
+    "import IPython\n",
+    "\n",
+    "# AWS imports: Import Braket SDK modules\n",
+    "from braket.devices import Devices\n",
+    "import braket.experimental.autoqasm as aq\n",
+    "from braket.experimental.autoqasm.instructions import h, cnot, measure"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5dd374f2",
+   "metadata": {},
+   "source": [
+    "TODO: introduce Bell state, why native programming might be important"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ddf6cca5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OPENQASM 3.0;\n",
+      "qubit[2] __qubits__;\n",
+      "h __qubits__[0];\n",
+      "cnot __qubits__[0], __qubits__[1];\n",
+      "bit[2] __bit_0__ = \"00\";\n",
+      "__bit_0__[0] = measure __qubits__[0];\n",
+      "__bit_0__[1] = measure __qubits__[1];\n"
+     ]
+    }
+   ],
+   "source": [
+    "@aq.main\n",
+    "def bell_state():\n",
+    "    h(0)\n",
+    "    cnot(0, 1)\n",
+    "    measure([0, 1])\n",
+    "\n",
+    "\n",
+    "bell_state_program = bell_state()\n",
+    "print(bell_state_program.to_ir())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9ff3d255",
+   "metadata": {},
+   "source": [
+    "TODO: explain why verbatim and physical qubits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "940d4b22",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OPENQASM 3.0;\n",
+      "pragma braket verbatim\n",
+      "box {\n",
+      "    h $0;\n",
+      "    cnot $0, $1;\n",
+      "}\n",
+      "bit[2] __bit_0__ = \"00\";\n",
+      "__bit_0__[0] = measure $0;\n",
+      "__bit_0__[1] = measure $1;\n"
+     ]
+    }
+   ],
+   "source": [
+    "@aq.main\n",
+    "def bell_state():\n",
+    "    with aq.verbatim():\n",
+    "        h(\"$0\")\n",
+    "        cnot(\"$0\", \"$1\")\n",
+    "    measure([\"$0\", \"$1\"])\n",
+    "\n",
+    "\n",
+    "bell_state_program = bell_state()\n",
+    "print(bell_state_program.to_ir())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a9182030",
+   "metadata": {},
+   "source": [
+    "TODO: but what if I want to target this to a specific device? introduce `device` param\n",
+    "\n",
+    "and try it here - but it doesn't work!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "72cde00f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ERROR: The gate \"h\" is not a native gate of the target device \"Aria 1\". Only native gates may be used inside a verbatim block. The native gates of the device are: ['gpi', 'gpi2', 'ms']\n"
+     ]
+    }
+   ],
+   "source": [
+    "@aq.main(device=Devices.IonQ.Aria1)\n",
+    "def bell_state():\n",
+    "    with aq.verbatim():\n",
+    "        h(\"$0\")\n",
+    "        cnot(\"$0\", \"$1\")\n",
+    "    measure([\"$0\", \"$1\"])\n",
+    "\n",
+    "\n",
+    "try:\n",
+    "    bell_state_program = bell_state()\n",
+    "except Exception as e:\n",
+    "    print(\"ERROR:\", e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ef34c2d",
+   "metadata": {},
+   "source": [
+    "TODO: introduce idea of custom gate definition, what we're doing here, explain what is in ionq_gates.py and how you could implement your own library of native gate implementations for any device."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "518b9d23",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>pre { line-height: 125%; }\n",
+       "td.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }\n",
+       "span.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }\n",
+       "td.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }\n",
+       "span.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }\n",
+       ".output_html .hll { background-color: #ffffcc }\n",
+       ".output_html { background: #f8f8f8; }\n",
+       ".output_html .c { color: #3D7B7B; font-style: italic } /* Comment */\n",
+       ".output_html .err { border: 1px solid #FF0000 } /* Error */\n",
+       ".output_html .k { color: #008000; font-weight: bold } /* Keyword */\n",
+       ".output_html .o { color: #666666 } /* Operator */\n",
+       ".output_html .ch { color: #3D7B7B; font-style: italic } /* Comment.Hashbang */\n",
+       ".output_html .cm { color: #3D7B7B; font-style: italic } /* Comment.Multiline */\n",
+       ".output_html .cp { color: #9C6500 } /* Comment.Preproc */\n",
+       ".output_html .cpf { color: #3D7B7B; font-style: italic } /* Comment.PreprocFile */\n",
+       ".output_html .c1 { color: #3D7B7B; font-style: italic } /* Comment.Single */\n",
+       ".output_html .cs { color: #3D7B7B; font-style: italic } /* Comment.Special */\n",
+       ".output_html .gd { color: #A00000 } /* Generic.Deleted */\n",
+       ".output_html .ge { font-style: italic } /* Generic.Emph */\n",
+       ".output_html .gr { color: #E40000 } /* Generic.Error */\n",
+       ".output_html .gh { color: #000080; font-weight: bold } /* Generic.Heading */\n",
+       ".output_html .gi { color: #008400 } /* Generic.Inserted */\n",
+       ".output_html .go { color: #717171 } /* Generic.Output */\n",
+       ".output_html .gp { color: #000080; font-weight: bold } /* Generic.Prompt */\n",
+       ".output_html .gs { font-weight: bold } /* Generic.Strong */\n",
+       ".output_html .gu { color: #800080; font-weight: bold } /* Generic.Subheading */\n",
+       ".output_html .gt { color: #0044DD } /* Generic.Traceback */\n",
+       ".output_html .kc { color: #008000; font-weight: bold } /* Keyword.Constant */\n",
+       ".output_html .kd { color: #008000; font-weight: bold } /* Keyword.Declaration */\n",
+       ".output_html .kn { color: #008000; font-weight: bold } /* Keyword.Namespace */\n",
+       ".output_html .kp { color: #008000 } /* Keyword.Pseudo */\n",
+       ".output_html .kr { color: #008000; font-weight: bold } /* Keyword.Reserved */\n",
+       ".output_html .kt { color: #B00040 } /* Keyword.Type */\n",
+       ".output_html .m { color: #666666 } /* Literal.Number */\n",
+       ".output_html .s { color: #BA2121 } /* Literal.String */\n",
+       ".output_html .na { color: #687822 } /* Name.Attribute */\n",
+       ".output_html .nb { color: #008000 } /* Name.Builtin */\n",
+       ".output_html .nc { color: #0000FF; font-weight: bold } /* Name.Class */\n",
+       ".output_html .no { color: #880000 } /* Name.Constant */\n",
+       ".output_html .nd { color: #AA22FF } /* Name.Decorator */\n",
+       ".output_html .ni { color: #717171; font-weight: bold } /* Name.Entity */\n",
+       ".output_html .ne { color: #CB3F38; font-weight: bold } /* Name.Exception */\n",
+       ".output_html .nf { color: #0000FF } /* Name.Function */\n",
+       ".output_html .nl { color: #767600 } /* Name.Label */\n",
+       ".output_html .nn { color: #0000FF; font-weight: bold } /* Name.Namespace */\n",
+       ".output_html .nt { color: #008000; font-weight: bold } /* Name.Tag */\n",
+       ".output_html .nv { color: #19177C } /* Name.Variable */\n",
+       ".output_html .ow { color: #AA22FF; font-weight: bold } /* Operator.Word */\n",
+       ".output_html .w { color: #bbbbbb } /* Text.Whitespace */\n",
+       ".output_html .mb { color: #666666 } /* Literal.Number.Bin */\n",
+       ".output_html .mf { color: #666666 } /* Literal.Number.Float */\n",
+       ".output_html .mh { color: #666666 } /* Literal.Number.Hex */\n",
+       ".output_html .mi { color: #666666 } /* Literal.Number.Integer */\n",
+       ".output_html .mo { color: #666666 } /* Literal.Number.Oct */\n",
+       ".output_html .sa { color: #BA2121 } /* Literal.String.Affix */\n",
+       ".output_html .sb { color: #BA2121 } /* Literal.String.Backtick */\n",
+       ".output_html .sc { color: #BA2121 } /* Literal.String.Char */\n",
+       ".output_html .dl { color: #BA2121 } /* Literal.String.Delimiter */\n",
+       ".output_html .sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */\n",
+       ".output_html .s2 { color: #BA2121 } /* Literal.String.Double */\n",
+       ".output_html .se { color: #AA5D1F; font-weight: bold } /* Literal.String.Escape */\n",
+       ".output_html .sh { color: #BA2121 } /* Literal.String.Heredoc */\n",
+       ".output_html .si { color: #A45A77; font-weight: bold } /* Literal.String.Interpol */\n",
+       ".output_html .sx { color: #008000 } /* Literal.String.Other */\n",
+       ".output_html .sr { color: #A45A77 } /* Literal.String.Regex */\n",
+       ".output_html .s1 { color: #BA2121 } /* Literal.String.Single */\n",
+       ".output_html .ss { color: #19177C } /* Literal.String.Symbol */\n",
+       ".output_html .bp { color: #008000 } /* Name.Builtin.Pseudo */\n",
+       ".output_html .fm { color: #0000FF } /* Name.Function.Magic */\n",
+       ".output_html .vc { color: #19177C } /* Name.Variable.Class */\n",
+       ".output_html .vg { color: #19177C } /* Name.Variable.Global */\n",
+       ".output_html .vi { color: #19177C } /* Name.Variable.Instance */\n",
+       ".output_html .vm { color: #19177C } /* Name.Variable.Magic */\n",
+       ".output_html .il { color: #666666 } /* Literal.Number.Integer.Long */</style><div class=\"highlight\"><pre><span></span><span class=\"kn\">import</span> <span class=\"nn\">numpy</span> <span class=\"k\">as</span> <span class=\"nn\">np</span>\n",
+       "<span class=\"kn\">import</span> <span class=\"nn\">braket.experimental.autoqasm</span> <span class=\"k\">as</span> <span class=\"nn\">aq</span>\n",
+       "<span class=\"kn\">from</span> <span class=\"nn\">braket.experimental.autoqasm.instructions</span> <span class=\"kn\">import</span> <span class=\"n\">gpi</span><span class=\"p\">,</span> <span class=\"n\">gpi2</span><span class=\"p\">,</span> <span class=\"n\">ms</span>\n",
+       "\n",
+       "\n",
+       "<span class=\"nd\">@aq</span><span class=\"o\">.</span><span class=\"n\">gate</span>\n",
+       "<span class=\"k\">def</span> <span class=\"nf\">h</span><span class=\"p\">(</span><span class=\"n\">q</span><span class=\"p\">:</span> <span class=\"n\">aq</span><span class=\"o\">.</span><span class=\"n\">Qubit</span><span class=\"p\">):</span>\n",
+       "    <span class=\"n\">gpi2</span><span class=\"p\">(</span><span class=\"n\">q</span><span class=\"p\">,</span> <span class=\"n\">np</span><span class=\"o\">.</span><span class=\"n\">pi</span> <span class=\"o\">/</span> <span class=\"mi\">2</span><span class=\"p\">)</span>\n",
+       "    <span class=\"n\">gpi</span><span class=\"p\">(</span><span class=\"n\">q</span><span class=\"p\">,</span> <span class=\"mi\">0</span><span class=\"p\">)</span>\n",
+       "\n",
+       "\n",
+       "<span class=\"nd\">@aq</span><span class=\"o\">.</span><span class=\"n\">gate</span>\n",
+       "<span class=\"k\">def</span> <span class=\"nf\">x</span><span class=\"p\">(</span><span class=\"n\">q</span><span class=\"p\">:</span> <span class=\"n\">aq</span><span class=\"o\">.</span><span class=\"n\">Qubit</span><span class=\"p\">):</span>\n",
+       "    <span class=\"n\">gpi</span><span class=\"p\">(</span><span class=\"n\">q</span><span class=\"p\">,</span> <span class=\"mi\">0</span><span class=\"p\">)</span>\n",
+       "\n",
+       "\n",
+       "<span class=\"nd\">@aq</span><span class=\"o\">.</span><span class=\"n\">gate</span>\n",
+       "<span class=\"k\">def</span> <span class=\"nf\">u</span><span class=\"p\">(</span><span class=\"n\">q</span><span class=\"p\">:</span> <span class=\"n\">aq</span><span class=\"o\">.</span><span class=\"n\">Qubit</span><span class=\"p\">,</span> <span class=\"n\">a</span><span class=\"p\">:</span> <span class=\"nb\">float</span><span class=\"p\">,</span> <span class=\"n\">b</span><span class=\"p\">:</span> <span class=\"nb\">float</span><span class=\"p\">,</span> <span class=\"n\">c</span><span class=\"p\">:</span> <span class=\"nb\">float</span><span class=\"p\">):</span>\n",
+       "    <span class=\"n\">gpi2</span><span class=\"p\">(</span><span class=\"n\">q</span><span class=\"p\">,</span> <span class=\"n\">a</span><span class=\"p\">)</span>\n",
+       "    <span class=\"n\">gpi</span><span class=\"p\">(</span><span class=\"n\">q</span><span class=\"p\">,</span> <span class=\"n\">b</span><span class=\"p\">)</span>\n",
+       "    <span class=\"n\">gpi2</span><span class=\"p\">(</span><span class=\"n\">q</span><span class=\"p\">,</span> <span class=\"n\">c</span><span class=\"p\">)</span>\n",
+       "\n",
+       "\n",
+       "<span class=\"nd\">@aq</span><span class=\"o\">.</span><span class=\"n\">gate</span>\n",
+       "<span class=\"k\">def</span> <span class=\"nf\">rx</span><span class=\"p\">(</span><span class=\"n\">q</span><span class=\"p\">:</span> <span class=\"n\">aq</span><span class=\"o\">.</span><span class=\"n\">Qubit</span><span class=\"p\">,</span> <span class=\"n\">theta</span><span class=\"p\">:</span> <span class=\"nb\">float</span><span class=\"p\">):</span>\n",
+       "    <span class=\"n\">u</span><span class=\"p\">(</span><span class=\"n\">q</span><span class=\"p\">,</span> <span class=\"n\">np</span><span class=\"o\">.</span><span class=\"n\">pi</span> <span class=\"o\">/</span> <span class=\"mi\">2</span><span class=\"p\">,</span> <span class=\"n\">theta</span> <span class=\"o\">/</span> <span class=\"mi\">2</span> <span class=\"o\">+</span> <span class=\"n\">np</span><span class=\"o\">.</span><span class=\"n\">pi</span> <span class=\"o\">/</span> <span class=\"mi\">2</span><span class=\"p\">,</span> <span class=\"n\">np</span><span class=\"o\">.</span><span class=\"n\">pi</span> <span class=\"o\">/</span> <span class=\"mi\">2</span><span class=\"p\">)</span>\n",
+       "\n",
+       "\n",
+       "<span class=\"nd\">@aq</span><span class=\"o\">.</span><span class=\"n\">gate</span>\n",
+       "<span class=\"k\">def</span> <span class=\"nf\">ry</span><span class=\"p\">(</span><span class=\"n\">q</span><span class=\"p\">:</span> <span class=\"n\">aq</span><span class=\"o\">.</span><span class=\"n\">Qubit</span><span class=\"p\">,</span> <span class=\"n\">theta</span><span class=\"p\">:</span> <span class=\"nb\">float</span><span class=\"p\">):</span>\n",
+       "    <span class=\"n\">u</span><span class=\"p\">(</span><span class=\"n\">q</span><span class=\"p\">,</span> <span class=\"n\">np</span><span class=\"o\">.</span><span class=\"n\">pi</span><span class=\"p\">,</span> <span class=\"n\">theta</span> <span class=\"o\">/</span> <span class=\"mi\">2</span> <span class=\"o\">+</span> <span class=\"n\">np</span><span class=\"o\">.</span><span class=\"n\">pi</span><span class=\"p\">,</span> <span class=\"n\">np</span><span class=\"o\">.</span><span class=\"n\">pi</span><span class=\"p\">)</span>\n",
+       "\n",
+       "\n",
+       "<span class=\"nd\">@aq</span><span class=\"o\">.</span><span class=\"n\">gate</span>\n",
+       "<span class=\"k\">def</span> <span class=\"nf\">cnot</span><span class=\"p\">(</span><span class=\"n\">q0</span><span class=\"p\">:</span> <span class=\"n\">aq</span><span class=\"o\">.</span><span class=\"n\">Qubit</span><span class=\"p\">,</span> <span class=\"n\">q1</span><span class=\"p\">:</span> <span class=\"n\">aq</span><span class=\"o\">.</span><span class=\"n\">Qubit</span><span class=\"p\">):</span>\n",
+       "    <span class=\"n\">ry</span><span class=\"p\">(</span><span class=\"n\">q0</span><span class=\"p\">,</span> <span class=\"n\">np</span><span class=\"o\">.</span><span class=\"n\">pi</span> <span class=\"o\">/</span> <span class=\"mi\">2</span><span class=\"p\">)</span>\n",
+       "    <span class=\"n\">ms</span><span class=\"p\">(</span><span class=\"n\">q0</span><span class=\"p\">,</span> <span class=\"n\">q1</span><span class=\"p\">,</span> <span class=\"mi\">0</span><span class=\"p\">,</span> <span class=\"mi\">0</span><span class=\"p\">,</span> <span class=\"n\">np</span><span class=\"o\">.</span><span class=\"n\">pi</span> <span class=\"o\">/</span> <span class=\"mi\">2</span><span class=\"p\">)</span>\n",
+       "    <span class=\"n\">rx</span><span class=\"p\">(</span><span class=\"n\">q0</span><span class=\"p\">,</span> <span class=\"o\">-</span><span class=\"n\">np</span><span class=\"o\">.</span><span class=\"n\">pi</span> <span class=\"o\">/</span> <span class=\"mi\">2</span><span class=\"p\">)</span>\n",
+       "    <span class=\"n\">rx</span><span class=\"p\">(</span><span class=\"n\">q1</span><span class=\"p\">,</span> <span class=\"o\">-</span><span class=\"n\">np</span><span class=\"o\">.</span><span class=\"n\">pi</span> <span class=\"o\">/</span> <span class=\"mi\">2</span><span class=\"p\">)</span>\n",
+       "    <span class=\"n\">ry</span><span class=\"p\">(</span><span class=\"n\">q0</span><span class=\"p\">,</span> <span class=\"o\">-</span><span class=\"n\">np</span><span class=\"o\">.</span><span class=\"n\">pi</span> <span class=\"o\">/</span> <span class=\"mi\">2</span><span class=\"p\">)</span>\n",
+       "</pre></div>\n"
+      ],
+      "text/latex": [
+       "\\begin{Verbatim}[commandchars=\\\\\\{\\}]\n",
+       "\\PY{k+kn}{import} \\PY{n+nn}{numpy} \\PY{k}{as} \\PY{n+nn}{np}\n",
+       "\\PY{k+kn}{import} \\PY{n+nn}{braket}\\PY{n+nn}{.}\\PY{n+nn}{experimental}\\PY{n+nn}{.}\\PY{n+nn}{autoqasm} \\PY{k}{as} \\PY{n+nn}{aq}\n",
+       "\\PY{k+kn}{from} \\PY{n+nn}{braket}\\PY{n+nn}{.}\\PY{n+nn}{experimental}\\PY{n+nn}{.}\\PY{n+nn}{autoqasm}\\PY{n+nn}{.}\\PY{n+nn}{instructions} \\PY{k+kn}{import} \\PY{n}{gpi}\\PY{p}{,} \\PY{n}{gpi2}\\PY{p}{,} \\PY{n}{ms}\n",
+       "\n",
+       "\n",
+       "\\PY{n+nd}{@aq}\\PY{o}{.}\\PY{n}{gate}\n",
+       "\\PY{k}{def} \\PY{n+nf}{h}\\PY{p}{(}\\PY{n}{q}\\PY{p}{:} \\PY{n}{aq}\\PY{o}{.}\\PY{n}{Qubit}\\PY{p}{)}\\PY{p}{:}\n",
+       "    \\PY{n}{gpi2}\\PY{p}{(}\\PY{n}{q}\\PY{p}{,} \\PY{n}{np}\\PY{o}{.}\\PY{n}{pi} \\PY{o}{/} \\PY{l+m+mi}{2}\\PY{p}{)}\n",
+       "    \\PY{n}{gpi}\\PY{p}{(}\\PY{n}{q}\\PY{p}{,} \\PY{l+m+mi}{0}\\PY{p}{)}\n",
+       "\n",
+       "\n",
+       "\\PY{n+nd}{@aq}\\PY{o}{.}\\PY{n}{gate}\n",
+       "\\PY{k}{def} \\PY{n+nf}{x}\\PY{p}{(}\\PY{n}{q}\\PY{p}{:} \\PY{n}{aq}\\PY{o}{.}\\PY{n}{Qubit}\\PY{p}{)}\\PY{p}{:}\n",
+       "    \\PY{n}{gpi}\\PY{p}{(}\\PY{n}{q}\\PY{p}{,} \\PY{l+m+mi}{0}\\PY{p}{)}\n",
+       "\n",
+       "\n",
+       "\\PY{n+nd}{@aq}\\PY{o}{.}\\PY{n}{gate}\n",
+       "\\PY{k}{def} \\PY{n+nf}{u}\\PY{p}{(}\\PY{n}{q}\\PY{p}{:} \\PY{n}{aq}\\PY{o}{.}\\PY{n}{Qubit}\\PY{p}{,} \\PY{n}{a}\\PY{p}{:} \\PY{n+nb}{float}\\PY{p}{,} \\PY{n}{b}\\PY{p}{:} \\PY{n+nb}{float}\\PY{p}{,} \\PY{n}{c}\\PY{p}{:} \\PY{n+nb}{float}\\PY{p}{)}\\PY{p}{:}\n",
+       "    \\PY{n}{gpi2}\\PY{p}{(}\\PY{n}{q}\\PY{p}{,} \\PY{n}{a}\\PY{p}{)}\n",
+       "    \\PY{n}{gpi}\\PY{p}{(}\\PY{n}{q}\\PY{p}{,} \\PY{n}{b}\\PY{p}{)}\n",
+       "    \\PY{n}{gpi2}\\PY{p}{(}\\PY{n}{q}\\PY{p}{,} \\PY{n}{c}\\PY{p}{)}\n",
+       "\n",
+       "\n",
+       "\\PY{n+nd}{@aq}\\PY{o}{.}\\PY{n}{gate}\n",
+       "\\PY{k}{def} \\PY{n+nf}{rx}\\PY{p}{(}\\PY{n}{q}\\PY{p}{:} \\PY{n}{aq}\\PY{o}{.}\\PY{n}{Qubit}\\PY{p}{,} \\PY{n}{theta}\\PY{p}{:} \\PY{n+nb}{float}\\PY{p}{)}\\PY{p}{:}\n",
+       "    \\PY{n}{u}\\PY{p}{(}\\PY{n}{q}\\PY{p}{,} \\PY{n}{np}\\PY{o}{.}\\PY{n}{pi} \\PY{o}{/} \\PY{l+m+mi}{2}\\PY{p}{,} \\PY{n}{theta} \\PY{o}{/} \\PY{l+m+mi}{2} \\PY{o}{+} \\PY{n}{np}\\PY{o}{.}\\PY{n}{pi} \\PY{o}{/} \\PY{l+m+mi}{2}\\PY{p}{,} \\PY{n}{np}\\PY{o}{.}\\PY{n}{pi} \\PY{o}{/} \\PY{l+m+mi}{2}\\PY{p}{)}\n",
+       "\n",
+       "\n",
+       "\\PY{n+nd}{@aq}\\PY{o}{.}\\PY{n}{gate}\n",
+       "\\PY{k}{def} \\PY{n+nf}{ry}\\PY{p}{(}\\PY{n}{q}\\PY{p}{:} \\PY{n}{aq}\\PY{o}{.}\\PY{n}{Qubit}\\PY{p}{,} \\PY{n}{theta}\\PY{p}{:} \\PY{n+nb}{float}\\PY{p}{)}\\PY{p}{:}\n",
+       "    \\PY{n}{u}\\PY{p}{(}\\PY{n}{q}\\PY{p}{,} \\PY{n}{np}\\PY{o}{.}\\PY{n}{pi}\\PY{p}{,} \\PY{n}{theta} \\PY{o}{/} \\PY{l+m+mi}{2} \\PY{o}{+} \\PY{n}{np}\\PY{o}{.}\\PY{n}{pi}\\PY{p}{,} \\PY{n}{np}\\PY{o}{.}\\PY{n}{pi}\\PY{p}{)}\n",
+       "\n",
+       "\n",
+       "\\PY{n+nd}{@aq}\\PY{o}{.}\\PY{n}{gate}\n",
+       "\\PY{k}{def} \\PY{n+nf}{cnot}\\PY{p}{(}\\PY{n}{q0}\\PY{p}{:} \\PY{n}{aq}\\PY{o}{.}\\PY{n}{Qubit}\\PY{p}{,} \\PY{n}{q1}\\PY{p}{:} \\PY{n}{aq}\\PY{o}{.}\\PY{n}{Qubit}\\PY{p}{)}\\PY{p}{:}\n",
+       "    \\PY{n}{ry}\\PY{p}{(}\\PY{n}{q0}\\PY{p}{,} \\PY{n}{np}\\PY{o}{.}\\PY{n}{pi} \\PY{o}{/} \\PY{l+m+mi}{2}\\PY{p}{)}\n",
+       "    \\PY{n}{ms}\\PY{p}{(}\\PY{n}{q0}\\PY{p}{,} \\PY{n}{q1}\\PY{p}{,} \\PY{l+m+mi}{0}\\PY{p}{,} \\PY{l+m+mi}{0}\\PY{p}{,} \\PY{n}{np}\\PY{o}{.}\\PY{n}{pi} \\PY{o}{/} \\PY{l+m+mi}{2}\\PY{p}{)}\n",
+       "    \\PY{n}{rx}\\PY{p}{(}\\PY{n}{q0}\\PY{p}{,} \\PY{o}{\\PYZhy{}}\\PY{n}{np}\\PY{o}{.}\\PY{n}{pi} \\PY{o}{/} \\PY{l+m+mi}{2}\\PY{p}{)}\n",
+       "    \\PY{n}{rx}\\PY{p}{(}\\PY{n}{q1}\\PY{p}{,} \\PY{o}{\\PYZhy{}}\\PY{n}{np}\\PY{o}{.}\\PY{n}{pi} \\PY{o}{/} \\PY{l+m+mi}{2}\\PY{p}{)}\n",
+       "    \\PY{n}{ry}\\PY{p}{(}\\PY{n}{q0}\\PY{p}{,} \\PY{o}{\\PYZhy{}}\\PY{n}{np}\\PY{o}{.}\\PY{n}{pi} \\PY{o}{/} \\PY{l+m+mi}{2}\\PY{p}{)}\n",
+       "\\end{Verbatim}\n"
+      ],
+      "text/plain": [
+       "import numpy as np\n",
+       "import braket.experimental.autoqasm as aq\n",
+       "from braket.experimental.autoqasm.instructions import gpi, gpi2, ms\n",
+       "\n",
+       "\n",
+       "@aq.gate\n",
+       "def h(q: aq.Qubit):\n",
+       "    gpi2(q, np.pi / 2)\n",
+       "    gpi(q, 0)\n",
+       "\n",
+       "\n",
+       "@aq.gate\n",
+       "def x(q: aq.Qubit):\n",
+       "    gpi(q, 0)\n",
+       "\n",
+       "\n",
+       "@aq.gate\n",
+       "def u(q: aq.Qubit, a: float, b: float, c: float):\n",
+       "    gpi2(q, a)\n",
+       "    gpi(q, b)\n",
+       "    gpi2(q, c)\n",
+       "\n",
+       "\n",
+       "@aq.gate\n",
+       "def rx(q: aq.Qubit, theta: float):\n",
+       "    u(q, np.pi / 2, theta / 2 + np.pi / 2, np.pi / 2)\n",
+       "\n",
+       "\n",
+       "@aq.gate\n",
+       "def ry(q: aq.Qubit, theta: float):\n",
+       "    u(q, np.pi, theta / 2 + np.pi, np.pi)\n",
+       "\n",
+       "\n",
+       "@aq.gate\n",
+       "def cnot(q0: aq.Qubit, q1: aq.Qubit):\n",
+       "    ry(q0, np.pi / 2)\n",
+       "    ms(q0, q1, 0, 0, np.pi / 2)\n",
+       "    rx(q0, -np.pi / 2)\n",
+       "    rx(q1, -np.pi / 2)\n",
+       "    ry(q0, -np.pi / 2)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "IPython.display.Code(filename=\"ionq_gates.py\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5ef522c8",
+   "metadata": {},
+   "source": [
+    "TODO: now I can write the same program again, and it works!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "366c4035",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OPENQASM 3.0;\n",
+      "gate h q {\n",
+      "    gpi2(pi / 2) q;\n",
+      "    gpi(0) q;\n",
+      "}\n",
+      "gate u(a, b, c) q {\n",
+      "    gpi2(a) q;\n",
+      "    gpi(b) q;\n",
+      "    gpi2(c) q;\n",
+      "}\n",
+      "gate ry(theta) q {\n",
+      "    u(pi, theta / 2 + pi, pi) q;\n",
+      "}\n",
+      "gate rx(theta) q {\n",
+      "    u(pi / 2, theta / 2 + pi / 2, pi / 2) q;\n",
+      "}\n",
+      "gate cnot q0, q1 {\n",
+      "    ry(pi / 2) q0;\n",
+      "    ms(0, 0, pi / 2) q0, q1;\n",
+      "    rx(-(pi / 2)) q0;\n",
+      "    rx(-(pi / 2)) q1;\n",
+      "    ry(-(pi / 2)) q0;\n",
+      "}\n",
+      "pragma braket verbatim\n",
+      "box {\n",
+      "    h $0;\n",
+      "    cnot $0, $1;\n",
+      "}\n",
+      "bit[2] __bit_0__ = \"00\";\n",
+      "__bit_0__[0] = measure $0;\n",
+      "__bit_0__[1] = measure $1;\n"
+     ]
+    }
+   ],
+   "source": [
+    "from ionq_gates import h, cnot\n",
+    "\n",
+    "\n",
+    "@aq.main(device=Devices.IonQ.Aria1)\n",
+    "def bell_state():\n",
+    "    with aq.verbatim():\n",
+    "        h(\"$0\")\n",
+    "        cnot(\"$0\", \"$1\")\n",
+    "    measure([\"$0\", \"$1\"])\n",
+    "\n",
+    "\n",
+    "bell_state_program = bell_state()\n",
+    "print(bell_state_program.to_ir())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa2c2c9e",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "TODO: summarize what we did!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/autoqasm/ionq_gates.py
+++ b/examples/autoqasm/ionq_gates.py
@@ -10,11 +10,6 @@ def h(q: aq.Qubit):
 
 
 @aq.gate
-def x(q: aq.Qubit):
-    gpi(q, 0)
-
-
-@aq.gate
 def u(q: aq.Qubit, a: float, b: float, c: float):
     gpi2(q, a)
     gpi(q, b)

--- a/examples/autoqasm/ionq_gates.py
+++ b/examples/autoqasm/ionq_gates.py
@@ -1,18 +1,3 @@
-# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License"). You
-# may not use this file except in compliance with the License. A copy of
-# the License is located at
-#
-#     http://aws.amazon.com/apache2.0/
-#
-# or in the "license" file accompanying this file. This file is
-# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
-# ANY KIND, either express or implied. See the License for the specific
-# language governing permissions and limitations under the License.
-
-"""Custom AutoQASM gate implementations using IonQ native gates."""
-
 import numpy as np
 import braket.experimental.autoqasm as aq
 from braket.experimental.autoqasm.instructions import gpi, gpi2, ms

--- a/examples/autoqasm/ionq_gates.py
+++ b/examples/autoqasm/ionq_gates.py
@@ -1,0 +1,40 @@
+import numpy as np
+import braket.experimental.autoqasm as aq
+from braket.experimental.autoqasm.instructions import gpi, gpi2, ms
+
+
+@aq.gate
+def h(q: aq.Qubit):
+    gpi2(q, np.pi / 2)
+    gpi(q, 0)
+
+
+@aq.gate
+def x(q: aq.Qubit):
+    gpi(q, 0)
+
+
+@aq.gate
+def u(q: aq.Qubit, a: float, b: float, c: float):
+    gpi2(q, a)
+    gpi(q, b)
+    gpi2(q, c)
+
+
+@aq.gate
+def rx(q: aq.Qubit, theta: float):
+    u(q, np.pi / 2, theta / 2 + np.pi / 2, np.pi / 2)
+
+
+@aq.gate
+def ry(q: aq.Qubit, theta: float):
+    u(q, np.pi, theta / 2 + np.pi, np.pi)
+
+
+@aq.gate
+def cnot(q0: aq.Qubit, q1: aq.Qubit):
+    ry(q0, np.pi / 2)
+    ms(q0, q1, 0, 0, np.pi / 2)
+    rx(q0, -np.pi / 2)
+    rx(q1, -np.pi / 2)
+    ry(q0, -np.pi / 2)

--- a/examples/autoqasm/ionq_gates.py
+++ b/examples/autoqasm/ionq_gates.py
@@ -1,3 +1,18 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+"""Custom AutoQASM gate implementations using IonQ native gates."""
+
 import numpy as np
 import braket.experimental.autoqasm as aq
 from braket.experimental.autoqasm.instructions import gpi, gpi2, ms

--- a/src/braket/experimental/autoqasm/api.py
+++ b/src/braket/experimental/autoqasm/api.py
@@ -60,8 +60,8 @@ def main(
         device = AwsDevice(device)
 
     return _function_wrapper(
-        args,
-        _convert_main,
+        *args,
+        converter_callback=_convert_main,
         converter_args={"user_config": aq_program.UserConfig(num_qubits=num_qubits, device=device)},
     )
 
@@ -74,7 +74,7 @@ def subroutine(*args) -> Callable[[Any], aq_program.Program]:
         Callable[[Any], Program]: A callable which returns the converted
         quantum program when called.
     """
-    return _function_wrapper(args, _convert_subroutine)
+    return _function_wrapper(*args, converter_callback=_convert_subroutine)
 
 
 def gate(*args) -> Callable[[Any], None]:
@@ -84,18 +84,17 @@ def gate(*args) -> Callable[[Any], None]:
         Callable[[Any],]: A callable which can be used as a custom gate inside an
         aq.function or inside another aq.gate.
     """
-    return _function_wrapper(args, _convert_gate)
+    return _function_wrapper(*args, converter_callback=_convert_gate)
 
 
 def _function_wrapper(
-    args: Tuple[Any],
+    *args: Tuple[Any],
     converter_callback: Callable,
     converter_args: Optional[Dict[str, Any]] = None,
 ) -> Callable[[Any], aq_program.Program]:
     """Wrapping and conversion logic around the user function `f`.
 
     Args:
-        args (Tuple[Any]): The arguments to the decorated function.
         converter_callback (Callable): The function converter, e.g., _convert_main.
         converter_args (Optional[Dict[str, Any]]): Extra arguments for the function converter.
 
@@ -107,12 +106,11 @@ def _function_wrapper(
         # This the case where a decorator is called with only keyword args, for example:
         #     @aq.main(num_qubits=4)
         #     def my_function():
-        # To make this work, here we simply return another wrapper function which expects
-        # a Callable as the first argument.
-        def _function_wrapper_with_params(*args) -> Callable[[Any], aq_program.Program]:
-            return _function_wrapper(args, converter_callback, converter_args=converter_args)
-
-        return _function_wrapper_with_params
+        # To make this work, here we simply return a partial application of this function
+        # which still expects a Callable as the first argument.
+        return functools.partial(
+            _function_wrapper, converter_callback=converter_callback, converter_args=converter_args
+        )
 
     f = args[0]
     if is_autograph_artifact(f):

--- a/src/braket/experimental/autoqasm/api.py
+++ b/src/braket/experimental/autoqasm/api.py
@@ -105,9 +105,11 @@ def gate_calibration(*args, implements: Callable, **kwargs) -> Callable[[], Gate
         Callable[[], GateCalibration]: A callable to be added to a main program using
         `with_calibrations` method of the main program.
     """
-    converter_args = {"gate_function": implements, **kwargs}
-
-    return _function_wrapper(args, _convert_calibration, converter_args)
+    return _function_wrapper(
+        *args,
+        converter_callback=_convert_calibration,
+        converter_args={"gate_function": implements, **kwargs},
+    )
 
 
 def _function_wrapper(

--- a/src/braket/experimental/autoqasm/api.py
+++ b/src/braket/experimental/autoqasm/api.py
@@ -28,6 +28,7 @@ import braket.experimental.autoqasm.program as aq_program
 import braket.experimental.autoqasm.transpiler as aq_transpiler
 import braket.experimental.autoqasm.types as aq_types
 from braket.aws import AwsDevice
+from braket.devices.device import Device
 from braket.experimental.autoqasm import errors
 from braket.experimental.autoqasm.autograph.core import converter
 from braket.experimental.autoqasm.autograph.impl.api_core import (
@@ -38,7 +39,7 @@ from braket.experimental.autoqasm.autograph.tf_utils import tf_decorator
 
 
 def main(
-    *args, num_qubits: Optional[int] = None, device: Optional[Union[AwsDevice, str]] = None
+    *args, num_qubits: Optional[int] = None, device: Optional[Union[Device, str]] = None
 ) -> Callable[[Any], aq_program.Program]:
     """Decorator that converts a function into a callable that returns
     a Program object containing the quantum program.
@@ -49,8 +50,8 @@ def main(
     Args:
         num_qubits (Optional[int]): Configuration to set the total number of qubits to declare in
             the program.
-        device (Optional[Union[AwsDevice, str]]): Configuration to set the target device for the
-            program. Can be either an AwsDevice object or a valid Amazon Braket device ARN.
+        device (Optional[Union[Device, str]]): Configuration to set the target device for the
+            program. Can be either an Device object or a valid Amazon Braket device ARN.
 
     Returns:
         Callable[[Any], Program]: A callable which returns the converted

--- a/src/braket/experimental/autoqasm/errors.py
+++ b/src/braket/experimental/autoqasm/errors.py
@@ -41,6 +41,10 @@ class InvalidGateDefinition(AutoQasmError):
     """Gate definition does not meet the necessary requirements."""
 
 
+class UnsupportedGate(AutoQasmError):
+    """Gate is not supported by the target device."""
+
+
 class UnknownQubitCountError(AutoQasmError):
     """Missing declaration for the number of qubits."""
 

--- a/src/braket/experimental/autoqasm/errors.py
+++ b/src/braket/experimental/autoqasm/errors.py
@@ -45,6 +45,14 @@ class UnsupportedGate(AutoQasmError):
     """Gate is not supported by the target device."""
 
 
+class UnsupportedNativeGate(AutoQasmError):
+    """Native gate is not supported by the target device."""
+
+
+class VerbatimBlockNotAllowed(AutoQasmError):
+    """Verbatim block is not supported by the target device."""
+
+
 class UnknownQubitCountError(AutoQasmError):
     """Missing declaration for the number of qubits."""
 

--- a/src/braket/experimental/autoqasm/errors.py
+++ b/src/braket/experimental/autoqasm/errors.py
@@ -41,6 +41,10 @@ class InvalidGateDefinition(AutoQasmError):
     """Gate definition does not meet the necessary requirements."""
 
 
+class InvalidTargetQubit(AutoQasmError):
+    """Target qubit is invalid in the current context."""
+
+
 class UnsupportedGate(AutoQasmError):
     """Gate is not supported by the target device."""
 

--- a/src/braket/experimental/autoqasm/instructions/instructions.py
+++ b/src/braket/experimental/autoqasm/instructions/instructions.py
@@ -31,6 +31,7 @@ def _qubit_instruction(
     program_conversion_context.validate_gate_targets(qubits, args)
 
     # Add the instruction to the program.
+    program_conversion_context.register_gate(name)
     program_mode = aq_program.ProgramMode.UNITARY if is_unitary else aq_program.ProgramMode.NONE
     oqpy_program = program_conversion_context.get_oqpy_program(mode=program_mode)
     oqpy_program.gate([_qubit(q) for q in qubits], name, *args)

--- a/src/braket/experimental/autoqasm/instructions/instructions.py
+++ b/src/braket/experimental/autoqasm/instructions/instructions.py
@@ -25,8 +25,6 @@ from .qubits import QubitIdentifierType, _qubit
 def _qubit_instruction(
     name: str, qubits: List[QubitIdentifierType], *args: Any, is_unitary: bool = True
 ) -> None:
-    # If this is an instruction inside a gate definition, ensure that it only operates on
-    # qubits and angles which are passed as arguments to the gate definition.
     program_conversion_context = aq_program.get_program_conversion_context()
     program_conversion_context.validate_gate_targets(qubits, args)
 

--- a/src/braket/experimental/autoqasm/instructions/qubits.py
+++ b/src/braket/experimental/autoqasm/instructions/qubits.py
@@ -21,7 +21,6 @@ from typing import Any, List, Union
 import oqpy.base
 from openpulse.printer import dumps
 
-from braket.circuits.qubit_set import QubitSet
 from braket.experimental.autoqasm import constants, errors, program
 
 QubitIdentifierType = Union[int, oqpy._ClassicalVar, oqpy.base.OQPyExpression, str, oqpy.Qubit]
@@ -39,24 +38,24 @@ def is_qubit_identifier_type(qubit: Any) -> bool:
     return isinstance(qubit, QubitIdentifierType.__args__)
 
 
-def physical_qubit_to_braket_qubit(qids: List[str]) -> QubitSet:
-    """Convert a physical qubit label to a QubitSet.
+def _get_physical_qubit_indices(qids: List[str]) -> List[int]:
+    """Convert physical qubit labels to the corresponding qubit indices.
 
     Args:
         qids (List[str]): Physical qubit labels.
 
     Returns:
-        QubitSet: Represent physical qubits.
+        List[int]: Qubit indices corresponding to the input physical qubits.
     """
     braket_qubits = []
     for qid in qids:
         if not (isinstance(qid, str) and re.match(r"\$\d+", qid)):
             raise ValueError(
-                f"invalid physical qubit label: '{qid}'. Physical qubit must be labeled as a string"
-                "with `$` followed by an integer. For example: `$1`."
+                f"Invalid physical qubit label: '{qid}'. Physical qubit must be labeled as a string"
+                "with '$' followed by an integer. For example: '$1'."
             )
         braket_qubits.append(int(qid[1:]))
-    return QubitSet(braket_qubits)
+    return braket_qubits
 
 
 def _global_qubit_register(qubit_idx_expr: Union[int, str]) -> str:

--- a/src/braket/experimental/autoqasm/program/__init__.py
+++ b/src/braket/experimental/autoqasm/program/__init__.py
@@ -15,7 +15,7 @@
 for AutoQASM.
 """
 
-from .pragmas import Verbatim as verbatim  # noqa: F401
+from .pragmas import verbatim  # noqa: F401
 from .program import (  # noqa: F401
     GateArgs,
     Program,

--- a/src/braket/experimental/autoqasm/program/pragmas.py
+++ b/src/braket/experimental/autoqasm/program/pragmas.py
@@ -31,20 +31,19 @@ The verbatim pragma would then apply to the `h` and `cnot`, but not the `x`.
 
 import contextlib
 
-import oqpy.base
-
 from braket.experimental.autoqasm import program
 
 
 @contextlib.contextmanager
 def verbatim() -> None:
     """Context management protocol that, when used with a `with` statement, wraps the code block
-    in a verbatim box.
+    in a verbatim block.
 
-    The verbatim pragma around a code block specifies that operations are to be executed as
+    A verbatim block specifies that operations contained within the block are to be executed as
     programmed without compilation or modification of any sort.
+
+    Raises:
+        errors.VerbatimBlockNotAllowed: If the target device does not support verbatim blocks.
     """
-    oqpy_program = program.get_program_conversion_context().get_oqpy_program()
-    oqpy_program.pragma("braket verbatim")
-    with oqpy.Box(oqpy_program):
+    with program.get_program_conversion_context().verbatim_block():
         yield

--- a/src/braket/experimental/autoqasm/program/pragmas.py
+++ b/src/braket/experimental/autoqasm/program/pragmas.py
@@ -20,7 +20,7 @@ Pragmas specify how a program should be compiled or executed. In AutoQASM, we su
 
     @aq.main
     def pragma_example() -> None:
-        with aq.Verbatim():
+        with aq.verbatim():
             h(0)
             cnot(0, 1)
         x(0)
@@ -29,24 +29,22 @@ The verbatim pragma would then apply to the `h` and `cnot`, but not the `x`.
 """
 
 
+import contextlib
+
 import oqpy.base
 
 from braket.experimental.autoqasm import program
 
 
-class Verbatim:
+@contextlib.contextmanager
+def verbatim() -> None:
     """Context management protocol that, when used with a `with` statement, wraps the code block
     in a verbatim box.
 
     The verbatim pragma around a code block specifies that operations are to be executed as
     programmed without compilation or modification of any sort.
     """
-
-    def __enter__(self):
-        oqpy_program = program.get_program_conversion_context().get_oqpy_program()
-        self.box = oqpy.Box(oqpy_program)
-        oqpy_program.pragma("braket verbatim")
-        self.box.__enter__()
-
-    def __exit__(self, exc_type, exc, traceback):
-        return self.box.__exit__(exc_type, exc, traceback)
+    oqpy_program = program.get_program_conversion_context().get_oqpy_program()
+    oqpy_program.pragma("braket verbatim")
+    with oqpy.Box(oqpy_program):
+        yield

--- a/src/braket/experimental/autoqasm/program/program.py
+++ b/src/braket/experimental/autoqasm/program/program.py
@@ -480,8 +480,12 @@ class ProgramConversionContext:
         """Sets the program conversion context into a verbatim block context.
 
         Raises:
-            errors.VerbatimBlockNotAllowed: If the target device does not support verbatim blocks.
+            errors.VerbatimBlockNotAllowed: If a verbatim block is not allowed at this point in
+                the program; for example, if the target device does not support verbatim blocks.
         """
+        if self._in_verbatim:
+            raise errors.VerbatimBlockNotAllowed("Verbatim blocks cannot be nested.")
+
         device = self.get_target_device()
         if (
             device

--- a/src/braket/experimental/autoqasm/program/program.py
+++ b/src/braket/experimental/autoqasm/program/program.py
@@ -222,11 +222,12 @@ class ProgramConversionContext:
             return
 
         # If we are in verbatim and there is a target device specified, validate that the
-        # provided gate is a native gate on the target device.
+        # provided gate is a native gate on the target device (or is a custom gate definition).
         device = self.get_target_device()
         if device:
             native_gates = [gate.lower() for gate in device.properties.paradigm.nativeGateSet]
-            if gate_name not in native_gates:
+            allowed_verbatim_gates = self._gates_defined.union(native_gates)
+            if gate_name not in allowed_verbatim_gates:
                 raise errors.UnsupportedNativeGate(
                     f'The gate "{gate_name}" is not a native gate of the target '
                     f'device "{device.name}". Only native gates may be used inside a verbatim '
@@ -292,7 +293,7 @@ class ProgramConversionContext:
             errors.InvalidTargetQubit: Target qubits are invalid in the current context.
             errors.InvalidGateDefinition: Targets are invalid in the current gate definition.
         """
-        if self._in_verbatim:
+        if self._in_verbatim and not self._gate_definitions_processing:
             self._validate_verbatim_target_qubits(qubits)
 
         if self._gate_definitions_processing:

--- a/src/braket/experimental/autoqasm/program/program.py
+++ b/src/braket/experimental/autoqasm/program/program.py
@@ -21,8 +21,8 @@ from typing import Any, List, Optional, Union
 
 import oqpy.base
 
-from braket.aws import AwsDevice
 from braket.circuits.serialization import IRType, SerializableProgram
+from braket.devices.device import Device
 from braket.experimental.autoqasm import constants, errors
 
 # Create the thread-local object for the program conversion context.
@@ -46,7 +46,7 @@ class UserConfig:
     num_qubits: Optional[int] = None
     """The total number of qubits to declare in the program."""
 
-    device: Optional[AwsDevice] = None
+    device: Optional[Device] = None
     """The target device for the program."""
 
 
@@ -185,7 +185,7 @@ class ProgramConversionContext:
         """
         return self.user_config.num_qubits
 
-    def get_target_device(self) -> Optional[AwsDevice]:
+    def get_target_device(self) -> Optional[Device]:
         """Return the target device for the program, as specified by the user.
         Returns None if the user did not specify a target device.
         """

--- a/src/braket/experimental/autoqasm/program/program.py
+++ b/src/braket/experimental/autoqasm/program/program.py
@@ -243,26 +243,28 @@ class ProgramConversionContext:
         Raises:
             errors.InvalidGateDefinition: Targets are invalid in the current gate definition.
         """
-        if self._gate_definitions_processing:
-            gate_name = self._gate_definitions_processing[-1]["name"]
-            gate_qubit_args = self._gate_definitions_processing[-1]["gate_args"].qubits
-            for qubit in qubits:
-                if not isinstance(qubit, oqpy.Qubit) or qubit not in gate_qubit_args:
-                    qubit_name = qubit.name if isinstance(qubit, oqpy.Qubit) else str(qubit)
-                    raise errors.InvalidGateDefinition(
-                        f'Gate definition "{gate_name}" uses qubit "{qubit_name}" which is not '
-                        "an argument to the gate. Gates may only operate on qubits which are "
-                        "passed as arguments."
-                    )
-            gate_angle_args = self._gate_definitions_processing[-1]["gate_args"].angles
-            gate_angle_arg_names = [arg.name for arg in gate_angle_args]
-            for angle in angles:
-                if isinstance(angle, oqpy.base.Var) and angle.name not in gate_angle_arg_names:
-                    raise errors.InvalidGateDefinition(
-                        f'Gate definition "{gate_name}" uses angle "{angle.name}" which is not '
-                        "an argument to the gate. Gates may only use constant angles or angles "
-                        "passed as arguments."
-                    )
+        if not self._gate_definitions_processing:
+            return
+
+        gate_name = self._gate_definitions_processing[-1]["name"]
+        gate_qubit_args = self._gate_definitions_processing[-1]["gate_args"].qubits
+        for qubit in qubits:
+            if not isinstance(qubit, oqpy.Qubit) or qubit not in gate_qubit_args:
+                qubit_name = qubit.name if isinstance(qubit, oqpy.Qubit) else str(qubit)
+                raise errors.InvalidGateDefinition(
+                    f'Gate definition "{gate_name}" uses qubit "{qubit_name}" which is not '
+                    "an argument to the gate. Gates may only operate on qubits which are "
+                    "passed as arguments."
+                )
+        gate_angle_args = self._gate_definitions_processing[-1]["gate_args"].angles
+        gate_angle_arg_names = [arg.name for arg in gate_angle_args]
+        for angle in angles:
+            if isinstance(angle, oqpy.base.Var) and angle.name not in gate_angle_arg_names:
+                raise errors.InvalidGateDefinition(
+                    f'Gate definition "{gate_name}" uses angle "{angle.name}" which is not '
+                    "an argument to the gate. Gates may only use constant angles or angles "
+                    "passed as arguments."
+                )
 
     def get_oqpy_program(
         self, scope: ProgramScope = ProgramScope.CURRENT, mode: ProgramMode = ProgramMode.NONE

--- a/src/braket/experimental/autoqasm/program/program.py
+++ b/src/braket/experimental/autoqasm/program/program.py
@@ -27,7 +27,7 @@ from braket.device_schema import DeviceActionType
 from braket.devices.device import Device
 from braket.experimental.autoqasm import constants, errors
 from braket.experimental.autoqasm.instructions.qubits import QubitIdentifierType as Qubit
-from braket.experimental.autoqasm.instructions.qubits import _qubit, physical_qubit_to_braket_qubit
+from braket.experimental.autoqasm.instructions.qubits import _get_physical_qubit_indices, _qubit
 
 # Create the thread-local object for the program conversion context.
 _local = threading.local()
@@ -353,18 +353,18 @@ class ProgramConversionContext:
                     f'Qubit "{qubit_name}" is not a physical qubit. Only physical qubits such '
                     'as "$0" can be targeted inside a verbatim block.'
                 )
-        qubits = physical_qubit_to_braket_qubit(qubits)
+        qubits = _get_physical_qubit_indices(qubits)
 
         # Validate physical qubit connectivity on the target device:
         device = self.get_target_device()
         if device and not device.properties.paradigm.connectivity.fullyConnected:
-            # connectivityGraph uses integer qubit indices, but represented as strings.
             connectivity_graph = device.properties.paradigm.connectivity.connectivityGraph
-            start_qubit = f"{int(qubits[0])}"
-            valid_target_qubits = connectivity_graph[start_qubit]
-            for qubit in qubits[1:]:
-                target_qubit = f"{int(qubit)}"
-                if target_qubit not in valid_target_qubits:
+
+            # connectivity_graph uses integer qubit indices, but represented as strings.
+            start_qubit = qubits[0]
+            valid_target_qubits = connectivity_graph[str(start_qubit)]
+            for target_qubit in qubits[1:]:
+                if str(target_qubit) not in valid_target_qubits:
                     raise errors.InvalidTargetQubit(
                         f'Qubit "{start_qubit}" is not connected to qubit "{target_qubit}" '
                         f'on device "{device.name}". The connectivity graph of the device is: '

--- a/src/braket/experimental/autoqasm/pulse/pulse.py
+++ b/src/braket/experimental/autoqasm/pulse/pulse.py
@@ -19,11 +19,12 @@ from typing import List, Union
 
 import oqpy
 
+from braket.circuits.qubit_set import QubitSet
 from braket.experimental.autoqasm import program as aq_program
 from braket.experimental.autoqasm.instructions.qubits import (
     QubitIdentifierType,
+    _get_physical_qubit_indices,
     is_qubit_identifier_type,
-    physical_qubit_to_braket_qubit,
 )
 from braket.pulse import PulseSequence
 from braket.pulse.frame import Frame
@@ -136,7 +137,7 @@ def delay(
     if not isinstance(qubits_or_frames, List):
         qubits_or_frames = [qubits_or_frames]
     if all(is_qubit_identifier_type(q) for q in qubits_or_frames):
-        qubits_or_frames = physical_qubit_to_braket_qubit(qubits_or_frames)
+        qubits_or_frames = QubitSet(_get_physical_qubit_indices(qubits_or_frames))
     _pulse_instruction("delay", qubits_or_frames, duration)
 
 
@@ -154,5 +155,5 @@ def barrier(
     if not isinstance(qubits_or_frames, List):
         qubits_or_frames = [qubits_or_frames]
     if all(is_qubit_identifier_type(q) for q in qubits_or_frames):
-        qubits_or_frames = physical_qubit_to_braket_qubit(qubits_or_frames)
+        qubits_or_frames = QubitSet(_get_physical_qubit_indices(qubits_or_frames))
     _pulse_instruction("barrier", qubits_or_frames)

--- a/test/unit_tests/braket/experimental/autoqasm/test_devices.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_devices.py
@@ -169,6 +169,42 @@ def test_unsupported_native_gate(aws_device: Mock) -> None:
         my_program()
 
 
+def test_supported_native_gate_inside_gate_definition(aws_device: Mock) -> None:
+    aws_device.properties.action[DeviceActionType.OPENQASM].supportedOperations = ["h, x"]
+    aws_device.properties.action[DeviceActionType.OPENQASM].supportedPragmas = ["verbatim"]
+    aws_device.properties.paradigm.nativeGateSet = ["x"]
+
+    @aq.gate
+    def my_gate(q: aq.Qubit):
+        x(q)
+
+    @aq.main(device=aws_device)
+    def my_program():
+        with aq.verbatim():
+            x("$0")
+            my_gate("$0")
+
+    assert my_program().to_ir()
+
+
+def test_unsupported_native_gate_inside_gate_definition(aws_device: Mock) -> None:
+    aws_device.properties.action[DeviceActionType.OPENQASM].supportedOperations = ["h, x"]
+    aws_device.properties.action[DeviceActionType.OPENQASM].supportedPragmas = ["verbatim"]
+    aws_device.properties.paradigm.nativeGateSet = ["x"]
+
+    @aq.gate
+    def my_gate(q: aq.Qubit):
+        h(q)
+
+    @aq.main(device=aws_device)
+    def my_program():
+        with aq.verbatim():
+            my_gate("$0")
+
+    with pytest.raises(errors.UnsupportedNativeGate):
+        my_program()
+
+
 def test_unsupported_verbatim_block(aws_device: Mock) -> None:
     aws_device.properties.action[DeviceActionType.OPENQASM].supportedPragmas = []
 

--- a/test/unit_tests/braket/experimental/autoqasm/test_pragmas.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_pragmas.py
@@ -13,7 +13,10 @@
 
 """Tests for pragmas."""
 
+import pytest
+
 import braket.experimental.autoqasm as aq
+from braket.experimental.autoqasm import errors
 from braket.experimental.autoqasm.instructions import cnot, h
 
 
@@ -25,14 +28,24 @@ def test_with_verbatim_box() -> None:
         """User program to test."""
         h(0)
         with aq.verbatim():
-            cnot(1, 2)
+            cnot("$1", "$2")
 
     expected = """OPENQASM 3.0;
-qubit[3] __qubits__;
+qubit[1] __qubits__;
 h __qubits__[0];
 pragma braket verbatim
 box {
-    cnot __qubits__[1], __qubits__[2];
+    cnot $1, $2;
 }"""
 
     assert program_func().to_ir() == expected
+
+
+def test_verbatim_box_invalid_target_qubit() -> None:
+    @aq.main
+    def program_func() -> None:
+        with aq.verbatim():
+            h(0)
+
+    with pytest.raises(errors.InvalidTargetQubit):
+        program_func()

--- a/test/unit_tests/braket/experimental/autoqasm/test_pragmas.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_pragmas.py
@@ -41,6 +41,17 @@ box {
     assert program_func().to_ir() == expected
 
 
+def test_nested_verbatim_box() -> None:
+    @aq.main
+    def program_func() -> None:
+        with aq.verbatim():
+            with aq.verbatim():
+                h(0)
+
+    with pytest.raises(errors.VerbatimBlockNotAllowed):
+        program_func()
+
+
 def test_verbatim_box_invalid_target_qubit() -> None:
     @aq.main
     def program_func() -> None:

--- a/test/unit_tests/braket/experimental/autoqasm/test_pragmas.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_pragmas.py
@@ -20,6 +20,20 @@ from braket.experimental.autoqasm import errors
 from braket.experimental.autoqasm.instructions import cnot, h
 
 
+def test_basic_box() -> None:
+    """Tests the box statement without a pragma."""
+    with aq.build_program() as program_conversion_context:
+        with program_conversion_context.box():
+            pass
+
+    expected = """OPENQASM 3.0;
+box {
+}"""
+
+    program = program_conversion_context.make_program()
+    assert program.to_ir() == expected
+
+
 def test_with_verbatim_box() -> None:
     """Tests the with statement with verbatim box `Verbatim`."""
 

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,7 @@ commands =
     jupyter nbconvert --to html --execute --ExecutePreprocessor.kernel_name=python3 ./examples/autoqasm/1_Getting_started_with_AutoQASM.ipynb
     jupyter nbconvert --to html --execute --ExecutePreprocessor.kernel_name=python3 ./examples/autoqasm/2_Expressing_classical_control_flow.ipynb
     jupyter nbconvert --to html --execute --ExecutePreprocessor.kernel_name=python3 ./examples/autoqasm/3_Iterative_phase_estimation.ipynb
+    jupyter nbconvert --to html --execute --ExecutePreprocessor.kernel_name=python3 ./examples/autoqasm/4_Native_programming.ipynb
 extras = test
 
 [testenv:linters]


### PR DESCRIPTION
*Issue #, if available:*
- [Validation against device capabilities](https://github.com/orgs/amazon-braket/projects/2/views/1?pane=issue&itemId=35380241)
- [User story: Native programming customer mini-journey with device-specific validation
](https://github.com/orgs/amazon-braket/projects/2/views/1?pane=issue&itemId=32620015)

*Description of changes:*
- Validate that all gates used are in the `supportedOperations` of the device properties.
- Validate that verbatim blocks contain only native gates of the target device.
- Validate that verbatim blocks reference only physical qubits.
- Validate that verbatim blocks respect the connectivity of the target device.

*Testing done:*
- Example notebook added with user scenario of custom native gate definitions and verbatim usage.
- Tests added to cover new functionality.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
