### PR TITLE
feat: support free parameters in aq range indices

### DIFF
--- a/src/braket/parametric/free_parameter_expression.py
+++ b/src/braket/parametric/free_parameter_expression.py
@@ -200,21 +200,11 @@ class FreeParameterExpression:
         Returns:
             Expression: The AST node.
         """
+        # TODO: capture expressions into expression ASTs rather than just an Identifier
+        identifier = Identifier(name=str(self))
         if isinstance(self._type, DurationType):
-            return DurationLiteral(_FreeParameterExpressionIdentifier(self), TimeUnit.s)
-        return _FreeParameterExpressionIdentifier(self)
-
-
-class _FreeParameterExpressionIdentifier(Identifier):
-    """Dummy AST node with FreeParameterExpression instance attached"""
-
-    def __init__(self, expression: FreeParameterExpression):
-        super().__init__(name=f"FreeParameterExpression({expression})")
-        self._expression = expression
-
-    @property
-    def expression(self) -> FreeParameterExpression:
-        return self._expression
+            return DurationLiteral(identifier, TimeUnit.s)
+        return identifier
 
 
 def subs_if_free_parameter(parameter: Any, **kwargs) -> Any:

--- a/src/braket/pulse/ast/free_parameters.py
+++ b/src/braket/pulse/ast/free_parameters.py
@@ -18,10 +18,7 @@ from openqasm3.visitor import QASMTransformer
 from oqpy.program import Program
 from oqpy.timing import OQDurationLiteral
 
-from braket.parametric.free_parameter_expression import (
-    FreeParameterExpression,
-    _FreeParameterExpressionIdentifier,
-)
+from braket.parametric.free_parameter_expression import FreeParameterExpression
 
 
 class _FreeParameterTransformer(QASMTransformer):
@@ -32,21 +29,19 @@ class _FreeParameterTransformer(QASMTransformer):
         self.program = program
         super().__init__()
 
-    def visit__FreeParameterExpressionIdentifier(
-        self, identifier: _FreeParameterExpressionIdentifier
-    ) -> Union[_FreeParameterExpressionIdentifier, ast.FloatLiteral]:
-        """Visit a FreeParameterExpressionIdentifier.
+    def visit_Identifier(self, identifier: ast.Identifier) -> Union[ast.Expression, ast.FloatLiteral]:
+        """Visit an Identifier.
         Args:
-            identifier (_FreeParameterExpressionIdentifier): The identifier.
+            identifier (Identifier): The identifier.
 
         Returns:
-            Union[_FreeParameterExpressionIdentifier, FloatLiteral]: The transformed expression.
+            Union[Expression, FloatLiteral]: The transformed expression.
         """
-        new_value = identifier.expression.subs(self.param_values)
+        new_value = FreeParameterExpression(identifier.name).subs(self.param_values)
         if isinstance(new_value, FreeParameterExpression):
-            return _FreeParameterExpressionIdentifier(new_value)
+            return ast.Identifier(str(new_value))
         else:
-            return ast.FloatLiteral(new_value)
+            return ast.FloatLiteral(float(new_value))
 
     def visit_DurationLiteral(self, duration_literal: ast.DurationLiteral) -> ast.DurationLiteral:
         """Visit Duration Literal.
@@ -58,11 +53,9 @@ class _FreeParameterTransformer(QASMTransformer):
             DurationLiteral: The transformed duration literal.
         """
         duration = duration_literal.value
-        if not isinstance(duration, _FreeParameterExpressionIdentifier):
+        if not isinstance(duration, ast.Identifier):
             return duration_literal
-        new_duration = duration.expression.subs(self.param_values)
+        new_duration = FreeParameterExpression(duration.name).subs(self.param_values)
         if isinstance(new_duration, FreeParameterExpression):
-            return ast.DurationLiteral(
-                _FreeParameterExpressionIdentifier(new_duration), duration_literal.unit
-            )
+            return ast.DurationLiteral(ast.Identifier(str(new_duration)), duration_literal.unit)
         return OQDurationLiteral(new_duration).to_ast(self.program)

--- a/src/braket/pulse/ast/qasm_parser.py
+++ b/src/braket/pulse/ast/qasm_parser.py
@@ -18,8 +18,6 @@ from openpulse.printer import Printer
 from openqasm3.ast import DurationLiteral
 from openqasm3.printer import PrinterState
 
-from braket.pulse.ast.free_parameters import _FreeParameterExpressionIdentifier
-
 
 class _PulsePrinter(Printer):
     """Walks the AST and prints it to an OpenQASM3 string."""
