### PR TITLE
AutoQASM freeparameter usage with pulse instruction

### DIFF
--- a/src/braket/experimental/autoqasm/pulse/pulse.py
+++ b/src/braket/experimental/autoqasm/pulse/pulse.py
@@ -43,6 +43,7 @@ def _pulse_instruction(name: str, frame: Frame, *args) -> None:
     """
     program_conversion_context = aq_program.get_program_conversion_context()
     program_conversion_context._has_pulse_control = True
+    program_conversion_context.register_args(args)
 
     pulse_sequence = PulseSequence()
     pulse_sequence._program = program_conversion_context.get_oqpy_program(


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/orgs/amazon-braket/projects/2/views/6?pane=issue&itemId=44479389

*Description of changes:*
- Register the pulse usage of free parameter in program. 
- Enable binding value to free parameter for pulse instructions.

*Testing done:*
tox

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
