### PR TITLE
feature: Add get_compiled_circuit convenience method

### DIFF
--- a/src/braket/tasks/gate_model_quantum_task_result.py
+++ b/src/braket/tasks/gate_model_quantum_task_result.py
@@ -134,6 +134,21 @@ class GateModelQuantumTaskResult:
             return self.task_metadata.id == other.task_metadata.id
         return NotImplemented
 
+    def get_compiled_circuit(self) -> str:
+        """
+        Get the compiled circuit, if one is available.
+
+        Returns:
+            str: The compiled circuit or None.
+        """
+        metadata = self.additional_metadata
+        if not metadata:
+            return
+        if metadata.rigettiMetadata:
+            return metadata.rigettiMetadata.compiledProgram
+        elif metadata.oqcMetadata:
+            return metadata.oqcMetadata.compiledProgram
+
     @staticmethod
     def measurement_counts_from_measurements(measurements: np.ndarray) -> Counter:
         """

--- a/src/braket/tasks/gate_model_quantum_task_result.py
+++ b/src/braket/tasks/gate_model_quantum_task_result.py
@@ -143,11 +143,13 @@ class GateModelQuantumTaskResult:
         """
         metadata = self.additional_metadata
         if not metadata:
-            return
+            return None
         if metadata.rigettiMetadata:
             return metadata.rigettiMetadata.compiledProgram
         elif metadata.oqcMetadata:
             return metadata.oqcMetadata.compiledProgram
+        else:
+            return None
 
     @staticmethod
     def measurement_counts_from_measurements(measurements: np.ndarray) -> Counter:

--- a/src/braket/tasks/gate_model_quantum_task_result.py
+++ b/src/braket/tasks/gate_model_quantum_task_result.py
@@ -134,12 +134,12 @@ class GateModelQuantumTaskResult:
             return self.task_metadata.id == other.task_metadata.id
         return NotImplemented
 
-    def get_compiled_circuit(self) -> str:
+    def get_compiled_circuit(self) -> Optional[str]:
         """
         Get the compiled circuit, if one is available.
 
         Returns:
-            str: The compiled circuit or None.
+            Optional[str]: The compiled circuit or None.
         """
         metadata = self.additional_metadata
         if not metadata:

--- a/test/unit_tests/braket/tasks/test_gate_model_quantum_task_result.py
+++ b/test/unit_tests/braket/tasks/test_gate_model_quantum_task_result.py
@@ -333,14 +333,14 @@ def test_get_compiled_circuit_oqc(result_oqc, qasm2_program):
 def test_get_compiled_circuit(result_obj_1):
     """Test get_compiled_circuit method."""
     result = GateModelQuantumTaskResult.from_object(result_obj_1)
-    assert result.get_compiled_circuit() == None
+    assert result.get_compiled_circuit() is None
 
 
 def test_get_compiled_circuit_no_metadata(result_obj_1):
     """Test that the method does not raise an error if metadata is missing."""
     result = GateModelQuantumTaskResult.from_object(result_obj_1)
     result.additional_metadata = None
-    assert result.get_compiled_circuit() == None
+    assert result.get_compiled_circuit() is None
 
 
 def test_measurement_counts_from_measurements():

--- a/test/unit_tests/braket/tasks/test_gate_model_quantum_task_result.py
+++ b/test/unit_tests/braket/tasks/test_gate_model_quantum_task_result.py
@@ -157,7 +157,6 @@ def result_oqc(task_metadata_shots, additional_metadata_oqc):
     return GateModelQuantumTaskResult.from_object(result)
 
 
-
 @pytest.fixture
 def result_str_1(result_obj_1):
     return result_obj_1.json()
@@ -334,6 +333,13 @@ def test_get_compiled_circuit_oqc(result_oqc, qasm2_program):
 def test_get_compiled_circuit(result_obj_1):
     """Test get_compiled_circuit method."""
     result = GateModelQuantumTaskResult.from_object(result_obj_1)
+    assert result.get_compiled_circuit() == None
+
+
+def test_get_compiled_circuit_no_metadata(result_obj_1):
+    """Test that the method does not raise an error if metadata is missing."""
+    result = GateModelQuantumTaskResult.from_object(result_obj_1)
+    result.additional_metadata = None
     assert result.get_compiled_circuit() == None
 
 

