### PR TITLE
feature: Support OpenQASM annotations in AutoQASM programs

### DIFF
--- a/src/braket/experimental/autoqasm/__init__.py
+++ b/src/braket/experimental/autoqasm/__init__.py
@@ -45,4 +45,4 @@ from .instructions import QubitIdentifierType as Qubit  # noqa: F401
 from .program import Program, build_program, verbatim  # noqa: F401
 from .transpiler import transpiler  # noqa: F401
 from .types import ArrayVar, BitVar, BoolVar, FloatVar, IntVar  # noqa: F401
-from .types import qasm_range as range  # noqa: F401
+from .types import QasmRange as range  # noqa: F401

--- a/src/braket/experimental/autoqasm/__init__.py
+++ b/src/braket/experimental/autoqasm/__init__.py
@@ -45,4 +45,4 @@ from .instructions import QubitIdentifierType as Qubit  # noqa: F401
 from .program import Program, build_program, verbatim  # noqa: F401
 from .transpiler import transpiler  # noqa: F401
 from .types import ArrayVar, BitVar, BoolVar, FloatVar, IntVar  # noqa: F401
-from .types import QasmRange as range  # noqa: F401
+from .types import Range as range  # noqa: F401

--- a/src/braket/experimental/autoqasm/api.py
+++ b/src/braket/experimental/autoqasm/api.py
@@ -95,7 +95,7 @@ def main(
 
 
 def subroutine(
-    func: Optional[Callable] = None, annotations: Optional[Iterable[str | tuple[str, str]]] = None
+    func: Optional[Callable] = None, annotations: Optional[str | Iterable[str]] = None
 ) -> Callable[..., aq_program.Program]:
     """Decorator that converts a function into a callable that will insert a subroutine into
     the quantum program.
@@ -103,9 +103,7 @@ def subroutine(
     Args:
         func (Optional[Callable]): Decorated function. May be `None` in the case where decorator
             is used with parentheses.
-        annotations (Optional[Iterable[str | tuple[str, str]]]): Annotations to be added to
-            the subroutine. The annotations can be either a string or a tuple of the form
-            (annotation_name, annotation_value).
+        annotations (Optional[str | Iterable[str]]): Annotations to be added to the subroutine.
 
     Returns:
         Callable[..., Program]: A callable which returns the converted
@@ -115,7 +113,7 @@ def subroutine(
         func,
         converter_callback=_convert_subroutine,
         converter_args={
-            "annotations": annotations or [],
+            "annotations": aq_types.make_annotations_list(annotations),
         },
     )
 
@@ -316,7 +314,7 @@ def _add_qubit_declaration(program_conversion_context: aq_program.ProgramConvers
 def _convert_subroutine(
     f: Callable,
     options: converter.ConversionOptions,
-    annotations: Iterable[str | tuple[str, str]],
+    annotations: Iterable[str],
     args: list[Any],
     kwargs: dict[str, Any],
 ) -> None:
@@ -329,9 +327,7 @@ def _convert_subroutine(
     Args:
         f (Callable): The function to be converted.
         options (converter.ConversionOptions): Converter options.
-        annotations (Iterable[str | tuple[str, str]]): Annotations to be added to
-            the subroutine. The annotations can be either a string or a tuple of the form
-            (annotation_name, annotation_value).
+        annotations (Iterable[str]): Annotations to be added to the subroutine.
         args (list[Any]): Arguments passed to the program when called.
         kwargs (dict[str, Any]): Keyword arguments passed to the program when called.
     """

--- a/src/braket/experimental/autoqasm/program/pragmas.py
+++ b/src/braket/experimental/autoqasm/program/pragmas.py
@@ -28,9 +28,11 @@ Pragmas specify how a program should be compiled or executed. In AutoQASM, we su
 The verbatim pragma would then apply to the `h` and `cnot`, but not the `x`.
 """
 
+from __future__ import annotations
 
 import contextlib
 from enum import Enum
+from typing import Iterable, Optional
 
 from braket.device_schema import DeviceActionType
 from braket.experimental.autoqasm import errors, program
@@ -44,12 +46,17 @@ class PragmaType(str, Enum):
 
 
 @contextlib.contextmanager
-def verbatim() -> None:
+def verbatim(annotations: Optional[Iterable[str | tuple[str, str]]] = None) -> None:
     """Context management protocol that, when used with a `with` statement, wraps the code block
     in a verbatim block.
 
     A verbatim block specifies that operations contained within the block are to be executed as
     programmed without compilation or modification of any sort.
+
+    Args:
+        annotations (Optional[Iterable[str | tuple[str, str]]]): Annotations for the box.
+            The annotations can be either a string or a tuple of the form
+            (annotation_name, annotation_value).
 
     Raises:
         errors.VerbatimBlockNotAllowed: If a verbatim block is not allowed at this point in
@@ -69,7 +76,9 @@ def verbatim() -> None:
             )
 
     try:
