### PR TITLE
fix: use separate aws session for python validation

### DIFF
--- a/src/braket/jobs/hybrid_job.py
+++ b/src/braket/jobs/hybrid_job.py
@@ -150,8 +150,7 @@ def hybrid_job(
         logger (Logger): Logger object with which to write logs, such as task statuses
             while waiting for task to be in a terminal state. Default is `getLogger(__name__)`
     """
-    aws_session = aws_session or AwsSession()
-    _validate_python_version(aws_session, image_uri)
+    _validate_python_version(image_uri, aws_session)
 
     def _hybrid_job(entry_point):
         @functools.wraps(entry_point)
@@ -209,8 +208,9 @@ def hybrid_job(
     return _hybrid_job
 
 
-def _validate_python_version(aws_session: AwsSession, image_uri: str | None):
+def _validate_python_version(image_uri: str | None, aws_session: AwsSession | None = None):
     """Validate python version at job definition time"""
+    aws_session = aws_session or AwsSession()
     # user provides a custom image_uri
     if image_uri and image_uri not in built_in_images(aws_session.region):
         print(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Don't instantiate aws_session in the decorator

*Testing done:*

notebook testing passing from this fix, unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
