### PR TITLE
[fix] Update AutoQASM to consume qubit types from braket.registers module

### DIFF
--- a/src/braket/experimental/autoqasm/pulse/pulse.py
+++ b/src/braket/experimental/autoqasm/pulse/pulse.py
@@ -19,7 +19,6 @@ from typing import Union
 
 import oqpy
 
-from braket.circuits.qubit_set import QubitSet
 from braket.experimental.autoqasm import program as aq_program
 from braket.experimental.autoqasm.instructions.qubits import (
     QubitIdentifierType,
@@ -32,6 +31,7 @@ from braket.pulse import PulseSequence
 from braket.pulse.frame import Frame
 from braket.pulse.pulse_sequence import _validate_uniqueness
 from braket.pulse.waveforms import Waveform
+from braket.registers.qubit_set import QubitSet
 
 
 def _pulse_instruction(name: str, frame: Frame, *args) -> None:


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
- Support the `Qubit` and `QubitSet` types from the `braket.registers` module.
- Additional minor cleanup.

*Testing done:*
- `tox` passes.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
