### PR TITLE
fix: Return correctly-sized bit register from AutoQASM subroutine

### DIFF
--- a/src/braket/experimental/autoqasm/api.py
+++ b/src/braket/experimental/autoqasm/api.py
@@ -437,10 +437,18 @@ def _make_return_instance_from_oqpy_return_type(return_type: Any) -> Any:
     if not return_type:
         return None
 
-    return_type = aq_types.conversions.var_type_from_ast_type(return_type)
-    if return_type == aq_types.ArrayVar:
+    var_type = aq_types.conversions.var_type_from_ast_type(return_type)
+    if var_type == aq_types.ArrayVar:
         return []
-    return return_type()
+    if var_type == aq_types.BitVar:
+        return var_type(size=_get_bitvar_size(return_type))
+    return var_type()
+
+
+def _get_bitvar_size(node: qasm_ast.BitType) -> Optional[int]:
+    if not isinstance(node, qasm_ast.BitType) or not node.size:
+        return None
+    return node.size.value
 
 
 def _convert_gate(

--- a/test/unit_tests/braket/experimental/autoqasm/test_api.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_api.py
@@ -483,9 +483,7 @@ def ground_state_measurements_subroutine() -> bit[3] {
     return __bit_0__;
 }
 qubit[6] __qubits__;
-"""
-    # TODO: this should be `bit[3]`, but there's a bug. It's being tracked in an issue.
-    expected += """bit __bit_1__;
+bit[3] __bit_1__ = "000";
 __bit_1__ = ground_state_measurements_subroutine();"""
     assert ground_state_measurements_wrapper().to_ir() == expected
 


### PR DESCRIPTION
*Issue #, if available:*
- [Bit register returned from subroutine is assigned to single bit variable](https://github.com/orgs/amazon-braket/projects/2/views/6?pane=issue&itemId=36846211)

*Description of changes:*
- Initialize the `aq.BitVar` return instance with the correct size based on the return value of the subroutine.

*Testing done:*
- Test updated to account for fixed behavior.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