--- a/test/unit_tests/braket/tasks/test_gate_model_quantum_task_result.py
+++ b/test/unit_tests/braket/tasks/test_gate_model_quantum_task_result.py
@@ -26,6 +26,8 @@ from braket.task_result import (
     ResultTypeValue,
     TaskMetadata,
 )
+from braket.task_result.oqc_metadata_v1 import OqcMetadata
+from braket.task_result.rigetti_metadata_v1 import RigettiMetadata
 from braket.tasks import GateModelQuantumTaskResult
 
 
@@ -62,6 +64,68 @@ def additional_metadata_openqasm():
 
 
 @pytest.fixture
+def quil_program():
+    return """
+PRAGMA INITIAL_REWIRING "NAIVE"
+RESET
+DECLARE ro BIT[2]
+PRAGMA PRESERVE_BLOCK
+RX(1.5707963267948966) 0
+RX(1.5707963267948966) 7
+RZ(1.5707963267948966) 0
+RZ(1.5707963267948966) 7
+RX(-1.5707963267948966) 7
+CZ 0 7
+RZ(3.141592653589793) 7
+RX(1.5707963267948966) 7
+RZ(1.5707963267948966) 7
+RX(-1.5707963267948966) 7
+PRAGMA END_PRESERVE_BLOCK
+MEASURE 0 ro[0]
+MEASURE 7 ro[1]
+"""
+
+
+@pytest.fixture
+def additional_metadata_rigetti(quil_program):
+    program = openqasm.Program(
+        source="""
+        OPENQASM 3.0;
+        bit[2] b;
+        h $0;
+        cnot $0, $7;
+        b[0] = measure $0;
+        b[1] = measure $7;
+        """
+    )
+    rigetti_metadata = RigettiMetadata(compiledProgram=quil_program)
+
+    return AdditionalMetadata(action=program, rigettiMetadata=rigetti_metadata)
+
+
+@pytest.fixture
+def qasm2_program():
+    return """TODO"""
+
+
+@pytest.fixture
+def additional_metadata_oqc(qasm2_program):
+    program = openqasm.Program(
+        source="""
+        OPENQASM 3.0;
+        bit[2] b;
+        h $0;
+        cnot $0, $7;
+        b[0] = measure $0;
+        b[1] = measure $7;
+        """
+    )
+    oqc_metadata = OqcMetadata(compiledProgram=qasm2_program)
+
+    return AdditionalMetadata(action=program, oqcMetadata=oqc_metadata)
+
+
+@pytest.fixture
 def result_obj_1(task_metadata_shots, additional_metadata):
     return GateModelTaskResult(
         measurements=[[0, 0], [0, 1], [0, 1], [0, 1]],
@@ -69,6 +133,29 @@ def result_obj_1(task_metadata_shots, additional_metadata):
         taskMetadata=task_metadata_shots,
         additionalMetadata=additional_metadata,
     )
+
+
+@pytest.fixture
+def result_rigetti(task_metadata_shots, additional_metadata_rigetti):
+    result = GateModelTaskResult(
+        measurements=[[0, 0], [0, 1], [0, 1], [0, 1]],
+        measuredQubits=[0, 1],
+        taskMetadata=task_metadata_shots,
+        additionalMetadata=additional_metadata_rigetti,
+    )
+    return GateModelQuantumTaskResult.from_object(result)
+
+
+@pytest.fixture
+def result_oqc(task_metadata_shots, additional_metadata_oqc):
+    result = GateModelTaskResult(
+        measurements=[[0, 0], [0, 1], [0, 1], [0, 1]],
+        measuredQubits=[0, 1],
+        taskMetadata=task_metadata_shots,
+        additionalMetadata=additional_metadata_oqc,
+    )
+    return GateModelQuantumTaskResult.from_object(result)
+
 
 
 @pytest.fixture
@@ -232,6 +319,22 @@ test_ir_results = [
     (jaqcd.Variance(targets=[1, 2], observable=["z", "y"]), 0.64),
     (jaqcd.Variance(observable=["z"]), [0.84, 0.96, 0.96, 0.84]),
 ]
