### PR TITLE
feature: Add support for FreeParameters in AutoQASM conditional statements

### DIFF
--- a/src/braket/experimental/autoqasm/converters/comparisons.py
+++ b/src/braket/experimental/autoqasm/converters/comparisons.py
@@ -1,0 +1,70 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+"""Converters for comparison nodes."""
+
+import ast
+
+import gast
+
+from braket.experimental.autoqasm.autograph.core import ag_ctx, converter
+from braket.experimental.autoqasm.autograph.pyct import templates
+
+COMPARISON_OPERATORS = {
+    gast.Lt: "ag__.lt_",
+    gast.LtE: "ag__.lteq_",
+    gast.Gt: "ag__.gt_",
+    gast.GtE: "ag__.gteq_",
+}
+
+
+class ComparisonTransformer(converter.Base):
+    """Transformer for comparison nodes."""
+
+    def visit_Compare(self, node: ast.stmt) -> ast.stmt:
+        """Transforms a comparison node.
+
+        Args:
+            node (ast.stmt): AST node to transform.
+
+        Returns:
+            ast.stmt: Transformed node.
+        """
+        node = self.generic_visit(node)
+
+        op_type = type(node.ops[0])
+        if op_type not in COMPARISON_OPERATORS:
+            return node
+
+        template = f"{COMPARISON_OPERATORS[op_type]}(lhs_, rhs_)"
+
+        return templates.replace(
+            template,
+            lhs_=node.left,
+            rhs_=node.comparators[0],
+            original=node,
+        )[0].value
+
+
+def transform(node: ast.stmt, ctx: ag_ctx.ControlStatusCtx) -> ast.stmt:
+    """Transform comparison nodes.
+
+    Args:
+        node (ast.stmt): AST node to transform.
+        ctx (ag_ctx.ControlStatusCtx): Transformer context.
+
+    Returns:
+        ast.stmt: Transformed node.
+    """
+
+    return ComparisonTransformer(ctx).visit(node)

--- a/src/braket/experimental/autoqasm/errors.py
+++ b/src/braket/experimental/autoqasm/errors.py
@@ -37,6 +37,10 @@ class MissingParameterTypeError(AutoQasmError):
     """AutoQASM requires type hints for subroutine parameters."""
 
 
+class ParameterNotFoundError(AutoQasmError):
+    """A FreeParameter could not be found in the program."""
+
+
 class InvalidGateDefinition(AutoQasmError):
     """Gate definition does not meet the necessary requirements."""
 

--- a/src/braket/experimental/autoqasm/operators/__init__.py
+++ b/src/braket/experimental/autoqasm/operators/__init__.py
@@ -27,6 +27,7 @@ from braket.experimental.autoqasm.autograph.operators.variables import (  # noqa
 )
 
 from .assignments import assign_stmt  # noqa: F401
+from .comparisons import gt_, gteq_, lt_, lteq_  # noqa: F401
 from .conditional_expressions import if_exp  # noqa: F401
 from .control_flow import for_stmt, if_stmt, while_stmt  # noqa: F401
 from .data_structures import ListPopOpts  # noqa: F401

--- a/src/braket/experimental/autoqasm/operators/comparisons.py
+++ b/src/braket/experimental/autoqasm/operators/comparisons.py
@@ -14,10 +14,7 @@
 
 """Operators for comparison operators: <, <=, >, and >=."""
 
-from collections.abc import Callable
 from typing import Any, Union
-
-import oqpy.base
 
 from braket.experimental.autoqasm import program
 from braket.experimental.autoqasm import types as aq_types

--- a/src/braket/experimental/autoqasm/operators/comparisons.py
+++ b/src/braket/experimental/autoqasm/operators/comparisons.py
@@ -1,0 +1,137 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+
+"""Operators for comparison operators: <, <=, >, and >=."""
+
+from collections.abc import Callable
+from typing import Any, Union
+
+import oqpy.base
+
+from braket.experimental.autoqasm import program
+from braket.experimental.autoqasm import types as aq_types
+
+from .utils import _convert_parameters
+
+
+def lt_(a: Any, b: Any) -> Union[bool, aq_types.BoolVar]:
+    """Functional form of "<".
+
+    Args:
+        a (Any): Callable that returns the first expression.
+        b (Any): Callable that returns the second expression.
+
+    Returns:
+        Union[bool, BoolVar]: Whether the first expression is less than the second.
+    """
+    if aq_types.is_qasm_type(a) or aq_types.is_qasm_type(b):
+        return _aq_lt(a, b)
+    else:
+        return a < b
+
+
+def _aq_lt(a: Any, b: Any) -> aq_types.BoolVar:
+    program_conversion_context = program.get_program_conversion_context()
+    program_conversion_context.register_args([a, b])
+    a, b = _convert_parameters(a, b)
+
+    oqpy_program = program_conversion_context.get_oqpy_program()
+    result = aq_types.BoolVar()
+    oqpy_program.declare(result)
+    oqpy_program.set(result, a < b)
+    return result
+
+
+def lteq_(a: Any, b: Any) -> Union[bool, aq_types.BoolVar]:
+    """Functional form of "<=".
+
+    Args:
+        a (Any): Callable that returns the first expression.
+        b (Any): Callable that returns the second expression.
+
+    Returns:
+        Union[bool, BoolVar]: Whether the first expression is less than or equal to the second.
+    """
+    if aq_types.is_qasm_type(a) or aq_types.is_qasm_type(b):
+        return _aq_lteq(a, b)
+    else:
+        return a <= b
+
+
+def _aq_lteq(a: Any, b: Any) -> aq_types.BoolVar:
+    program_conversion_context = program.get_program_conversion_context()
+    program_conversion_context.register_args([a, b])
+    a, b = _convert_parameters(a, b)
+
+    oqpy_program = program_conversion_context.get_oqpy_program()
+    result = aq_types.BoolVar()
+    oqpy_program.declare(result)
+    oqpy_program.set(result, a <= b)
+    return result
+
+
+def gt_(a: Any, b: Any) -> Union[bool, aq_types.BoolVar]:
+    """Functional form of ">".
+
+    Args:
+        a (Any): Callable that returns the first expression.
+        b (Any): Callable that returns the second expression.
+
+    Returns:
+        Union[bool, BoolVar]: Whether the first expression greater than the second.
+    """
+    if aq_types.is_qasm_type(a) or aq_types.is_qasm_type(b):
+        return _aq_gt(a, b)
+    else:
+        return a > b
+
+
+def _aq_gt(a: Any, b: Any) -> aq_types.BoolVar:
+    program_conversion_context = program.get_program_conversion_context()
+    program_conversion_context.register_args([a, b])
+    a, b = _convert_parameters(a, b)
+
+    oqpy_program = program_conversion_context.get_oqpy_program()
+    result = aq_types.BoolVar()
+    oqpy_program.declare(result)
+    oqpy_program.set(result, a > b)
+    return result
+
+
+def gteq_(a: Any, b: Any) -> Union[bool, aq_types.BoolVar]:
+    """Functional form of ">=".
+
+    Args:
+        a (Any): Callable that returns the first expression.
+        b (Any): Callable that returns the second expression.
+
+    Returns:
+        Union[bool, BoolVar]: Whether the first expression greater than or equal to the second.
+    """
+    if aq_types.is_qasm_type(a) or aq_types.is_qasm_type(b):
+        return _aq_gteq(a, b)
+    else:
+        return a >= b
+
+
+def _aq_gteq(a: Any, b: Any) -> aq_types.BoolVar:
+    program_conversion_context = program.get_program_conversion_context()
+    program_conversion_context.register_args([a, b])
+    a, b = _convert_parameters(a, b)
+
+    oqpy_program = program_conversion_context.get_oqpy_program()
+    result = aq_types.BoolVar()
+    oqpy_program.declare(result)
+    oqpy_program.set(result, a >= b)
+    return result