-        with program.get_program_conversion_context().box(pragma=PragmaType.VERBATIM):
+        with program.get_program_conversion_context().box(
+            pragma=PragmaType.VERBATIM, annotations=annotations
+        ):
             program_conversion_context.in_verbatim_block = True
             yield
     finally:

--- a/src/braket/experimental/autoqasm/program/pragmas.py
+++ b/src/braket/experimental/autoqasm/program/pragmas.py
@@ -46,7 +46,7 @@ class PragmaType(str, Enum):
 
 
 @contextlib.contextmanager
-def verbatim(annotations: Optional[Iterable[str | tuple[str, str]]] = None) -> None:
+def verbatim(annotations: Optional[str | Iterable[str]] = None) -> None:
     """Context management protocol that, when used with a `with` statement, wraps the code block
     in a verbatim block.
 
@@ -54,9 +54,7 @@ def verbatim(annotations: Optional[Iterable[str | tuple[str, str]]] = None) -> N
     programmed without compilation or modification of any sort.
 
     Args:
-        annotations (Optional[Iterable[str | tuple[str, str]]]): Annotations for the box.
-            The annotations can be either a string or a tuple of the form
-            (annotation_name, annotation_value).
+        annotations (Optional[str | Iterable[str]]): Annotations for the box.
 
     Raises:
         errors.VerbatimBlockNotAllowed: If a verbatim block is not allowed at this point in

--- a/src/braket/experimental/autoqasm/program/program.py
+++ b/src/braket/experimental/autoqasm/program/program.py
@@ -620,18 +620,22 @@ class ProgramConversionContext:
         return self._control_flow_block(oqpy.Else(oqpy_program))
 
     def for_in(
-        self, iterator: oqpy.Range, iterator_name: Optional[str]
+        self, iterator: aq_types.QasmRange, iterator_name: Optional[str]
     ) -> contextlib._GeneratorContextManager:
         """Sets the program conversion context into a for loop context.
 
         Args:
-            iterator (oqpy.Range): The iterator of the for loop.
+            iterator (QasmRange): The iterator of the for loop.
             iterator_name (Optional[str]): The symbol to use as the name of the iterator.
 
         Yields:
             _GeneratorContextManager: The context manager of the oqpy.ForIn block.
         """
         oqpy_program = self.get_oqpy_program()
+        for annotation in iterator.annotations:
+            if isinstance(annotation, str):
+                annotation = (annotation, None)
+            oqpy_program.annotate(*annotation)
         return self._control_flow_block(oqpy.ForIn(oqpy_program, iterator, iterator_name))
 
     def while_loop(self, condition: Any) -> contextlib._GeneratorContextManager:

--- a/src/braket/experimental/autoqasm/program/program.py
+++ b/src/braket/experimental/autoqasm/program/program.py
@@ -629,12 +629,12 @@ class ProgramConversionContext:
         return self._control_flow_block(oqpy.Else(oqpy_program))
 
     def for_in(
-        self, iterator: aq_types.QasmRange, iterator_name: Optional[str]
+        self, iterator: aq_types.Range, iterator_name: Optional[str]
     ) -> contextlib._GeneratorContextManager:
         """Sets the program conversion context into a for loop context.
 
         Args:
-            iterator (QasmRange): The iterator of the for loop.
+            iterator (Range): The iterator of the for loop.
             iterator_name (Optional[str]): The symbol to use as the name of the iterator.
 
         Yields:

--- a/src/braket/experimental/autoqasm/program/program.py
+++ b/src/braket/experimental/autoqasm/program/program.py
@@ -597,14 +597,10 @@ class ProgramConversionContext:
         finally:
             self.at_function_root_scope = original
 
-    def _add_annotations(
-        self, annotations: Optional[Iterable[str | tuple[str, str]]] = None
-    ) -> None:
+    def _add_annotations(self, annotations: Optional[str | Iterable[str]] = None) -> None:
         oqpy_program = self.get_oqpy_program()