+
+
+def test_get_compiled_circuit_rigetti(result_rigetti, quil_program):
+    """Test get_compiled_circuit method."""
+    assert result_rigetti.get_compiled_circuit() == quil_program
+
+
+def test_get_compiled_circuit_oqc(result_oqc, qasm2_program):
+    """Test get_compiled_circuit method."""
+    assert result_oqc.get_compiled_circuit() == qasm2_program
+
+
+def test_get_compiled_circuit(result_obj_1):
+    """Test get_compiled_circuit method."""
+    result = GateModelQuantumTaskResult.from_object(result_obj_1)
+    assert result.get_compiled_circuit() == None
 
 
 def test_measurement_counts_from_measurements():

--- a/test/unit_tests/braket/tasks/test_gate_model_quantum_task_result.py
+++ b/test/unit_tests/braket/tasks/test_gate_model_quantum_task_result.py
@@ -147,25 +147,17 @@ def result_obj_1(task_metadata_shots, additional_metadata):
 
 
 @pytest.fixture
-def result_rigetti(task_metadata_shots, additional_metadata_rigetti):
-    result = GateModelTaskResult(
-        measurements=[[0, 0], [0, 1], [0, 1], [0, 1]],
-        measuredQubits=[0, 1],
-        taskMetadata=task_metadata_shots,
-        additionalMetadata=additional_metadata_rigetti,
-    )
-    return GateModelQuantumTaskResult.from_object(result)
+def result_rigetti(result_obj_1, additional_metadata_rigetti):
+    result = GateModelQuantumTaskResult.from_object(result_obj_1)
+    result.additional_metadata = additional_metadata_rigetti
+    return result
 
 
 @pytest.fixture
-def result_oqc(task_metadata_shots, additional_metadata_oqc):
-    result = GateModelTaskResult(
-        measurements=[[0, 0], [0, 1], [0, 1], [0, 1]],
-        measuredQubits=[0, 1],
-        taskMetadata=task_metadata_shots,
-        additionalMetadata=additional_metadata_oqc,
-    )
-    return GateModelQuantumTaskResult.from_object(result)
+def result_oqc(result_obj_1, additional_metadata_oqc):
+    result = GateModelQuantumTaskResult.from_object(result_obj_1)
+    result.additional_metadata = additional_metadata_oqc
+    return result
 
 
 @pytest.fixture
@@ -341,7 +333,7 @@ def test_get_compiled_circuit_oqc(result_oqc, qasm2_program):
     assert result_oqc.get_compiled_circuit() == qasm2_program
 
 
-def test_get_compiled_circuit(result_obj_1):
+def test_get_compiled_circuit_no_qhp_metadata(result_obj_1):
     """Test get_compiled_circuit method."""
     result = GateModelQuantumTaskResult.from_object(result_obj_1)
     assert result.get_compiled_circuit() is None

--- a/test/unit_tests/braket/tasks/test_gate_model_quantum_task_result.py
+++ b/test/unit_tests/braket/tasks/test_gate_model_quantum_task_result.py
@@ -105,7 +105,17 @@ def additional_metadata_rigetti(quil_program):
 
 @pytest.fixture
 def qasm2_program():
-    return """TODO"""
+    return """
+    OPENQASM 2.0;
+    include "qelib1.inc";
+
+    qreg node[8];
+    creg b[2];
+    u3(0.5*pi,0.0*pi,1.0*pi) node[0];
+    cx node[0],node[1];
+    measure node[0] -> b[0];
+    measure node[1] -> b[1];
+    """
 
 
 @pytest.fixture
@@ -114,10 +124,11 @@ def additional_metadata_oqc(qasm2_program):
         source="""
         OPENQASM 3.0;
         bit[2] b;
-        h $0;
-        cnot $0, $7;
-        b[0] = measure $0;
-        b[1] = measure $7;
+        qubit[8] q;
+        h q[0];
+        cnot q[0], q[7];
+        b[0] = measure q[0];
+        b[1] = measure q[7];
         """
     )
     oqc_metadata = OqcMetadata(compiledProgram=qasm2_program)


### PR DESCRIPTION
Add `get_compiled_circuit` to GateModelQuantumTaskResult

*Issue #, if available:*
Closes #780 

*Description of changes:*

Proposed method:

```
compiled_program = task.result().get_compiled_program()
```

For Rigetti and OQC tasks, this could be used instead of the method described here: https://docs.aws.amazon.com/braket/latest/developerguide/braket-compiled-circuits-inspecting.html

*Testing done:*
New unit tests, local testing with successful quantum tasks ran on hardware

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