--- a/src/braket/experimental/autoqasm/operators/comparisons.py
+++ b/src/braket/experimental/autoqasm/operators/comparisons.py
@@ -52,8 +52,8 @@ def lteq_(a: Any, b: Any) -> Union[bool, aq_types.BoolVar]:
     """Functional form of "<=".
 
     Args:
-        a (Any): Callable that returns the first expression.
-        b (Any): Callable that returns the second expression.
+        a (Any): The first expression.
+        b (Any): The second expression.
 
     Returns:
         Union[bool, BoolVar]: Whether the first expression is less than or equal to the second.
@@ -78,8 +78,8 @@ def gt_(a: Any, b: Any) -> Union[bool, aq_types.BoolVar]:
     """Functional form of ">".
 
     Args:
-        a (Any): Callable that returns the first expression.
-        b (Any): Callable that returns the second expression.
+        a (Any): The first expression.
+        b (Any): The second expression.
 
     Returns:
         Union[bool, BoolVar]: Whether the first expression is greater than the second.
@@ -104,8 +104,8 @@ def gteq_(a: Any, b: Any) -> Union[bool, aq_types.BoolVar]:
     """Functional form of ">=".
 
     Args:
-        a (Any): Callable that returns the first expression.
-        b (Any): Callable that returns the second expression.
+        a (Any): The first expression.
+        b (Any): The second expression.
 
     Returns:
         Union[bool, BoolVar]: Whether the first expression is greater than or equal to the second.

--- a/src/braket/experimental/autoqasm/operators/comparisons.py
+++ b/src/braket/experimental/autoqasm/operators/comparisons.py
@@ -26,8 +26,8 @@ def lt_(a: Any, b: Any) -> Union[bool, aq_types.BoolVar]:
     """Functional form of "<".
 
     Args:
-        a (Any): Callable that returns the first expression.
-        b (Any): Callable that returns the second expression.
+        a (Any): The first expression.
+        b (Any): The second expression.
 
     Returns:
         Union[bool, BoolVar]: Whether the first expression is less than the second.

--- a/src/braket/experimental/autoqasm/operators/comparisons.py
+++ b/src/braket/experimental/autoqasm/operators/comparisons.py
@@ -19,7 +19,7 @@ from typing import Any, Union
 from braket.experimental.autoqasm import program
 from braket.experimental.autoqasm import types as aq_types
 
-from .utils import _convert_parameters
+from .utils import _register_and_convert_parameters
 
 
 def lt_(a: Any, b: Any) -> Union[bool, aq_types.BoolVar]:
@@ -39,11 +39,9 @@ def lt_(a: Any, b: Any) -> Union[bool, aq_types.BoolVar]:
 
 
 def _aq_lt(a: Any, b: Any) -> aq_types.BoolVar:
-    program_conversion_context = program.get_program_conversion_context()
-    program_conversion_context.register_args([a, b])
-    a, b = _convert_parameters(a, b)
+    a, b = _register_and_convert_parameters(a, b)
 
-    oqpy_program = program_conversion_context.get_oqpy_program()
+    oqpy_program = program.get_program_conversion_context().get_oqpy_program()
     result = aq_types.BoolVar()
     oqpy_program.declare(result)
     oqpy_program.set(result, a < b)
@@ -67,11 +65,9 @@ def lteq_(a: Any, b: Any) -> Union[bool, aq_types.BoolVar]:
 
 
 def _aq_lteq(a: Any, b: Any) -> aq_types.BoolVar:
-    program_conversion_context = program.get_program_conversion_context()
-    program_conversion_context.register_args([a, b])
-    a, b = _convert_parameters(a, b)
+    a, b = _register_and_convert_parameters(a, b)
 
-    oqpy_program = program_conversion_context.get_oqpy_program()
+    oqpy_program = program.get_program_conversion_context().get_oqpy_program()
     result = aq_types.BoolVar()
     oqpy_program.declare(result)
     oqpy_program.set(result, a <= b)
@@ -95,11 +91,9 @@ def gt_(a: Any, b: Any) -> Union[bool, aq_types.BoolVar]:
 
 
 def _aq_gt(a: Any, b: Any) -> aq_types.BoolVar:
-    program_conversion_context = program.get_program_conversion_context()
-    program_conversion_context.register_args([a, b])
-    a, b = _convert_parameters(a, b)
+    a, b = _register_and_convert_parameters(a, b)
 
-    oqpy_program = program_conversion_context.get_oqpy_program()
+    oqpy_program = program.get_program_conversion_context().get_oqpy_program()
     result = aq_types.BoolVar()
     oqpy_program.declare(result)
     oqpy_program.set(result, a > b)
@@ -123,11 +117,9 @@ def gteq_(a: Any, b: Any) -> Union[bool, aq_types.BoolVar]:
 
 
 def _aq_gteq(a: Any, b: Any) -> aq_types.BoolVar:
-    program_conversion_context = program.get_program_conversion_context()
-    program_conversion_context.register_args([a, b])
-    a, b = _convert_parameters(a, b)
+    a, b = _register_and_convert_parameters(a, b)
 