-        for annotation in annotations:
-            if isinstance(annotation, str):
-                annotation = (annotation, None)
-            oqpy_program.annotate(*annotation)
+        for annotation in aq_types.make_annotations_list(annotations):
+            oqpy_program.annotate(annotation)
 
     def if_block(self, condition: Any) -> contextlib._GeneratorContextManager:
         """Sets the program conversion context into an if block context.
@@ -707,21 +703,18 @@ class ProgramConversionContext:
     def box(
         self,
         pragma: Optional[str] = None,
-        annotations: Optional[Iterable[str | tuple[str, str]]] = None,
+        annotations: Optional[str | Iterable[str]] = None,
     ) -> None:
         """Sets the program conversion context into a box context.
 
         Args:
             pragma (Optional[str]): Pragma to include before the box. Defaults to None.
-            annotations (Optional[Iterable[str | tuple[str, str]]]): Annotations for the box.
-                The annotations can be either a string or a tuple of the form
-                (annotation_name, annotation_value).
+            annotations (Optional[str | Iterable[str]]): Annotations for the box.
         """
         oqpy_program = self.get_oqpy_program()
         if pragma:
             oqpy_program.pragma(pragma)
-        if annotations:
-            self._add_annotations(annotations)
+        self._add_annotations(annotations)
         with oqpy.Box(oqpy_program):
             yield
 

--- a/src/braket/experimental/autoqasm/types/__init__.py
+++ b/src/braket/experimental/autoqasm/types/__init__.py
@@ -22,6 +22,6 @@ from .types import (  # noqa: F401
     BoolVar,
     FloatVar,
     IntVar,
+    QasmRange,
     is_qasm_type,
-    qasm_range,
 )

--- a/src/braket/experimental/autoqasm/types/__init__.py
+++ b/src/braket/experimental/autoqasm/types/__init__.py
@@ -16,12 +16,4 @@ for type handling.
 """
 
 from .conversions import map_parameter_type, var_type_from_oqpy, wrap_value  # noqa: F401
-from .types import (  # noqa: F401
-    ArrayVar,
-    BitVar,
-    BoolVar,
-    FloatVar,
-    IntVar,
-    QasmRange,
-    is_qasm_type,
-)
+from .types import ArrayVar, BitVar, BoolVar, FloatVar, IntVar, Range, is_qasm_type  # noqa: F401

--- a/src/braket/experimental/autoqasm/types/__init__.py
+++ b/src/braket/experimental/autoqasm/types/__init__.py
@@ -16,4 +16,13 @@ for type handling.
 """
 
 from .conversions import map_parameter_type, var_type_from_oqpy, wrap_value  # noqa: F401
-from .types import ArrayVar, BitVar, BoolVar, FloatVar, IntVar, Range, is_qasm_type  # noqa: F401
+from .types import (  # noqa: F401
+    ArrayVar,
+    BitVar,
+    BoolVar,
+    FloatVar,
+    IntVar,
+    Range,
+    is_qasm_type,
+    make_annotations_list,
+)

--- a/src/braket/experimental/autoqasm/types/types.py
+++ b/src/braket/experimental/autoqasm/types/types.py
@@ -15,7 +15,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Iterable, Optional
+from collections.abc import Iterable, List
+from typing import Any, Optional
 
 import oqpy
 import oqpy.base
@@ -43,13 +44,17 @@ def is_qasm_type(val: Any) -> bool:
     return isinstance(val, qasm_types)
 
 
+def make_annotations_list(annotations: Optional[str | Iterable[str]]) -> List[str]:
+    return [annotations] if isinstance(annotations, str) else annotations or []
+
+
 class Range(oqpy.Range):
     def __init__(
         self,
         start: int,
         stop: Optional[int] = None,
         step: Optional[int] = 1,
-        annotations: Optional[Iterable[str | tuple[str, str]]] = None,
+        annotations: Optional[str | Iterable[str]] = None,
     ):
         """Creates a range definition.
 
@@ -57,19 +62,17 @@ class Range(oqpy.Range):
             start (int): Start of the range.
             stop (Optional[int]): End of the range. Defaults to None.
             step (Optional[int]): Step of the range. Defaults to 1.
