### PR TITLE
fix: update batch circuit to limit repeat calls

### DIFF
--- a/src/braket/aws/aws_quantum_task_batch.py
+++ b/src/braket/aws/aws_quantum_task_batch.py
@@ -150,27 +150,36 @@ class AwsQuantumTaskBatch(QuantumTaskBatch):
     ]:
         inputs = inputs or {}
 
+        max_inputs_tasks = 1
         single_task = isinstance(
             task_specifications,
             (Circuit, Problem, OpenQasmProgram, BlackbirdProgram, AnalogHamiltonianSimulation),
         )
         single_input = isinstance(inputs, dict)
 
+        max_inputs_tasks = (
+            max(max_inputs_tasks, len(task_specifications)) if not single_task else max_inputs_tasks
+        )
+        max_inputs_tasks = (
+            max(max_inputs_tasks, len(inputs)) if not single_input else max_inputs_tasks
+        )
+
         if not single_task and not single_input:
             if len(task_specifications) != len(inputs):
                 raise ValueError(
                     "Multiple inputs and task specifications must " "be equal in number."
                 )
+
         if single_task:
-            task_specifications = repeat(task_specifications)
+            task_specifications = repeat(task_specifications, times=max_inputs_tasks)
 
         if single_input:
-            inputs = repeat(inputs)
+            inputs = repeat(inputs, times=max_inputs_tasks)
 
         tasks_and_inputs = zip(task_specifications, inputs)
 
         if single_task and single_input:
-            tasks_and_inputs = [next(tasks_and_inputs)]
+            tasks_and_inputs = list(tasks_and_inputs)
 
         tasks_and_inputs = list(tasks_and_inputs)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`repeat()` is unbounded unless `times` is set. This sets it to the max of the list of inputs or task specifications.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
