### PR TITLE
fix: set decorator job working directory inside of function

### DIFF
--- a/src/braket/jobs/_entry_point_template.py
+++ b/src/braket/jobs/_entry_point_template.py
@@ -5,16 +5,16 @@ from braket.jobs import get_results_dir, save_job_result
 from braket.jobs_data import PersistedJobDataFormat
 
 
-# set working directory to results dir
-os.chdir(get_results_dir())
-
-# create symlinks to input data
-links = link_input()
-
 # load and run serialized entry point function
 recovered = cloudpickle.loads({serialized})
 def {function_name}():
     try:
+        # set working directory to results dir
+        os.chdir(get_results_dir())
+
+        # create symlinks to input data
+        links = link_input()
+
         result = recovered()
     finally:
         clean_links(links)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Move cd to set working directory at run time rather than import time. Important because container sets its own working directory between the two.

*Testing done:*

Manual verification, regression testing

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