-            annotations (Optional[Iterable[str | tuple[str, str]]]): Annotations for the range.
-                The annotations can be either a string or a tuple of the form
-                (annotation_name, annotation_value).
+            annotations (Optional[str | Iterable[str]]): Annotations for the range.
         """
         if stop is None:
             stop = start
             start = 0
         super(Range, self).__init__(start, stop, step)
-        self.annotations = annotations or []
+        self.annotations = make_annotations_list(annotations)
 
 
 class ArrayVar(oqpy.ArrayVar):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, annotations: Optional[str | Iterable[str]] = None, **kwargs):
         if (
             program.get_program_conversion_context().subroutines_processing
             or not program.get_program_conversion_context().at_function_root_scope
@@ -77,13 +80,17 @@ class ArrayVar(oqpy.ArrayVar):
             raise errors.InvalidArrayDeclaration(
                 "Arrays may only be declared at the root scope of an AutoQASM main function."
             )
-        super(ArrayVar, self).__init__(*args, **kwargs)
+        super(ArrayVar, self).__init__(
+            *args, annotations=make_annotations_list(annotations), **kwargs
+        )
         self.name = program.get_program_conversion_context().next_var_name(oqpy.ArrayVar)
 
 
 class BitVar(oqpy.BitVar):
-    def __init__(self, *args, **kwargs):
-        super(BitVar, self).__init__(*args, **kwargs)
+    def __init__(self, *args, annotations: Optional[str | Iterable[str]] = None, **kwargs):
+        super(BitVar, self).__init__(
+            *args, annotations=make_annotations_list(annotations), **kwargs
+        )
         self.name = program.get_program_conversion_context().next_var_name(oqpy.BitVar)
         if self.size:
             value = self.init_expression or 0
@@ -91,18 +98,24 @@ class BitVar(oqpy.BitVar):
 
 
 class BoolVar(oqpy.BoolVar):
-    def __init__(self, *args, **kwargs):
-        super(BoolVar, self).__init__(*args, **kwargs)
+    def __init__(self, *args, annotations: Optional[str | Iterable[str]] = None, **kwargs):
+        super(BoolVar, self).__init__(
+            *args, annotations=make_annotations_list(annotations), **kwargs
+        )
         self.name = program.get_program_conversion_context().next_var_name(oqpy.BoolVar)
 
 
 class FloatVar(oqpy.FloatVar):
-    def __init__(self, *args, **kwargs):
-        super(FloatVar, self).__init__(*args, **kwargs)
+    def __init__(self, *args, annotations: Optional[str | Iterable[str]] = None, **kwargs):
+        super(FloatVar, self).__init__(
+            *args, annotations=make_annotations_list(annotations), **kwargs
+        )
         self.name = program.get_program_conversion_context().next_var_name(oqpy.FloatVar)
 
 
 class IntVar(oqpy.IntVar):
-    def __init__(self, *args, **kwargs):
-        super(IntVar, self).__init__(*args, **kwargs)
+    def __init__(self, *args, annotations: Optional[str | Iterable[str]] = None, **kwargs):
+        super(IntVar, self).__init__(
+            *args, annotations=make_annotations_list(annotations), **kwargs
+        )
         self.name = program.get_program_conversion_context().next_var_name(oqpy.IntVar)

--- a/src/braket/experimental/autoqasm/types/types.py
+++ b/src/braket/experimental/autoqasm/types/types.py
@@ -13,7 +13,9 @@
 
 """AutoQASM types and type utilities."""
 
-from typing import Any, Optional
+from __future__ import annotations
+
+from typing import Any, Iterable, Optional
 
 import oqpy
 import oqpy.base
@@ -41,21 +43,29 @@ def is_qasm_type(val: Any) -> bool:
     return isinstance(val, qasm_types)
 
 
-def qasm_range(start: int, stop: Optional[int] = None, step: Optional[int] = 1) -> oqpy.Range:
-    """Range definition.
+class QasmRange(oqpy.Range):
+    def __init__(
+        self,
+        start: int,
+        stop: Optional[int] = None,
+        step: Optional[int] = 1,
+        annotations: Optional[Iterable[str | tuple[str, str]]] = None,
+    ):
+        """Creates a range definition.
 
-    Args:
-        start (int): Start of the range
-        stop (Optional[int]): End of the range. Defaults to None.
-        step (Optional[int]): Step of the range. Defaults to 1.
-
-    Returns:
-        oqpy.Range: oqpy range definition.
-    """
-    if stop is None:
-        stop = start
-        start = 0
-    return oqpy.Range(start, stop, step)
+        Args:
+            start (int): Start of the range.
+            stop (Optional[int]): End of the range. Defaults to None.
+            step (Optional[int]): Step of the range. Defaults to 1.
+            annotations (Optional[Iterable[str | tuple[str, str]]]): Annotations for the range.
+                The annotations can be either a string or a tuple of the form
+                (annotation_name, annotation_value).
+        """
+        if stop is None:
+            stop = start
+            start = 0
+        super(QasmRange, self).__init__(start, stop, step)
+        self.annotations = annotations or []
 
 
 class ArrayVar(oqpy.ArrayVar):

--- a/src/braket/experimental/autoqasm/types/types.py
+++ b/src/braket/experimental/autoqasm/types/types.py
@@ -43,7 +43,7 @@ def is_qasm_type(val: Any) -> bool:
     return isinstance(val, qasm_types)
 
 
-class QasmRange(oqpy.Range):
+class Range(oqpy.Range):
     def __init__(
         self,
         start: int,
@@ -64,7 +64,7 @@ class QasmRange(oqpy.Range):
         if stop is None:
             stop = start
             start = 0
-        super(QasmRange, self).__init__(start, stop, step)
+        super(Range, self).__init__(start, stop, step)
         self.annotations = annotations or []
 
 

--- a/src/braket/experimental/autoqasm/types/types.py
+++ b/src/braket/experimental/autoqasm/types/types.py
@@ -15,8 +15,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, List
-from typing import Any, Optional
+from collections.abc import Iterable
+from typing import Any, List, Optional
 
 import oqpy
 import oqpy.base

--- a/test/unit_tests/braket/experimental/autoqasm/test_annotations.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_annotations.py
@@ -18,7 +18,7 @@ from typing import Any
 import pytest
 
 import braket.experimental.autoqasm as aq
-from braket.experimental.autoqasm.instructions import h
+from braket.experimental.autoqasm.instructions import cnot, h
 
 
 @pytest.mark.parametrize(
@@ -84,6 +84,24 @@ qubit[5] __qubits__;
 @bar baz
 for int i in [0:5 - 1] {
     h __qubits__[i];
+}"""
+
+    assert main.to_ir() == expected
+
+
+def test_verbatim_box_annotations():
+    """Test annotations on verbatim boxes."""
+
+    @aq.main
+    def main():
+        with aq.verbatim(annotations=["box_annotation"]):
+            cnot("$0", "$1")
+
+    expected = """OPENQASM 3.0;
+pragma braket verbatim
+@box_annotation
+box {
+    cnot $0, $1;
 }"""
 
     assert main.to_ir() == expected