-    oqpy_program = program_conversion_context.get_oqpy_program()
+    oqpy_program = program.get_program_conversion_context().get_oqpy_program()
     result = aq_types.BoolVar()
     oqpy_program.declare(result)
     oqpy_program.set(result, a >= b)

--- a/src/braket/experimental/autoqasm/operators/comparisons.py
+++ b/src/braket/experimental/autoqasm/operators/comparisons.py
@@ -82,7 +82,7 @@ def gt_(a: Any, b: Any) -> Union[bool, aq_types.BoolVar]:
         b (Any): Callable that returns the second expression.
 
     Returns:
-        Union[bool, BoolVar]: Whether the first expression greater than the second.
+        Union[bool, BoolVar]: Whether the first expression is greater than the second.
     """
     if aq_types.is_qasm_type(a) or aq_types.is_qasm_type(b):
         return _aq_gt(a, b)
@@ -108,7 +108,7 @@ def gteq_(a: Any, b: Any) -> Union[bool, aq_types.BoolVar]:
         b (Any): Callable that returns the second expression.
 
     Returns:
-        Union[bool, BoolVar]: Whether the first expression greater than or equal to the second.
+        Union[bool, BoolVar]: Whether the first expression is greater than or equal to the second.
     """
     if aq_types.is_qasm_type(a) or aq_types.is_qasm_type(b):
         return _aq_gteq(a, b)

--- a/src/braket/experimental/autoqasm/operators/logical.py
+++ b/src/braket/experimental/autoqasm/operators/logical.py
@@ -19,31 +19,10 @@ from typing import Any, Callable, Union
 import oqpy.base
 from openpulse import ast
 
-from braket.circuits import FreeParameter
 from braket.experimental.autoqasm import program
 from braket.experimental.autoqasm import types as aq_types
 
-
-def _convert_parameters(*args: list[FreeParameter]) -> list[aq_types.FloatVar]:
-    """Converts FreeParameter objects to FloatVars through the program conversion context
-    parameter registry.
-
-    FloatVars are more compatible with the program conversion operations.
-
-    Args:
-        args (list[FreeParameter]): FreeParameter objects.
-
-    Returns:
-        list[FloatVar]: FloatVars for program conversion.
-    """
-    result = []
-    for arg in args:
-        if isinstance(arg, FreeParameter):
-            var = program.get_program_conversion_context()._free_parameters[arg.name]
-            result.append(var)
-        else:
-            result.append(arg)
-    return result[0] if len(result) == 1 else result
+from .utils import _convert_parameters
 
 
 def and_(a: Callable[[], Any], b: Callable[[], Any]) -> Union[bool, aq_types.BoolVar]:

--- a/src/braket/experimental/autoqasm/operators/logical.py
+++ b/src/braket/experimental/autoqasm/operators/logical.py
@@ -22,7 +22,7 @@ from openpulse import ast
 from braket.experimental.autoqasm import program
 from braket.experimental.autoqasm import types as aq_types
 
-from .utils import _convert_parameters
+from .utils import _register_and_convert_parameters
 
 
 def and_(a: Callable[[], Any], b: Callable[[], Any]) -> Union[bool, aq_types.BoolVar]:
