### PR TITLE
change: Remove throw from local task cancellation

### DIFF
--- a/src/braket/tasks/local_quantum_task.py
+++ b/src/braket/tasks/local_quantum_task.py
@@ -25,7 +25,7 @@ from braket.tasks import (
 class LocalQuantumTask(QuantumTask):
     """A quantum task containing the results of a local simulation.
 
-    Since this class is instantiated with the results, cancel() and run_async() are unsupported.
+    Since this class is instantiated with the results, run_async() is unsupported.
     """
 
     def __init__(
@@ -43,7 +43,8 @@ class LocalQuantumTask(QuantumTask):
 
     def cancel(self) -> None:
         """Cancel the quantum task."""
-        raise NotImplementedError("Cannot cancel completed local task")
+        # A LocalQuantumTask is already completed, so there is nothing to cancel
+        pass
 
     def state(self) -> str:
         return "COMPLETED"

--- a/test/unit_tests/braket/tasks/test_local_quantum_task.py
+++ b/test/unit_tests/braket/tasks/test_local_quantum_task.py
@@ -46,7 +46,6 @@ def test_result():
     assert TASK.result() == RESULT
 
 
-@pytest.mark.xfail(raises=NotImplementedError)
 def test_cancel():
     TASK.cancel()
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Cancellation of AWS tasks is a best effort process. Attempting to cancel an AWS task which has already completed is not an error. This change will make local tasks behave the same way.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