--- a/test/unit_tests/braket/experimental/autoqasm/test_annotations.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_annotations.py
@@ -18,6 +18,7 @@ from typing import Any
 import pytest
 
 import braket.experimental.autoqasm as aq
+from braket.experimental.autoqasm.instructions import h
 
 
 @pytest.mark.parametrize(
@@ -65,5 +66,24 @@ def test_subroutine_annotations():
 def subroutine_test() {
 }
 subroutine_test();"""
+
+    assert main.to_ir() == expected
+
+
+def test_range_annotations():
+    """Test annotations on ranges."""
+
+    @aq.main(num_qubits=5)
+    def main():
+        for i in aq.range(5, annotations=["foo", ("bar", "baz")]):
+            h(i)
+
+    expected = """OPENQASM 3.0;
+qubit[5] __qubits__;
+@foo
+@bar baz
+for int i in [0:5 - 1] {
+    h __qubits__[i];
+}"""
 
     assert main.to_ir() == expected

--- a/test/unit_tests/braket/experimental/autoqasm/test_annotations.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_annotations.py
@@ -94,12 +94,13 @@ def test_verbatim_box_annotations():
 
     @aq.main
     def main():
-        with aq.verbatim(annotations=["box_annotation"]):
+        with aq.verbatim(annotations=["foo", ("bar", "baz")]):
             cnot("$0", "$1")
 
     expected = """OPENQASM 3.0;
 pragma braket verbatim
-@box_annotation
+@foo
+@bar baz
 box {
     cnot $0, $1;
 }"""

--- a/test/unit_tests/braket/experimental/autoqasm/test_annotations.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_annotations.py
@@ -1,0 +1,69 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+"""Tests for annotations."""
+
+from typing import Any
+
+import pytest
+
+import braket.experimental.autoqasm as aq
+
+
+@pytest.mark.parametrize(
+    "var_type, var_value, qasm_type, qasm_value",
+    [
+        (aq.IntVar, 0, "int[32]", "0"),
+        (aq.FloatVar, 0.0, "float[64]", "0.0"),
+        (aq.BoolVar, False, "bool", "false"),
+    ],
+)
+def test_variable_annotations(
+    var_type: type, var_value: Any, qasm_type: str, qasm_value: str
+) -> None:
+    """Test annotations on variable declarations."""
+
+    @aq.main
+    def main():
+        a = var_type(var_value, annotations=["foo", ("bar", "baz")])  # noqa: F841
+
+    expected = (
+        """OPENQASM 3.0;
+@foo
+@bar baz
+"""
+        + f"{qasm_type} a = {qasm_value};"
+    )
+
+    assert main.to_ir() == expected
+
+
+def test_subroutine_annotations():
+    """Test annotations on subroutine declarations."""
+
+    @aq.subroutine(annotations=["foo", ("bar", "baz")])
+    def subroutine_test():
+        pass
+
+    @aq.main
+    def main():
+        subroutine_test()
+
+    expected = """OPENQASM 3.0;
+@foo
+@bar baz
+def subroutine_test() {
+}
+subroutine_test();"""
+
+    assert main.to_ir() == expected

--- a/test/unit_tests/braket/experimental/autoqasm/test_operators.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_operators.py
@@ -180,7 +180,7 @@ def test_control_flow_for_loop_qasm() -> None:
     """Tests aq.operators.for_stmt with a QASM iterable."""
     with aq.build_program(aq.program.UserConfig(num_qubits=10)) as program_conversion_context:
         aq.operators.for_stmt(
-            iter=aq.types.qasm_range(3),
+            iter=aq.types.QasmRange(3),
             extra_test=None,
             body=for_body,
             get_state=None,

--- a/test/unit_tests/braket/experimental/autoqasm/test_operators.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_operators.py
@@ -180,7 +180,7 @@ def test_control_flow_for_loop_qasm() -> None:
     """Tests aq.operators.for_stmt with a QASM iterable."""
     with aq.build_program(aq.program.UserConfig(num_qubits=10)) as program_conversion_context:
         aq.operators.for_stmt(
-            iter=aq.types.QasmRange(3),
+            iter=aq.types.Range(3),
             extra_test=None,
             body=for_body,
             get_state=None,

--- a/test/unit_tests/braket/experimental/autoqasm/test_types.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_types.py
@@ -13,6 +13,7 @@
 
 """Tests for the types module."""
 
+from typing import Any
 import oqpy
 import pytest
 
@@ -673,3 +674,28 @@ def test_param_array_list_missing_arg():
         @aq.main(num_qubits=4)
         def main():
             param_test()
+
+
+@pytest.mark.parametrize(
+    "var_type, var_value, qasm_type, qasm_value",
+    [
+        (aq.IntVar, 0, "int[32]", "0"),
+        (aq.FloatVar, 0.0, "float[64]", "0.0"),
+        (aq.BoolVar, False, "bool", "false"),
+    ],
+)
+def test_variable_annotations(
+    var_type: type, var_value: Any, qasm_type: str, qasm_value: str
+) -> None:
+    """Test annotations on variable declarations."""
+
+    @aq.main
+    def main():
+        a = var_type(var_value, annotations=["foo", ("bar", "baz")])  # noqa: F841
+
+    expected = """OPENQASM 3.0;
+@foo
+@bar baz
+""" + f"{qasm_type} a = {qasm_value};"
+
+    assert main.to_ir() == expected

--- a/test/unit_tests/braket/experimental/autoqasm/test_types.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_types.py
@@ -17,7 +17,7 @@ import oqpy
 import pytest
 
 import braket.experimental.autoqasm as aq
-from braket.experimental.autoqasm.types import QasmRange
+from braket.experimental.autoqasm.types import Range
 
 
 @pytest.mark.parametrize(
@@ -30,14 +30,14 @@ from braket.experimental.autoqasm.types import QasmRange
 def test_range(
     range_params: tuple[int, int, int], expected_range_params: tuple[int, int, int]
 ) -> None:
-    """Test `QasmRange()` returning correct `QasmRange` object.
+    """Test `Range()` returning correct `Range` object.
 
     Args:
-        range_params (tuple[int, int, int]): Range parameters to instantiate `QasmRange`
+        range_params (tuple[int, int, int]): Range parameters to instantiate `Range`
         expected_range_params (tuple[int, int, int]): Expected range parameters
     """
     start, stop, step = range_params
-    qrange = QasmRange(start, stop, step)
+    qrange = Range(start, stop, step)
     assert isinstance(qrange, oqpy.Range)
     assert (qrange.start, qrange.stop, qrange.step) == expected_range_params
 

--- a/test/unit_tests/braket/experimental/autoqasm/test_types.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_types.py
@@ -13,8 +13,6 @@
 
 """Tests for the types module."""
 
-from typing import Any
-
 import oqpy
 import pytest
 
@@ -675,31 +673,3 @@ def test_param_array_list_missing_arg():
         @aq.main(num_qubits=4)
         def main():
             param_test()
-
-
-@pytest.mark.parametrize(
-    "var_type, var_value, qasm_type, qasm_value",
-    [
-        (aq.IntVar, 0, "int[32]", "0"),
-        (aq.FloatVar, 0.0, "float[64]", "0.0"),
-        (aq.BoolVar, False, "bool", "false"),
-    ],
-)
-def test_variable_annotations(
-    var_type: type, var_value: Any, qasm_type: str, qasm_value: str
-) -> None:
-    """Test annotations on variable declarations."""
-
-    @aq.main
-    def main():
-        a = var_type(var_value, annotations=["foo", ("bar", "baz")])  # noqa: F841
-
-    expected = (
-        """OPENQASM 3.0;
-@foo
-@bar baz
-"""
-        + f"{qasm_type} a = {qasm_value};"
-    )
-
-    assert main.to_ir() == expected

--- a/test/unit_tests/braket/experimental/autoqasm/test_types.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_types.py
@@ -17,7 +17,7 @@ import oqpy
 import pytest
 
 import braket.experimental.autoqasm as aq
-from braket.experimental.autoqasm.types.types import qasm_range
+from braket.experimental.autoqasm.types import QasmRange
 
 
 @pytest.mark.parametrize(
@@ -27,17 +27,17 @@ from braket.experimental.autoqasm.types.types import qasm_range
         ((5, None, 2), (0, 5, 2)),
     ],
 )
