### PR TITLE
infra: stop flake8 running over the src directory twice

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -62,8 +62,7 @@ deps =
     flake8-rst-docstrings
     git+https://github.com/amazon-braket/amazon-braket-build-tools.git
 commands =
-    flake8 {posargs}
-    flake8 --enable-extensions=BCS src
+    flake8 --enable-extensions=BCS {posargs}
 
 [testenv:isort]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,8 @@ deps =
     flake8-rst-docstrings
     git+https://github.com/amazon-braket/amazon-braket-build-tools.git
 commands =
-    flake8 --enable-extensions=BCS {posargs}
+    flake8 --extend-exclude src {posargs}
+    flake8 --enable-extensions=BCS src {posargs}
 
 [testenv:isort]
 basepython = python3


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently, we are running over the `src` directory twice for our linters. The BCS plugin only needs to run over the `src` directory so this will alleviate the amount of times this is ran.

*Testing done:*
```
tox -e linters
...
linters run-test: commands[0] | isort .
Skipped 3 files
linters run-test: commands[1] | black ./
All done! ✨ 🍰 ✨
235 files left unchanged.
linters run-test: commands[2] | flake8 --extend-exclude src
linters run-test: commands[3] | flake8 --enable-extensions=BCS src
src/braket/circuits/circuit.py:77:101: E501 line too long (175 > 100 characters)
```

From benchmarking, average runtime before was around 23 seconds and this brings it down to 15 seconds.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