@@ -44,11 +44,9 @@ def and_(a: Callable[[], Any], b: Callable[[], Any]) -> Union[bool, aq_types.Boo
 
 
 def _oqpy_and(a: Any, b: Any) -> aq_types.BoolVar:
-    program_conversion_context = program.get_program_conversion_context()
-    program_conversion_context.register_args([a, b])
-    a, b = _convert_parameters(a, b)
+    a, b = _register_and_convert_parameters(a, b)
 
-    oqpy_program = program_conversion_context.get_oqpy_program()
+    oqpy_program = program.get_program_conversion_context().get_oqpy_program()
     result = aq_types.BoolVar()
     oqpy_program.declare(result)
     oqpy_program.set(result, oqpy.base.logical_and(a, b))
@@ -78,11 +76,9 @@ def or_(a: Callable[[], Any], b: Callable[[], Any]) -> Union[bool, aq_types.Bool
 
 
 def _oqpy_or(a: Any, b: Any) -> aq_types.BoolVar:
-    program_conversion_context = program.get_program_conversion_context()
-    program_conversion_context.register_args([a, b])
-    a, b = _convert_parameters(a, b)
+    a, b = _register_and_convert_parameters(a, b)
 
-    oqpy_program = program_conversion_context.get_oqpy_program()
+    oqpy_program = program.get_program_conversion_context().get_oqpy_program()
     result = aq_types.BoolVar()
     oqpy_program.declare(result)
     oqpy_program.set(result, oqpy.base.logical_or(a, b))
@@ -109,11 +105,9 @@ def not_(a: Any) -> Union[bool, aq_types.BoolVar]:
 
 
 def _oqpy_not(a: Any) -> aq_types.BoolVar:
-    program_conversion_context = program.get_program_conversion_context()
-    program_conversion_context.register_args([a])
-    a = _convert_parameters(a)
+    a = _register_and_convert_parameters(a)
 
-    oqpy_program = program_conversion_context.get_oqpy_program()
+    oqpy_program = program.get_program_conversion_context().get_oqpy_program()
     result = aq_types.BoolVar()
     oqpy_program.declare(result)
     oqpy_program.set(result, oqpy.base.OQPyUnaryExpression(ast.UnaryOperator["!"], a))
@@ -141,11 +135,9 @@ def eq(a: Any, b: Any) -> Union[bool, aq_types.BoolVar]:
 
 
 def _oqpy_eq(a: Any, b: Any) -> aq_types.BoolVar:
-    program_conversion_context = program.get_program_conversion_context()
-    program_conversion_context.register_args([a, b])
-    a, b = _convert_parameters(a, b)
+    a, b = _register_and_convert_parameters(a, b)
 
-    oqpy_program = program_conversion_context.get_oqpy_program()
+    oqpy_program = program.get_program_conversion_context().get_oqpy_program()
     is_equal = aq_types.BoolVar()
     oqpy_program.declare(is_equal)
     oqpy_program.set(is_equal, a == b)
@@ -173,11 +165,9 @@ def not_eq(a: Any, b: Any) -> Union[bool, aq_types.BoolVar]:
 
 
 def _oqpy_not_eq(a: Any, b: Any) -> aq_types.BoolVar:
-    program_conversion_context = program.get_program_conversion_context()
-    program_conversion_context.register_args([a, b])
-    a, b = _convert_parameters(a, b)
+    a, b = _register_and_convert_parameters(a, b)
 
-    oqpy_program = program_conversion_context.get_oqpy_program()
+    oqpy_program = program.get_program_conversion_context().get_oqpy_program()
     is_not_equal = aq_types.BoolVar()
     oqpy_program.declare(is_not_equal)
     oqpy_program.set(is_not_equal, a != b)

--- a/src/braket/experimental/autoqasm/operators/logical.py
+++ b/src/braket/experimental/autoqasm/operators/logical.py
@@ -19,6 +19,8 @@ from typing import Any, Callable, Union
 import oqpy.base
 from openpulse import ast
 
+from braket.circuits import FreeParameter
+
 from braket.experimental.autoqasm import program
 from braket.experimental.autoqasm import types as aq_types
 
@@ -130,6 +132,11 @@ def _oqpy_eq(a: Any, b: Any) -> aq_types.BoolVar:
     oqpy_program = program.get_program_conversion_context().get_oqpy_program()
     is_equal = aq_types.BoolVar()
     oqpy_program.declare(is_equal)
+    program.get_program_conversion_context().register_args([a, b])
+    if isinstance(a, FreeParameter):
+        a = aq_types.FloatVar(name=a.name, needs_declaration=False)
+    if isinstance(b, FreeParameter):
+        b = aq_types.FloatVar(name=b.name, needs_declaration=False)
     oqpy_program.set(is_equal, a == b)
     return is_equal
 

--- a/src/braket/experimental/autoqasm/operators/utils.py
+++ b/src/braket/experimental/autoqasm/operators/utils.py
@@ -14,27 +14,29 @@
 
 "Utility methods for operators."
 
-from typing import Any
+from typing import Any, Union
 
 from braket.circuits import FreeParameter
 from braket.experimental.autoqasm import program
 from braket.experimental.autoqasm import types as aq_types
 
 
-def _register_and_convert_parameters(*args: list[Any]) -> list[aq_types.FloatVar]:
+def _register_and_convert_parameters(
+    *args: tuple[Any],
+) -> Union[list[aq_types.FloatVar], aq_types.FloatVar]:
     """Adds FreeParameters to the program conversion context parameter registry, and
     returns the associated FloatVar objects.
 
     Notes: Adding a parameter to the registry twice is safe. Conversion is a pass through
-    for non-FreeParameter inputs.
+    for non-FreeParameter inputs. Input and output arity is the same.
 
     FloatVars are more compatible with the program conversion operations.
 
     Returns:
-        list[FloatVar]: FloatVars for program conversion.
+        Union[list[FloatVar], FloatVar]: FloatVars for program conversion.
     """
     program_conversion_context = program.get_program_conversion_context()
-    program_conversion_context.register_args(args)  # TODO could be one item
+    program_conversion_context.register_args(args)
     result = []
     for arg in args:
         if isinstance(arg, FreeParameter):

--- a/src/braket/experimental/autoqasm/operators/utils.py
+++ b/src/braket/experimental/autoqasm/operators/utils.py
@@ -14,20 +14,27 @@
 
 "Utility methods for operators."
 
+from typing import Any
+
 from braket.circuits import FreeParameter
 from braket.experimental.autoqasm import program
 from braket.experimental.autoqasm import types as aq_types
 
 
-def _convert_parameters(*args: list[FreeParameter]) -> list[aq_types.FloatVar]:
-    """Converts FreeParameter objects to FloatVars through the program conversion context
-    parameter registry.
+def _register_and_convert_parameters(*args: list[Any]) -> list[aq_types.FloatVar]:
+    """Adds FreeParameters to the program conversion context parameter registry, and
+    returns the associated FloatVar objects.
+
+    Notes: Adding a parameter to the registry twice is safe. Conversion is a pass through
+    for non-FreeParameter inputs.
 
     FloatVars are more compatible with the program conversion operations.
 
     Returns:
         list[FloatVar]: FloatVars for program conversion.
     """
+    program_conversion_context = program.get_program_conversion_context()
+    program_conversion_context.register_args(args)  # TODO could be one item
     result = []
     for arg in args:
         if isinstance(arg, FreeParameter):

--- a/src/braket/experimental/autoqasm/operators/utils.py
+++ b/src/braket/experimental/autoqasm/operators/utils.py
@@ -1,0 +1,41 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+
+"Utility methods for operators."
+
+from braket.circuits import FreeParameter
+from braket.experimental.autoqasm import program
+from braket.experimental.autoqasm import types as aq_types
+
+
+def _convert_parameters(*args: list[FreeParameter]) -> list[aq_types.FloatVar]:
+    """Converts FreeParameter objects to FloatVars through the program conversion context
+    parameter registry.
+
+    FloatVars are more compatible with the program conversion operations.
+
+    Args:
+        args (list[FreeParameter]): FreeParameter objects.
+
+    Returns:
+        list[FloatVar]: FloatVars for program conversion.
+    """
+    result = []
+    for arg in args:
+        if isinstance(arg, FreeParameter):
+            var = program.get_program_conversion_context().get_parameter(arg.name)
+            result.append(var)
+        else:
+            result.append(arg)
+    return result[0] if len(result) == 1 else result

--- a/src/braket/experimental/autoqasm/operators/utils.py
+++ b/src/braket/experimental/autoqasm/operators/utils.py
@@ -25,9 +25,6 @@ def _convert_parameters(*args: list[FreeParameter]) -> list[aq_types.FloatVar]:
 
     FloatVars are more compatible with the program conversion operations.
 
-    Args:
-        args (list[FreeParameter]): FreeParameter objects.
-
     Returns:
         list[FloatVar]: FloatVars for program conversion.
     """

--- a/src/braket/experimental/autoqasm/program/program.py
+++ b/src/braket/experimental/autoqasm/program/program.py
@@ -338,6 +338,22 @@ class ProgramConversionContext:
         if parameter.name not in self._free_parameters:
             self._free_parameters[parameter.name] = oqpy.FloatVar("input", name=parameter.name)
 
+    def get_parameter(self, name: str) -> oqpy.FloatVar:
+        """Return a named oqpy.FloatVar that is used as a free parameter in the program.
+
+        Args:
+            name (str): The name of the parameter.
+
+        Raises:
+            ValueError: If there is no parameter with the given name registered with the program.
+
+        Returns:
+            FloatVar: The associated variable.
+        """
+        if name not in self._free_parameters:
+            raise ValueError(f"Free parameter '{name}' was not found.")
+        return self._free_parameters[name]
+
     def get_free_parameters(self) -> list[oqpy.FloatVar]:
         """Return a list of named oqpy.Vars that are used as free parameters in the program."""
         return list(self._free_parameters.values())

--- a/src/braket/experimental/autoqasm/program/program.py
+++ b/src/braket/experimental/autoqasm/program/program.py
@@ -333,7 +333,7 @@ class ProgramConversionContext:
         Only floats are currently supported.
 
         Args:
-            parameter (Freeparameter): The parameter to register with the program.
+            parameter (FreeParameter): The parameter to register with the program.
         """
         if parameter.name not in self._free_parameters:
             self._free_parameters[parameter.name] = oqpy.FloatVar("input", name=parameter.name)

--- a/src/braket/experimental/autoqasm/program/program.py
+++ b/src/braket/experimental/autoqasm/program/program.py
@@ -130,11 +130,12 @@ class Program(SerializableProgram):
         Args:
             param_values (dict[str, float]): A mapping of FreeParameter names
                 to a value to assign to them.
-            strict (bool): If True, raises a ValueError if any of the FreeParameters
+            strict (bool): If True, raises a ParameterNotFoundError if any of the FreeParameters
                 in param_values do not appear in the program. False by default.
 
         Raises:
-            ValueError: If a parameter name is given which does not appear in the program.
+            ParameterNotFoundError: If a parameter name is given which does not appear in
+                the program.
 
         Returns:
             Program: Returns a program with all present parameters fixed to their respective
@@ -148,7 +149,7 @@ class Program(SerializableProgram):
                 assert target.init_expression == "input", "Only free parameters can be bound."
                 target.init_expression = value
             elif strict:
-                raise ValueError(f"No parameter in the program named: {name}")
+                raise errors.ParameterNotFoundError(f"No parameter in the program named: {name}")
 
         return Program(bound_oqpy_program, self._has_pulse_control)
 
@@ -345,13 +346,14 @@ class ProgramConversionContext:
             name (str): The name of the parameter.
 
         Raises:
-            ValueError: If there is no parameter with the given name registered with the program.
+            ParameterNotFoundError: If there is no parameter with the given name registered
+            with the program.
 
         Returns:
             FloatVar: The associated variable.
         """
         if name not in self._free_parameters:
-            raise ValueError(f"Free parameter '{name}' was not found.")
+            raise errors.ParameterNotFoundError(f"Free parameter '{name}' was not found.")
         return self._free_parameters[name]
 
     def get_free_parameters(self) -> list[oqpy.FloatVar]:

--- a/src/braket/experimental/autoqasm/program/program.py
+++ b/src/braket/experimental/autoqasm/program/program.py
@@ -321,22 +321,22 @@ class ProgramConversionContext:
         """
         for arg in args:
             if isinstance(arg, FreeParameter):
-                self.register_parameter(arg.name)
+                self.register_parameter(arg)
             elif isinstance(arg, FreeParameterExpression):
                 # TODO laurecap: Support for expressions
                 raise NotImplementedError(
                     "Expressions of FreeParameters will be supported shortly!"
                 )
 
-    def register_parameter(self, name: str) -> None:
-        """Register an input parameter with the given name, if it has not already been
-        registered. Only floats are currently supported.
+    def register_parameter(self, parameter: FreeParameter) -> None:
+        """Register an input parameter if it has not already been registered.
+        Only floats are currently supported.
 
         Args:
-            name (str): The identifier for the parameter.
+            parameter (Freeparameter): The parameter to register with the program.
         """
-        if name not in self._free_parameters:
-            self._free_parameters[name] = oqpy.FloatVar("input", name=name)
+        if parameter.name not in self._free_parameters:
+            self._free_parameters[parameter.name] = oqpy.FloatVar("input", name=parameter.name)
 
     def get_free_parameters(self) -> list[oqpy.FloatVar]:
         """Return a list of named oqpy.Vars that are used as free parameters in the program."""

--- a/src/braket/experimental/autoqasm/transpiler/transpiler.py
+++ b/src/braket/experimental/autoqasm/transpiler/transpiler.py
@@ -59,7 +59,12 @@ from braket.experimental.autoqasm.autograph.pyct.static_analysis import (
     reaching_definitions,
 )
 from braket.experimental.autoqasm.autograph.tf_utils import tf_stack
-from braket.experimental.autoqasm.converters import assignments, break_statements, return_statements
+from braket.experimental.autoqasm.converters import (
+    assignments,
+    break_statements,
+    comparisons,
+    return_statements,
+)
 
 
 class PyToOqpy(transpiler.PyToPy):
@@ -139,6 +144,7 @@ class PyToOqpy(transpiler.PyToPy):
         # canonicalization creates.
         node = continue_statements.transform(node, ctx)
         node = return_statements.transform(node, ctx)
+        node = comparisons.transform(node, ctx)
         node = assignments.transform(node, ctx)
         node = lists.transform(node, ctx)
         node = slices.transform(node, ctx)

--- a/src/braket/experimental/autoqasm/transpiler/transpiler.py
+++ b/src/braket/experimental/autoqasm/transpiler/transpiler.py
@@ -150,8 +150,8 @@ class PyToOqpy(transpiler.PyToPy):
         node = call_trees.transform(node, ctx)
         node = control_flow.transform(node, ctx)
         node = conditional_expressions.transform(node, ctx)
-        node = logical_expressions.transform(node, ctx)
         node = comparisons.transform(node, ctx)
+        node = logical_expressions.transform(node, ctx)
         node = variables.transform(node, ctx)
 
         return node

--- a/src/braket/experimental/autoqasm/transpiler/transpiler.py
+++ b/src/braket/experimental/autoqasm/transpiler/transpiler.py
@@ -144,7 +144,6 @@ class PyToOqpy(transpiler.PyToPy):
         # canonicalization creates.
         node = continue_statements.transform(node, ctx)
         node = return_statements.transform(node, ctx)
-        node = comparisons.transform(node, ctx)
         node = assignments.transform(node, ctx)
         node = lists.transform(node, ctx)
         node = slices.transform(node, ctx)
@@ -152,6 +151,7 @@ class PyToOqpy(transpiler.PyToPy):
         node = control_flow.transform(node, ctx)
         node = conditional_expressions.transform(node, ctx)
         node = logical_expressions.transform(node, ctx)
+        node = comparisons.transform(node, ctx)
         node = variables.transform(node, ctx)
 
         return node

--- a/src/braket/experimental/autoqasm/types/types.py
+++ b/src/braket/experimental/autoqasm/types/types.py
@@ -68,13 +68,15 @@ class ArrayVar(oqpy.ArrayVar):
                 "Arrays may only be declared at the root scope of an AutoQASM main function."
             )
         super(ArrayVar, self).__init__(*args, **kwargs)
-        self.name = program.get_program_conversion_context().next_var_name(oqpy.ArrayVar)
+        if not "name" in kwargs:
+            self.name = program.get_program_conversion_context().next_var_name(oqpy.ArrayVar)
 
 
 class BitVar(oqpy.BitVar):
     def __init__(self, *args, **kwargs):
         super(BitVar, self).__init__(*args, **kwargs)
-        self.name = program.get_program_conversion_context().next_var_name(oqpy.BitVar)
+        if not "name" in kwargs:
+            self.name = program.get_program_conversion_context().next_var_name(oqpy.BitVar)
         if self.size:
             value = self.init_expression or 0
             self.init_expression = ast.BitstringLiteral(value, self.size)
@@ -83,16 +85,19 @@ class BitVar(oqpy.BitVar):
 class BoolVar(oqpy.BoolVar):
     def __init__(self, *args, **kwargs):
         super(BoolVar, self).__init__(*args, **kwargs)
-        self.name = program.get_program_conversion_context().next_var_name(oqpy.BoolVar)
+        if not "name" in kwargs:
+            self.name = program.get_program_conversion_context().next_var_name(oqpy.BoolVar)
 
 
 class FloatVar(oqpy.FloatVar):
     def __init__(self, *args, **kwargs):
         super(FloatVar, self).__init__(*args, **kwargs)
-        self.name = program.get_program_conversion_context().next_var_name(oqpy.FloatVar)
+        if not "name" in kwargs:
+            self.name = program.get_program_conversion_context().next_var_name(oqpy.FloatVar)
 
 
 class IntVar(oqpy.IntVar):
     def __init__(self, *args, **kwargs):
         super(IntVar, self).__init__(*args, **kwargs)
-        self.name = program.get_program_conversion_context().next_var_name(oqpy.IntVar)
+        if not "name" in kwargs:
+            self.name = program.get_program_conversion_context().next_var_name(oqpy.IntVar)

--- a/src/braket/experimental/autoqasm/types/types.py
+++ b/src/braket/experimental/autoqasm/types/types.py
@@ -19,6 +19,7 @@ import oqpy
 import oqpy.base
 from openpulse import ast
 
+from braket.circuits import FreeParameterExpression
 from braket.experimental.autoqasm import errors, program
 
 
@@ -32,11 +33,12 @@ def is_qasm_type(val: Any) -> bool:
     Returns:
         bool: Whether the object is a QASM type.
     """
+    qasm_types = (oqpy.Range, oqpy._ClassicalVar, oqpy.base.OQPyExpression, FreeParameterExpression)
     # The input can either be a class, like oqpy.Range ...
     if type(val) is type:
-        return issubclass(val, (oqpy.Range, oqpy._ClassicalVar, oqpy.base.OQPyExpression))
+        return issubclass(val, qasm_types)
     # ... or an instance of a class, like oqpy.Range(10)
-    return isinstance(val, (oqpy.Range, oqpy._ClassicalVar, oqpy.base.OQPyExpression))
+    return isinstance(val, qasm_types)
 
 
 def qasm_range(start: int, stop: Optional[int] = None, step: Optional[int] = 1) -> oqpy.Range:

--- a/src/braket/experimental/autoqasm/types/types.py
+++ b/src/braket/experimental/autoqasm/types/types.py
@@ -68,15 +68,13 @@ class ArrayVar(oqpy.ArrayVar):
                 "Arrays may only be declared at the root scope of an AutoQASM main function."
             )
         super(ArrayVar, self).__init__(*args, **kwargs)
-        if "name" not in kwargs:
-            self.name = program.get_program_conversion_context().next_var_name(oqpy.ArrayVar)
+        self.name = program.get_program_conversion_context().next_var_name(oqpy.ArrayVar)
 
 
 class BitVar(oqpy.BitVar):
     def __init__(self, *args, **kwargs):
         super(BitVar, self).__init__(*args, **kwargs)
-        if "name" not in kwargs:
-            self.name = program.get_program_conversion_context().next_var_name(oqpy.BitVar)
+        self.name = program.get_program_conversion_context().next_var_name(oqpy.BitVar)
         if self.size:
             value = self.init_expression or 0
             self.init_expression = ast.BitstringLiteral(value, self.size)
@@ -85,19 +83,16 @@ class BitVar(oqpy.BitVar):
 class BoolVar(oqpy.BoolVar):
     def __init__(self, *args, **kwargs):
         super(BoolVar, self).__init__(*args, **kwargs)
-        if "name" not in kwargs:
-            self.name = program.get_program_conversion_context().next_var_name(oqpy.BoolVar)
+        self.name = program.get_program_conversion_context().next_var_name(oqpy.BoolVar)
 
 
 class FloatVar(oqpy.FloatVar):
     def __init__(self, *args, **kwargs):
         super(FloatVar, self).__init__(*args, **kwargs)
-        if "name" not in kwargs:
-            self.name = program.get_program_conversion_context().next_var_name(oqpy.FloatVar)
+        self.name = program.get_program_conversion_context().next_var_name(oqpy.FloatVar)
 
 
 class IntVar(oqpy.IntVar):
     def __init__(self, *args, **kwargs):
         super(IntVar, self).__init__(*args, **kwargs)
-        if "name" not in kwargs:
-            self.name = program.get_program_conversion_context().next_var_name(oqpy.IntVar)
+        self.name = program.get_program_conversion_context().next_var_name(oqpy.IntVar)

--- a/src/braket/experimental/autoqasm/types/types.py
+++ b/src/braket/experimental/autoqasm/types/types.py
@@ -68,14 +68,14 @@ class ArrayVar(oqpy.ArrayVar):
                 "Arrays may only be declared at the root scope of an AutoQASM main function."
             )
         super(ArrayVar, self).__init__(*args, **kwargs)
-        if not "name" in kwargs:
+        if "name" not in kwargs:
             self.name = program.get_program_conversion_context().next_var_name(oqpy.ArrayVar)
 
 
 class BitVar(oqpy.BitVar):
     def __init__(self, *args, **kwargs):
         super(BitVar, self).__init__(*args, **kwargs)
-        if not "name" in kwargs:
+        if "name" not in kwargs:
             self.name = program.get_program_conversion_context().next_var_name(oqpy.BitVar)
         if self.size:
             value = self.init_expression or 0
@@ -85,19 +85,19 @@ class BitVar(oqpy.BitVar):
 class BoolVar(oqpy.BoolVar):
     def __init__(self, *args, **kwargs):
         super(BoolVar, self).__init__(*args, **kwargs)
-        if not "name" in kwargs:
+        if "name" not in kwargs:
             self.name = program.get_program_conversion_context().next_var_name(oqpy.BoolVar)
 
 
 class FloatVar(oqpy.FloatVar):
     def __init__(self, *args, **kwargs):
         super(FloatVar, self).__init__(*args, **kwargs)
-        if not "name" in kwargs:
+        if "name" not in kwargs:
             self.name = program.get_program_conversion_context().next_var_name(oqpy.FloatVar)
 
 
 class IntVar(oqpy.IntVar):
     def __init__(self, *args, **kwargs):
         super(IntVar, self).__init__(*args, **kwargs)
-        if not "name" in kwargs:
+        if "name" not in kwargs:
             self.name = program.get_program_conversion_context().next_var_name(oqpy.IntVar)

--- a/test/unit_tests/braket/experimental/autoqasm/test_api.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_api.py
@@ -131,7 +131,9 @@ def do_h(int[32] q) {
 }
 def recursive_h(int[32] q) {
     do_h(q);
-    if (q > 0) {
+    bool __bool_0__;
+    __bool_0__ = q > 0;
+    if (__bool_0__) {
         recursive_h(q - 1);
     }
 }
@@ -155,7 +157,9 @@ def do_h(int[32] q) {
 }
 def recursive_h(int[32] q) {
     do_h(q);
-    if (q > 0) {
+    bool __bool_0__;
+    __bool_0__ = q > 0;
+    if (__bool_0__) {
         recursive_h(q - 1);
     }
 }

--- a/test/unit_tests/braket/experimental/autoqasm/test_operators.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_operators.py
@@ -487,6 +487,73 @@ def test_logical_ops_py() -> None:
     assert prog().to_ir() == expected
 
 
+def test_comparison_lt() -> None:
+    """Tests aq.operators.lt_."""
+
+    @aq.main
+    def prog():
+        a = measure(0)
+        if a < 1:
+            h(0)
+
+    expected = """OPENQASM 3.0;
+bit a;
+qubit[1] __qubits__;
+bit __bit_0__;
+__bit_0__ = measure __qubits__[0];
+a = __bit_0__;
+bool __bool_1__;
+__bool_1__ = a < 1;
+if (__bool_1__) {
+    h __qubits__[0];
+}"""
+    qasm = prog().to_ir()
+    assert qasm == expected
+
+
+def test_comparison_gt() -> None:
+    """Tests aq.operators.lt_."""
+
+    @aq.main
+    def prog():
+        a = measure(0)
+        if a > 1:
+            h(0)
+
+    expected = """OPENQASM 3.0;
+bit a;
+qubit[1] __qubits__;
+bit __bit_0__;
+__bit_0__ = measure __qubits__[0];
+a = __bit_0__;
+bool __bool_1__;
+__bool_1__ = a > 1;
+if (__bool_1__) {
+    h __qubits__[0];
+}"""
+    qasm = prog().to_ir()
+    assert qasm == expected
+
+
+def test_comparison_ops_py() -> None:
+    """Tests the comparison aq.operators for Python expressions."""
+
+    @aq.main
+    def prog():
+        a = 1.2
+        b = 12
+        c = a < b
+        d = a <= b
+        e = a > b
+        f = a >= b
+        g = 1.2
+        h = a <= g
+        assert all([c, d, not e, not f, h])
+
+    expected = """OPENQASM 3.0;"""
+    assert prog().to_ir() == expected
+
+
 @pytest.mark.parametrize(
     "target", [oqpy.ArrayVar(dimensions=[3], name="arr"), oqpy.BitVar(size=3, name="arr")]
 )

--- a/test/unit_tests/braket/experimental/autoqasm/test_operators.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_operators.py
@@ -488,7 +488,7 @@ def test_logical_ops_py() -> None:
 
 
 def test_comparison_lt() -> None:
-    """Tests aq.operators.lt_."""
+    """Tests less than operator handling."""
 
     @aq.main
     def prog():
@@ -512,7 +512,7 @@ if (__bool_1__) {
 
 
 def test_comparison_gt() -> None:
-    """Tests aq.operators.lt_."""
+    """Tests greater than operator handling."""
 
     @aq.main
     def prog():

--- a/test/unit_tests/braket/experimental/autoqasm/test_parameters.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_parameters.py
@@ -461,7 +461,9 @@ def test_strict_parameter_bind_failure():
         measure(0)
 
     prog = parametric(FreeParameter("alpha"))
-    with pytest.raises(ValueError, match="No parameter in the program named: beta"):
+    with pytest.raises(
+        aq.errors.ParameterNotFoundError, match="No parameter in the program named: beta"
+    ):
         prog.make_bound_program({"beta": 0.5}, strict=True)
 
 
@@ -484,7 +486,9 @@ def test_binding_variable_fails():
     def parametric():
         alpha = aq.FloatVar(1.2)  # noqa: F841
 
-    with pytest.raises(ValueError, match="No parameter in the program named: beta"):
+    with pytest.raises(
+        aq.errors.ParameterNotFoundError, match="No parameter in the program named: beta"
+    ):
         parametric().make_bound_program({"beta": 0.5}, strict=True)
 
 

--- a/test/unit_tests/braket/experimental/autoqasm/test_parameters.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_parameters.py
@@ -520,8 +520,6 @@ def test_lt_condition():
 
     @aq.main
     def parametric(val: float):
-        if 1 < 2:
-            pulse.delay("$1", 0)
         if val < 0.9:
             x(0)
         if val <= 0.9:
@@ -531,9 +529,6 @@ def test_lt_condition():
     expected = """OPENQASM 3.0;
 input float[64] val;
 qubit[1] __qubits__;
-cal {
-    delay[0.0ns] $1;
-}
 bool __bool_0__;
 __bool_0__ = val < 0.9;
 if (__bool_0__) {

--- a/test/unit_tests/braket/experimental/autoqasm/test_parameters.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_parameters.py
@@ -488,8 +488,8 @@ def test_binding_variable_fails():
         parametric().make_bound_program({"beta": 0.5}, strict=True)
 
 
-def test_parameter_as_condition():
-    """Test parameters used in conditional statements."""
+def test_parameter_as_condition_gt():
+    """Test parameters used in greater than conditional statements."""
 
     @aq.main
     def parametric(val: float):
@@ -500,14 +500,14 @@ def test_parameter_as_condition():
 
     expected = """OPENQASM 3.0;
 input float[64] val;
-float[64] threshold;
 qubit[1] __qubits__;
-threshold = 0.9;
-if (val > threshold) {
+bool __bool_0__;
+__bool_0__ = val > 0.9;
+if (__bool_0__) {
     x __qubits__[0];
 }
-bit __bit_0__;
-__bit_0__ = measure __qubits__[0];"""
+bit __bit_1__;
+__bit_1__ = measure __qubits__[0];"""
     assert parametric(FreeParameter("val")).to_ir() == expected
 
 
@@ -527,15 +527,17 @@ def test_parameter_as_condition_in_subroutine():
 
     expected = """OPENQASM 3.0;
 def sub(float[64] val) {
-    if (val > 0.9) {
+    bool __bool_0__;
+    __bool_0__ = val > 0.9;
+    if (__bool_0__) {
         x __qubits__[0];
     }
 }
 input float[64] val;
 qubit[1] __qubits__;
 sub(val);
-bit __bit_0__;
-__bit_0__ = measure __qubits__[0];"""
+bit __bit_1__;
+__bit_1__ = measure __qubits__[0];"""
     assert parametric(FreeParameter("val")).to_ir() == expected
 
 

--- a/test/unit_tests/braket/experimental/autoqasm/test_program.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_program.py
@@ -20,6 +20,7 @@ import oqpy.base
 import pytest
 
 import braket.experimental.autoqasm as aq
+from braket.circuits import FreeParameter
 from braket.circuits.serialization import IRType
 from braket.experimental.autoqasm.instructions import cnot, measure, rx
 
@@ -37,6 +38,14 @@ def test_program_conversion_context() -> None:
 
     assert prog.get_oqpy_program() == initial_oqpy_program
     assert len(prog._oqpy_program_stack) == 1
+
+
+def test_get_parameter_invalid_name():
+    """Tests the get_parameter function."""
+    prog = aq.program.ProgramConversionContext()
+    prog.register_parameter(FreeParameter("alpha"))
+    with pytest.raises(ValueError):
+        prog.get_parameter("not_a_parameter")
 
 
 def test_build_program() -> None:

--- a/test/unit_tests/braket/experimental/autoqasm/test_program.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_program.py
@@ -44,7 +44,7 @@ def test_get_parameter_invalid_name():
     """Tests the get_parameter function."""
     prog = aq.program.ProgramConversionContext()
     prog.register_parameter(FreeParameter("alpha"))
-    with pytest.raises(ValueError):
+    with pytest.raises(aq.errors.ParameterNotFoundError):
         prog.get_parameter("not_a_parameter")
 
 

--- a/test/unit_tests/braket/experimental/autoqasm/test_types.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_types.py
@@ -17,7 +17,14 @@ import oqpy
 import pytest
 
 import braket.experimental.autoqasm as aq
-from braket.experimental.autoqasm.types.types import qasm_range
+from braket.experimental.autoqasm.types.types import (
+    ArrayVar,
+    BitVar,
+    BoolVar,
+    FloatVar,
+    IntVar,
+    qasm_range,
+)
 
 
 @pytest.mark.parametrize(
@@ -40,6 +47,21 @@ def test_qasm_range(
     qrange = qasm_range(start, stop, step)
     assert isinstance(qrange, oqpy.Range)
     assert (qrange.start, qrange.stop, qrange.step) == expected_range_params
+
+
+@pytest.mark.parametrize("type_", [FloatVar, IntVar, BitVar, BoolVar])
+def test_manual_name_for_aq_types(type_):
+    """Test that types can accept a given name."""
+    with aq.build_program():
+        var = type_(name="test")
+        assert var.name == "test"
+
+
+def test_manual_name_for_arrayvar():
+    """Test that types can accept a given name."""
+    with aq.build_program():
+        var = ArrayVar(name="test", dimensions=[1])
+        assert var.name == "test"
 
 
 def test_return_bit():

--- a/test/unit_tests/braket/experimental/autoqasm/test_types.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_types.py
@@ -17,14 +17,7 @@ import oqpy
 import pytest
 
 import braket.experimental.autoqasm as aq
-from braket.experimental.autoqasm.types.types import (
-    ArrayVar,
-    BitVar,
-    BoolVar,
-    FloatVar,
-    IntVar,
-    qasm_range,
-)
+from braket.experimental.autoqasm.types.types import qasm_range
 
 
 @pytest.mark.parametrize(
@@ -47,21 +40,6 @@ def test_qasm_range(
     qrange = qasm_range(start, stop, step)
     assert isinstance(qrange, oqpy.Range)
     assert (qrange.start, qrange.stop, qrange.step) == expected_range_params
-
-
-@pytest.mark.parametrize("type_", [FloatVar, IntVar, BitVar, BoolVar])
-def test_manual_name_for_aq_types(type_):
-    """Test that types can accept a given name."""
-    with aq.build_program():
-        var = type_(name="test")
-        assert var.name == "test"
-
-
-def test_manual_name_for_arrayvar():
-    """Test that types can accept a given name."""
-    with aq.build_program():
-        var = ArrayVar(name="test", dimensions=[1])
-        assert var.name == "test"
 
 
 def test_return_bit():


### PR DESCRIPTION
*Issue #, if available:*
Closes #785 

*Description of changes:*
This is a follow up from https://github.com/amazon-braket/amazon-braket-sdk-python/issues/757

This adds support for FreeParameters in conditional statements. For example:

```
@aq.main
def parametric(val: float | FreeParameter):
    threshold = 0.9
    if val > threshold:
        x(0)
    measure(0)

parametric(FreeParameter("val"))
```

*Details*
 - New `ComparisonTransformer` to replace comparison operators with functions that we can later process ourselves
 - Comparison operator processing for <, <=, >, >=
 - arguments processed by `autoqasm/operators/` (both logical and comparison stmts) now check for FreeParameters. If found, they're registered with the program conversion context and converted to the newly associated FloatVar
 - Minor API cleanup for program conversion context
 - transpiler updated to use the new `ComparisonTransformer`
 - Minor improvements in types: if a name kwarg is supplied, it is no longer overwritten.
 - Lots of new tests

*Testing done:*
New unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
