### PR TITLE
fix: treating OpenQASM builtin types as constants

### DIFF
--- a/src/braket/circuits/braket_program_context.py
+++ b/src/braket/circuits/braket_program_context.py
@@ -14,7 +14,7 @@
 from typing import Optional, Union
 
 import numpy as np
-from sympy import Expr
+from sympy import Expr, Number
 
 from braket.circuits import Circuit, Instruction
 from braket.circuits.gates import Unitary
@@ -147,5 +147,8 @@ class BraketProgramContext(AbstractProgramContext):
             otherwise wraps the symbolic expression as a `FreeParameterExpression`.
         """
         if isinstance(value, Expr):
-            return FreeParameterExpression(value)
+            evaluated_value = value.evalf()
+            if isinstance(evaluated_value, Number):
+                return evaluated_value
+            return FreeParameterExpression(evaluated_value)
         return value

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -1718,6 +1718,36 @@ def test_circuit_user_gate(pulse_sequence_2):
                 inputs={},
             ),
         ),
+        (
+            Circuit().rx(0, np.pi),
+            OpenQasmProgram(
+                source="\n".join(
+                    [
+                        "OPENQASM 3.0;",
+                        "bit[1] b;",
+                        "qubit[1] q;",
+                        "rx(π) q[0];",
+                        "b[0] = measure q[0];",
+                    ]
+                ),
+                inputs={},
+            ),
+        ),
+        (
+            Circuit().rx(0, 2 * np.pi),
+            OpenQasmProgram(
+                source="\n".join(
+                    [
+                        "OPENQASM 3.0;",
+                        "bit[1] b;",
+                        "qubit[1] q;",
+                        "rx(τ) q[0];",
+                        "b[0] = measure q[0];",
+                    ]
+                ),
+                inputs={},
+            ),
+        ),
     ],
 )
 def test_from_ir(expected_circuit, ir):


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/amazon-braket/amazon-braket-sdk-python/issues/811

*Description of changes:*

This fixes a part of the problem, but it has the serious drawback that the OpenQASM from -> to conversions will now transform symbols to constants.

eg.

`qasm_str = """OPENQASM 3.0;
qubit[1] q;
bit[1] c;
rx(pi) q[0];
c[0] = measure q[0];
"""

circuit = Circuit.from_ir(qasm_str)

ir = circuit.to_ir(ir_type=IRType.OPENQASM)
print(ir.source)
`
will print
`
OPENQASM 3.0;
bit[1] b;
qubit[1] q;
rx(3.141592653589793) q[0];
b[0] = measure q[0];
`

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