-def test_qasm_range(
+def test_range(
     range_params: tuple[int, int, int], expected_range_params: tuple[int, int, int]
 ) -> None:
-    """Test `qasm_range()` returning correct `Range` object.
+    """Test `QasmRange()` returning correct `QasmRange` object.
 
     Args:
-        range_params (tuple[int, int, int]): Range parameters to instantiate `oqpy.Range`
+        range_params (tuple[int, int, int]): Range parameters to instantiate `QasmRange`
         expected_range_params (tuple[int, int, int]): Expected range parameters
     """
     start, stop, step = range_params
-    qrange = qasm_range(start, stop, step)
+    qrange = QasmRange(start, stop, step)
     assert isinstance(qrange, oqpy.Range)
     assert (qrange.start, qrange.stop, qrange.step) == expected_range_params
 

--- a/test/unit_tests/braket/experimental/autoqasm/test_types.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_types.py
@@ -14,6 +14,7 @@
 """Tests for the types module."""
 
 from typing import Any
+
 import oqpy
 import pytest
 
@@ -693,9 +694,12 @@ def test_variable_annotations(
     def main():
         a = var_type(var_value, annotations=["foo", ("bar", "baz")])  # noqa: F841
 
-    expected = """OPENQASM 3.0;
+    expected = (
+        """OPENQASM 3.0;
 @foo
 @bar baz
-""" + f"{qasm_type} a = {qasm_value};"
+"""
+        + f"{qasm_type} a = {qasm_value};"
+    )
 
     assert main.to_ir() == expected


### PR DESCRIPTION
*Issue #, if available:*
Resolves #837 

*Description of changes:*
Support `annotations` argument for subroutines, variables, ranges, and boxes. This will result in an OpenQASM annotation being added to the serialized program.

For example:
```
@aq.subroutine(annotations=["inline"])
def subroutine_test():
    pass

@aq.main
def main():
    subroutine_test()
```
produces:
```
OPENQASM 3.0;
@inline
def subroutine_test() {
}
subroutine_test();
```

*Testing done:*
Tests added to verify new functionality. tox passes.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