@@ -27,15 +25,13 @@ class _PulsePrinter(Printer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    def visit__FreeParameterExpressionIdentifier(
-        self, node: ast.Identifier, context: PrinterState
-    ) -> None:
-        """Visit a FreeParameterExpressionIdentifier.
+    def visit_Identifier(self, node: ast.Identifier, context: PrinterState) -> None:
+        """Visit an Identifier.
         Args:
             node (ast.Identifier): The identifier.
             context (PrinterState): The printer state context.
         """
-        self.stream.write(str(node.expression.expression))
+        self.stream.write(node.name)
 
     def visit_DurationLiteral(self, node: DurationLiteral, context: PrinterState) -> None:
         """Visit Duration Literal.
@@ -46,8 +42,8 @@ class _PulsePrinter(Printer):
             context (PrinterState): The printer state context.
         """
         duration = node.value
-        if isinstance(duration, _FreeParameterExpressionIdentifier):
-            self.stream.write(f"({duration.expression}) * 1{node.unit.name}")
+        if isinstance(duration, ast.Identifier):
+            self.stream.write(f"({duration.name}) * 1{node.unit.name}")
         else:
             super().visit_DurationLiteral(node, context)
 

--- a/src/braket/pulse/pulse_sequence.py
+++ b/src/braket/pulse/pulse_sequence.py
@@ -26,10 +26,7 @@ from braket.parametric.free_parameter import FreeParameter
 from braket.parametric.free_parameter_expression import FreeParameterExpression
 from braket.parametric.parameterizable import Parameterizable
 from braket.pulse.ast.approximation_parser import _ApproximationParser
-from braket.pulse.ast.free_parameters import (
-    _FreeParameterExpressionIdentifier,
-    _FreeParameterTransformer,
-)
+from braket.pulse.ast.free_parameters import _FreeParameterTransformer
 from braket.pulse.ast.qasm_parser import ast_to_qasm
 from braket.pulse.ast.qasm_transformer import _IRQASMTransformer
 from braket.pulse.frame import Frame
@@ -325,7 +322,7 @@ class PulseSequence:
         self,
         parameter: Union[float, FreeParameterExpression],
         _type: ast.ClassicalType = ast.FloatType(),
-    ) -> Union[float, _FreeParameterExpressionIdentifier]:
+    ) -> Union[float, FreeParameterExpression]:
         if isinstance(parameter, FreeParameterExpression):
             for p in parameter.expression.free_symbols:
                 self._free_parameters.add(FreeParameter(p.name))

--- a/test/unit_tests/braket/experimental/autoqasm/test_parameters.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_parameters.py
@@ -971,3 +971,24 @@ if (__bool_1__) {
 bit __bit_2__;
 __bit_2__ = measure __qubits__[0];"""
     assert parametric.to_ir() == expected
+
+
+def test_parameter_expressions_range_index():
+    """Test expressions of free parameters contained in a range index."""
+
+    @aq.main
+    def two_n_hs(n: int):
+        for _ in aq.range(2 * n):
+            h(0)
+        measure(0)
+
+    expected = """OPENQASM 3.0;
+input int[32] n;
+qubit[1] __qubits__;
+for int _ in [0:2*n - 1] {
+    h __qubits__[0];
+}
+bit __bit_0__;
+__bit_0__ = measure __qubits__[0];"""
+    assert two_n_hs.to_ir() == expected
+    _test_parametric_on_local_sim(two_n_hs, {"n": 3})

--- a/test/unit_tests/braket/pulse/test_pulse_sequence.py
+++ b/test/unit_tests/braket/pulse/test_pulse_sequence.py
@@ -194,7 +194,7 @@ def test_pulse_sequence_make_bound_pulse_sequence(predefined_frame_1, predefined
     )
     assert b_bound.to_ir() == b_bound_call.to_ir() == expected_str_b_bound
     assert pulse_sequence.to_ir() == expected_str_unbound
-    assert b_bound.parameters == set([FreeParameter("sigma_g"), FreeParameter("a")])
+    assert b_bound.parameters == {FreeParameter("sigma_g"), FreeParameter("a")}
     both_bound = b_bound.make_bound_pulse_sequence({"a": 1, "sigma_g": 0.7})
     both_bound_call = b_bound_call(1, sigma_g=0.7)  # use arg 1 for a
     expected_str_both_bound = "\n".join(
@@ -206,11 +206,11 @@ def test_pulse_sequence_make_bound_pulse_sequence(predefined_frame_1, predefined
             "    waveform constant_wf = constant(4.0ms, 2.0 + 0.3im);",
             "    waveform arb_wf = {1.0 + 0.4im, 0, 0.3, 0.1 + 0.2im};",
             "    bit[2] psb;",
-            "    set_frequency(predefined_frame_1, 5);",
-            "    shift_frequency(predefined_frame_1, 5);",
-            "    set_phase(predefined_frame_1, 5);",
-            "    shift_phase(predefined_frame_1, 5);",
-            "    set_scale(predefined_frame_1, 5);",
+            "    set_frequency(predefined_frame_1, 5.0);",
+            "    shift_frequency(predefined_frame_1, 5.0);",
+            "    set_phase(predefined_frame_1, 5.0);",
+            "    shift_phase(predefined_frame_1, 5.0);",
+            "    set_scale(predefined_frame_1, 5.0);",
             "    psb[0] = capture_v0(predefined_frame_1);",
             "    delay[5s] predefined_frame_1, predefined_frame_2;",
             "    delay[5s] predefined_frame_1;",


### PR DESCRIPTION
*Issue #, if available:*

#818

*Description of changes:*

Capture FreeParameterExpressions as Identifiers, so that OpenQASM knows how to convert to AST.

Future improvements:
- Consider capturing as an AST that properly mirrors the expression (i.e. `BinOp("+", Id(a), Id(b))` instead of `Id("a + b")`. We use string parsing for free parameters already, so it may not be the worst option as is though.

*Testing done:*

Unit tests passing and new test added. Modified one existing test because a float that was previously getting printed as `5` now gets printed as `5.0`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
