### PR TITLE
fix: AutoQASM measurement of physical qubits

### DIFF
--- a/src/braket/experimental/autoqasm/instructions/measurements.py
+++ b/src/braket/experimental/autoqasm/instructions/measurements.py
@@ -28,7 +28,11 @@ from typing import Union
 
 from braket.experimental.autoqasm import program
 from braket.experimental.autoqasm import types as aq_types
-from braket.experimental.autoqasm.instructions.qubits import QubitIdentifierType, _qubit
+from braket.experimental.autoqasm.instructions.qubits import (
+    QubitIdentifierType,
+    _qubit,
+    is_qubit_identifier_type,
+)
 
 
 def measure(qubits: Union[QubitIdentifierType, Iterable[QubitIdentifierType]]) -> aq_types.BitVar:
@@ -42,7 +46,7 @@ def measure(qubits: Union[QubitIdentifierType, Iterable[QubitIdentifierType]]) -
     Returns:
         BitVar: Bit variable the measurement results are assigned to.
     """
-    if not isinstance(qubits, Iterable):
+    if is_qubit_identifier_type(qubits):
         qubits = [qubits]
 
     oqpy_program = program.get_program_conversion_context().get_oqpy_program()

--- a/test/unit_tests/braket/experimental/autoqasm/test_api.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_api.py
@@ -302,6 +302,32 @@ def test_bell_measurement_invalid_declared_size() -> None:
     assert expected_error_message in str(exc_info.value)
 
 
+@aq.main
+def measure_physical_qubits() -> None:
+    """A program that measures physical qubits."""
+    a = measure("$0")  # noqa: F841
+    b = measure("$1")  # noqa: F841
+    c = measure(["$0", "$1"])  # noqa: F841
+
+
+def test_measure_physical_qubits() -> None:
+    expected = """OPENQASM 3.0;
+bit a;
+bit b;
+bit[2] c;
+bit __bit_0__;
+__bit_0__ = measure $0;
+a = __bit_0__;
+bit __bit_1__;
+__bit_1__ = measure $1;
+b = __bit_1__;
+bit[2] __bit_2__ = "00";
+__bit_2__[0] = measure $0;
+__bit_2__[1] = measure $1;
+c = __bit_2__;"""
+    assert measure_physical_qubits().to_ir() == expected
+
+
 @aq.main(num_qubits=5)
 def ghz_qasm_for_loop() -> None:
     """A function that generates a GHZ state using a QASM for loop."""


### PR DESCRIPTION
*Issue #, if available:*
- A change in #763 broke AutoQASM measurement of physical qubits, and we had no test to check for this.

*Description of changes:*
- Change the parameter type check in `measure` so that we handle physical qubits (i.e., strings) correctly.

*Testing done:*
- Add a test for physical qubit measurement. Also verify that `tox -e notebooks` passes locally.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
