### PR TITLE
feat: Support FreeParameter expressions in AutoQASM programs

### DIFF
--- a/src/braket/experimental/autoqasm/operators/utils.py
+++ b/src/braket/experimental/autoqasm/operators/utils.py
@@ -16,7 +16,7 @@
 
 from typing import Any, Union
 
-from braket.circuits import FreeParameter
+from braket.circuits import FreeParameterExpression
 from braket.experimental.autoqasm import program
 from braket.experimental.autoqasm import types as aq_types
 
@@ -39,8 +39,8 @@ def _register_and_convert_parameters(
     program_conversion_context.register_args(args)
     result = []
     for arg in args:
-        if isinstance(arg, FreeParameter):
-            var = program.get_program_conversion_context().get_parameter(arg.name)
+        if isinstance(arg, FreeParameterExpression):
+            var = program.get_program_conversion_context().get_expression_var(arg)
             result.append(var)
         else:
             result.append(arg)

--- a/src/braket/experimental/autoqasm/program/program.py
+++ b/src/braket/experimental/autoqasm/program/program.py
@@ -25,6 +25,7 @@ from typing import Any, Optional, Union
 import oqpy.base
 from sympy import Symbol
 
+import braket.experimental.autoqasm.types as aq_types
 from braket.circuits.free_parameter import FreeParameter
 from braket.circuits.free_parameter_expression import FreeParameterExpression
 from braket.circuits.serialization import IRType, SerializableProgram
@@ -322,14 +323,13 @@ class ProgramConversionContext:
             args (list[Any]): Arguments passed to the main program or a subroutine.
         """
         for arg in args:
-            if isinstance(arg, FreeParameter):
-                self.register_parameter(arg)
-            elif isinstance(arg, FreeParameterExpression):
-                free_symbol_names = [
-                    str(s) for s in arg._expression.free_symbols if isinstance(s, Symbol)
-                ]
-                for free_symbol_name in sorted(free_symbol_names):
+            if isinstance(arg, FreeParameterExpression):
+                for free_symbol_name in self._free_symbol_names(arg):
                     self.register_parameter(free_symbol_name)
+
+    @staticmethod
+    def _free_symbol_names(expr: FreeParameterExpression) -> Iterable[str]:
+        return sorted([str(s) for s in expr._expression.free_symbols if isinstance(s, Symbol)])
 
     def register_parameter(self, parameter: str | FreeParameter) -> None:
         """Register an input parameter if it has not already been registered.
@@ -342,22 +342,32 @@ class ProgramConversionContext:
         if parameter_name not in self._free_parameters:
             self._free_parameters[parameter_name] = oqpy.FloatVar("input", name=parameter_name)
 
-    def get_parameter(self, name: str) -> oqpy.FloatVar:
-        """Return a named oqpy.FloatVar that is used as a free parameter in the program.
+    def get_expression_var(self, expression: FreeParameterExpression) -> oqpy.FloatVar:
+        """Return an oqpy.FloatVar that represents the provided expression.
 
         Args:
-            name (str): The name of the parameter.
+            expression (FreeParameterExpression): The expression to represent.
 
         Raises:
-            ParameterNotFoundError: If there is no parameter with the given name registered
-            with the program.
+            ParameterNotFoundError: If the expression contains any free parameter which has
+            not already been registered with the program.
 
         Returns:
-            FloatVar: The associated variable.
+            FloatVar: The variable representing the expression.
         """
-        if name not in self._free_parameters:
-            raise errors.ParameterNotFoundError(f"Free parameter '{name}' was not found.")
-        return self._free_parameters[name]
+        # Validate that all of the free symbols are registered as free parameters.
+        for name in self._free_symbol_names(expression):
+            if name not in self._free_parameters:
+                raise errors.ParameterNotFoundError(f"Free parameter '{name}' was not found.")
+
+        # If the expression is just a standalone parameter, return the registered variable.
+        if isinstance(expression, FreeParameter):
+            return self._free_parameters[name]
+
+        # Otherwise, create a new variable and declare it here
+        var = aq_types.FloatVar(init_expression=expression)
+        self.get_oqpy_program().declare(var)
+        return var
 
     def get_free_parameters(self) -> list[oqpy.FloatVar]:
         """Return a list of named oqpy.Vars that are used as free parameters in the program."""

--- a/src/braket/experimental/autoqasm/program/program.py
+++ b/src/braket/experimental/autoqasm/program/program.py
@@ -341,14 +341,13 @@ class ProgramConversionContext:
         """
         return sorted([str(s) for s in expr._expression.free_symbols if isinstance(s, Symbol)])
 
-    def register_parameter(self, parameter: str | FreeParameter) -> None:
+    def register_parameter(self, parameter_name: str) -> None:
         """Register an input parameter if it has not already been registered.
         Only floats are currently supported.
 
         Args:
-            parameter (str | FreeParameter): The parameter to register with the program.
+            parameter_name (str): The name of the parameter to register with the program.
         """
-        parameter_name = str(parameter)
         if parameter_name not in self._free_parameters:
             self._free_parameters[parameter_name] = oqpy.FloatVar("input", name=parameter_name)
 

--- a/src/braket/experimental/autoqasm/program/program.py
+++ b/src/braket/experimental/autoqasm/program/program.py
@@ -325,11 +325,11 @@ class ProgramConversionContext:
             if isinstance(arg, FreeParameter):
                 self.register_parameter(arg)
             elif isinstance(arg, FreeParameterExpression):
-                free_symbols = [
+                free_symbol_names = [
                     str(s) for s in arg._expression.free_symbols if isinstance(s, Symbol)
                 ]
-                for free_symbol in sorted(free_symbols):
-                    self.register_parameter(free_symbol)
+                for free_symbol_name in sorted(free_symbol_names):
+                    self.register_parameter(free_symbol_name)
 
     def register_parameter(self, parameter: str | FreeParameter) -> None:
         """Register an input parameter if it has not already been registered.

--- a/src/braket/experimental/autoqasm/program/program.py
+++ b/src/braket/experimental/autoqasm/program/program.py
@@ -329,6 +329,16 @@ class ProgramConversionContext:
 
     @staticmethod
     def _free_symbol_names(expr: FreeParameterExpression) -> Iterable[str]:
+        """Return the names of any free symbols found in the provided expression
+        which are Symbol objects.
+
+        Args:
+            expr (FreeParameterExpression): The expression in which to look for free symbols.
+
+        Returns:
+            Iterable[str]: The list of free symbol names in sorted order (sorted to ensure
+            that the order is deterministic).
+        """
         return sorted([str(s) for s in expr._expression.free_symbols if isinstance(s, Symbol)])
 
     def register_parameter(self, parameter: str | FreeParameter) -> None:
@@ -362,7 +372,7 @@ class ProgramConversionContext:
 
         # If the expression is just a standalone parameter, return the registered variable.
         if isinstance(expression, FreeParameter):
-            return self._free_parameters[name]
+            return self._free_parameters[expression.name]
 
         # Otherwise, create a new variable and declare it here
         var = aq_types.FloatVar(init_expression=expression)

--- a/test/unit_tests/braket/experimental/autoqasm/test_parameters.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_parameters.py
@@ -826,3 +826,33 @@ input float[64] theta;
 qubit[1] __qubits__;
 gpi(alpha*theta) __qubits__[0];"""
     assert parametric().to_ir() == expected
+
+
+def test_bound_parameter_expressions():
+    """Test expressions of free parameters bound to specific values."""
+
+    @aq.main
+    def parametric():
+        rx(0, 2 * FreeParameter("phi"))
+
+    expected = """OPENQASM 3.0;
+float[64] phi = 1.5707963267948966;
+qubit[1] __qubits__;
+rx(2*phi) __qubits__[0];"""
+    assert parametric().make_bound_program({"phi": np.pi / 2}).to_ir() == expected
+
+
+def test_partially_bound_parameter_expressions():
+    """Test expressions of free parameters partially bound to specific values."""
+
+    @aq.main
+    def parametric():
+        expr = FreeParameter("prefactor") * FreeParameter("theta")
+        gpi(0, expr)
+
+    expected = """OPENQASM 3.0;
+float[64] prefactor = 3;
+input float[64] theta;
+qubit[1] __qubits__;
+gpi(prefactor*theta) __qubits__[0];"""
+    assert parametric().make_bound_program({"prefactor": 3}).to_ir() == expected

--- a/test/unit_tests/braket/experimental/autoqasm/test_program.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_program.py
@@ -40,12 +40,14 @@ def test_program_conversion_context() -> None:
     assert len(prog._oqpy_program_stack) == 1
 
 
-def test_get_parameter_invalid_name():
-    """Tests the get_parameter function."""
+def test_get_expression_var_invalid_name():
+    """Tests the get_expression_var function."""
     prog = aq.program.ProgramConversionContext()
     prog.register_parameter(FreeParameter("alpha"))
     with pytest.raises(aq.errors.ParameterNotFoundError):
-        prog.get_parameter("not_a_parameter")
+        prog.get_expression_var(FreeParameter("not_a_parameter"))
+    with pytest.raises(aq.errors.ParameterNotFoundError):
+        prog.get_expression_var(3 * FreeParameter("also_not_a_parameter"))
 
 
 def test_build_program() -> None:

--- a/test/unit_tests/braket/experimental/autoqasm/test_program.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_program.py
@@ -22,6 +22,7 @@ import pytest
 import braket.experimental.autoqasm as aq
 from braket.circuits.serialization import IRType
 from braket.experimental.autoqasm.instructions import cnot, measure, rx
+from braket.parametric.free_parameter import FreeParameter
 
 
 def test_program_conversion_context() -> None:
@@ -42,7 +43,7 @@ def test_program_conversion_context() -> None:
 def test_get_parameter_invalid_name():
     """Tests the get_parameter function."""
     prog = aq.program.ProgramConversionContext()
-    prog.register_parameter("alpha")
+    prog.register_parameter(FreeParameter("alpha"))
     with pytest.raises(aq.errors.ParameterNotFoundError):
         prog.get_parameter("not_a_parameter")
 

--- a/test/unit_tests/braket/experimental/autoqasm/test_program.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_program.py
@@ -20,7 +20,6 @@ import oqpy.base
 import pytest
 
 import braket.experimental.autoqasm as aq
-from braket.circuits import FreeParameter
 from braket.circuits.serialization import IRType
 from braket.experimental.autoqasm.instructions import cnot, measure, rx
 
@@ -43,7 +42,7 @@ def test_program_conversion_context() -> None:
 def test_get_parameter_invalid_name():
     """Tests the get_parameter function."""
     prog = aq.program.ProgramConversionContext()
-    prog.register_parameter(FreeParameter("alpha"))
+    prog.register_parameter("alpha")
     with pytest.raises(aq.errors.ParameterNotFoundError):
         prog.get_parameter("not_a_parameter")
 

--- a/test/unit_tests/braket/experimental/autoqasm/test_program.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_program.py
@@ -43,7 +43,7 @@ def test_program_conversion_context() -> None:
 def test_get_expression_var_invalid_name():
     """Tests the get_expression_var function."""
     prog = aq.program.ProgramConversionContext()
-    prog.register_parameter(FreeParameter("alpha"))
+    prog.register_parameter("alpha")
     with pytest.raises(aq.errors.ParameterNotFoundError):
         prog.get_expression_var(FreeParameter("not_a_parameter"))
     with pytest.raises(aq.errors.ParameterNotFoundError):

--- a/test/unit_tests/braket/experimental/autoqasm/test_program.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_program.py
@@ -20,9 +20,9 @@ import oqpy.base
 import pytest
 
 import braket.experimental.autoqasm as aq
+from braket.circuits import FreeParameter
 from braket.circuits.serialization import IRType
 from braket.experimental.autoqasm.instructions import cnot, measure, rx
-from braket.parametric.free_parameter import FreeParameter
 
 
 def test_program_conversion_context() -> None:


### PR DESCRIPTION
*Issue #, if available:*
[AutoQASM: support for FreeParameterExpressions](https://github.com/orgs/amazon-braket/projects/2/views/1?pane=issue&itemId=43127738)

*Description of changes:*
Support `FreeParameterExpression` objects as inputs to AutoQASM programs and subroutines, in addition to `FreeParameter` objects.

*Testing done:*
Unit tests added. tox passes.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
