### PR TITLE
AwsSession copies `endpoint_url` if region is the same

### DIFF
--- a/src/braket/aws/aws_session.py
+++ b/src/braket/aws/aws_session.py
@@ -805,9 +805,6 @@ class AwsSession(object):
         config = Config(max_pool_connections=max_connections) if max_connections else None
         session_region = self.boto_session.region_name
         new_region = region or session_region
-        new_braket_client = (
-            self.braket_client if new_region == self.braket_client.meta.region_name else None
-        )
         creds = self.boto_session.get_credentials()
         default_bucket = self._default_bucket if self._custom_default_bucket else None
         profile_name = self.boto_session.profile_name
@@ -827,6 +824,13 @@ class AwsSession(object):
                 region_name=new_region,
                 profile_name=profile_name,
             )
+        new_braket_client = (
+            boto_session.client(
+                "braket", region_name=new_region, endpoint_url=self.braket_client.meta._endpoint_url
+            )
+            if new_region == self.braket_client.meta.region_name
+            else None
+        )
         copied_session = AwsSession(
             boto_session=boto_session,
             braket_client=new_braket_client,

--- a/src/braket/aws/aws_session.py
+++ b/src/braket/aws/aws_session.py
@@ -805,6 +805,9 @@ class AwsSession(object):
         config = Config(max_pool_connections=max_connections) if max_connections else None
         session_region = self.boto_session.region_name
         new_region = region or session_region
+        new_braket_client = (
+            self.braket_client if new_region == self.braket_client.meta.region_name else None
+        )
         creds = self.boto_session.get_credentials()
         default_bucket = self._default_bucket if self._custom_default_bucket else None
         profile_name = self.boto_session.profile_name
@@ -825,7 +828,10 @@ class AwsSession(object):
                 profile_name=profile_name,
             )
         copied_session = AwsSession(
-            boto_session=boto_session, config=config, default_bucket=default_bucket
+            boto_session=boto_session,
+            braket_client=new_braket_client,
+            config=config,
+            default_bucket=default_bucket,
         )
         # Preserve user_agent information
         copied_session._braket_user_agents = self._braket_user_agents

--- a/test/unit_tests/braket/aws/test_aws_session.py
+++ b/test/unit_tests/braket/aws/test_aws_session.py
@@ -1321,6 +1321,7 @@ def test_copy_session(boto_session_init, aws_session):
     boto_session_init.return_value = Mock()
     boto_session_init.return_value.region_name = "us-west-2"
     aws_session._braket_user_agents = "foo/bar"
+    aws_session.braket_client = Mock(meta=Mock(region_name="us-test-2"))
     copied_session = AwsSession.copy_session(aws_session, "us-west-2")
     boto_session_init.assert_called_with(
         region_name="us-west-2",

--- a/test/unit_tests/braket/aws/test_aws_session.py
+++ b/test/unit_tests/braket/aws/test_aws_session.py
@@ -1318,8 +1318,7 @@ def test_get_log_events(aws_session, next_token):
 
 @patch("boto3.Session")
 def test_copy_session(boto_session_init, aws_session):
-    boto_session_init.return_value = Mock()
-    boto_session_init.return_value.region_name = "us-west-2"
+    boto_session_init.return_value = Mock(region_name="us-west-2")
     aws_session._braket_user_agents = "foo/bar"
     aws_session.braket_client = Mock(meta=Mock(region_name="us-test-2"))
     copied_session = AwsSession.copy_session(aws_session, "us-west-2")
@@ -1376,11 +1375,11 @@ def test_copy_session_endpoint_same_region(boto_session_init, aws_session):
 @patch.dict("os.environ", {"BRAKET_ENDPOINT": "new-endpoint"})
 @patch("boto3.Session")
 def test_copy_session_endpoint_different_region(boto_session_init, aws_session):
-    boto_session_init.return_value = Mock(region_name="new-region")
+    boto_session_init.return_value = Mock(region_name="old-region")
     aws_session.braket_client = Mock(
         meta=Mock(region_name="old-region", _endpoint_url="old-endpoint")
     )
-    copied_session = AwsSession.copy_session(aws_session)
+    copied_session = AwsSession.copy_session(aws_session, "new-region")
     copied_session.braket_client.meta._endpoint_url == "new-endpoint"
 
 


### PR DESCRIPTION
*Description of changes:*
If the `region` in `aws_session.copy_session(region)` is the same as the one of `aws_session`, the endpoint url is also copied.

Example:
```
import boto3
from braket.devices import Devices
from braket.aws import AwsSession, AwsDevice

region_name = "us-west-2"
endpoint_url = "some-endpoint"
braket_client = boto3.client("braket", region_name=region_name, endpoint_url=endpoint_url)
aws_session = AwsSession(braket_client=braket_client)

device = AwsDevice(Devices.Amazon.SV1, aws_session=aws_session)
task_batch = device.run_batch([Circuit().x(0)]*2, shots=100)
```
is expected to create tasks in `some-endpoint`. But currently it would create tasks in the default endpoint of users' region. This PR fix this issue and creates task in `some-endpoint`.

*Testing done:*
tox

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
