### PR TITLE
feature: Follow up with AutoQASM return statement fixes

### DIFF
--- a/src/braket/experimental/autoqasm/errors.py
+++ b/src/braket/experimental/autoqasm/errors.py
@@ -114,3 +114,7 @@ class InvalidArrayDeclaration(AutoQasmError):
 
 class UnsupportedSubroutineReturnType(AutoQasmError):
     """Unsupported return type for an AutoQASM subroutine."""
+
+
+class NameConflict(AutoQasmError):
+    """Name conflict between user-named variables."""

--- a/src/braket/experimental/autoqasm/operators/assignments.py
+++ b/src/braket/experimental/autoqasm/operators/assignments.py
@@ -40,8 +40,6 @@ def assign_for_output(target_name: str, value: Any) -> Any:
         Any: Assignment value with updated name attribute if the value is an
         `oqpy` type. Otherwise, it returns unchanged assignment value.
     """
-    if isinstance(value, UndefinedReturnValue):
-        return value
     aq_context = program.get_program_conversion_context()
 
     is_value_name_used = isinstance(value, oqpy.base.Var) and aq_context.is_var_name_used(

--- a/src/braket/experimental/autoqasm/operators/assignments.py
+++ b/src/braket/experimental/autoqasm/operators/assignments.py
@@ -42,15 +42,15 @@ def assign_for_output(target_name: str, value: Any) -> Any:
     """
     if isinstance(value, UndefinedReturnValue):
         return value
-    program_conversion_context = program.get_program_conversion_context()
+    aq_context = program.get_program_conversion_context()
 
-    is_value_name_used = isinstance(
-        value, oqpy.base.Var
-    ) and program_conversion_context.is_var_name_used(value.name)
+    is_value_name_used = isinstance(value, oqpy.base.Var) and aq_context.is_var_name_used(
+        value.name
+    )
 
     value = types.wrap_value(value)
 
-    oqpy_program = program_conversion_context.get_oqpy_program()
+    oqpy_program = aq_context.get_oqpy_program()
 
     if not isinstance(value, (oqpy.base.OQPyExpression, oqpy.base.Var)):
         return value
@@ -59,11 +59,8 @@ def assign_for_output(target_name: str, value: Any) -> Any:
         value, oqpy.base.Var
     ):  # Classical types subclass from both Var and OQPyExpression, and we
         # only need to handle `OQPyExpression`s here
-        try:
-            target = _get_oqpy_program_variable(target_name)
-        except KeyError:
-            # TODO laurecap type based on value
-            target = oqpy.FloatVar(name=target_name)
+        # Create a dummy target with the right name
+        target = oqpy.FloatVar(name=target_name)
         oqpy_program.set(target, value)
         return target
 

--- a/src/braket/experimental/autoqasm/operators/assignments.py
+++ b/src/braket/experimental/autoqasm/operators/assignments.py
@@ -55,11 +55,14 @@ def assign_for_output(target_name: str, value: Any) -> Any:
     if not isinstance(value, (oqpy.base.OQPyExpression, oqpy.base.Var)):
         return value
 
-    if isinstance(value, oqpy.base.OQPyExpression) and not isinstance(value, oqpy.base.Var):  # Var is a subclass of expr?
+    if isinstance(value, oqpy.base.OQPyExpression) and not isinstance(
+        value, oqpy.base.Var
+    ):  # Classical types subclass from both Var and OQPyExpression, and we
+        # only need to handle `OQPyExpression`s here
         try:
             target = _get_oqpy_program_variable(target_name)
         except KeyError:
-            # TODO laurecap type
+            # TODO laurecap type based on value
             target = oqpy.FloatVar(name=target_name)
         oqpy_program.set(target, value)
         return target

--- a/src/braket/experimental/autoqasm/operators/return_statements.py
+++ b/src/braket/experimental/autoqasm/operators/return_statements.py
@@ -16,6 +16,7 @@
 
 from typing import Any
 
+import oqpy
 from braket.circuits.free_parameter_expression import FreeParameterExpression
 from braket.experimental.autoqasm import program
 from braket.experimental.autoqasm import types as aq_types
@@ -35,9 +36,17 @@ def return_output_from_main(name: str, value: Any) -> Any:
     input = aq_context.get_input_parameter(name)
 
     if input is None:
-        if isinstance(value, FreeParameterExpression):
-            aq_context.register_output_parameter(name, aq_types.FloatVar)
+        if isinstance(value, oqpy.base.OQPyExpression) and not isinstance(value, oqpy.base.Var):
+            value_type = float
+            if value.type == oqpy.int_():
+                value_type = int
+            elif value.type == oqpy.bool_:
+                value_type = bool
+            # TODO laurecap bool, bit, angle?
+
+            aq_context.register_output_parameter(name, value_type)
         else:
+            # TODO laurecap what uses this?
             aq_context.register_output_parameter(name, type(value))
     else:
         # Handle name collisions with input variables

--- a/src/braket/experimental/autoqasm/operators/return_statements.py
+++ b/src/braket/experimental/autoqasm/operators/return_statements.py
@@ -17,7 +17,7 @@
 from typing import Any
 
 import oqpy
-from braket.circuits.free_parameter_expression import FreeParameterExpression
+
 from braket.experimental.autoqasm import program
 from braket.experimental.autoqasm import types as aq_types
 
@@ -42,12 +42,15 @@ def return_output_from_main(name: str, value: Any) -> Any:
                 value_type = int
             elif value.type == oqpy.bool_:
                 value_type = bool
-            # TODO laurecap bool, bit, angle?
+            # TODO laurecap test and add bit support here
 
             aq_context.register_output_parameter(name, value_type)
         else:
-            # TODO laurecap what uses this?
-            aq_context.register_output_parameter(name, type(value))
+            # Value is an oqpy classical variable
+            if isinstance(value, oqpy.BitVar):
+                aq_context.register_output_parameter(name, type(value), value)
+            else:
+                aq_context.register_output_parameter(name, type(value))
     else:
         # Handle name collisions with input variables
         name = name + "_"

--- a/src/braket/experimental/autoqasm/operators/return_statements.py
+++ b/src/braket/experimental/autoqasm/operators/return_statements.py
@@ -16,8 +16,6 @@
 
 from typing import Any
 
-import oqpy
-
 from braket.experimental.autoqasm import program
 from braket.experimental.autoqasm import types as aq_types
 
@@ -33,32 +31,5 @@ def return_output_from_main(name: str, value: Any) -> Any:
         Any: Returns the same value that is being returned in the statement.
     """
     aq_context = program.get_program_conversion_context()
-    input = aq_context.get_input_parameter(name)
-
-    if input is None:
-        if isinstance(value, oqpy.base.OQPyExpression) and not isinstance(value, oqpy.base.Var):
-            value_type = float
-            if value.type == oqpy.int_():
-                value_type = int
-            elif value.type == oqpy.bool_:
-                value_type = bool
-            # TODO laurecap test and add bit support here
-
-            aq_context.register_output_parameter(name, value_type)
-        else:
-            # Value is an oqpy classical variable
-            if isinstance(value, oqpy.BitVar):
-                aq_context.register_output_parameter(name, type(value), value)
-            else:
-                aq_context.register_output_parameter(name, type(value))
-    else:
-        # Handle name collisions with input variables
-        name = name + "_"
-        value_type = type(input)
-        aq_context.register_output_parameter(name, value_type)
-        # Add `val_ = val;` at the end of the program to equate these parameters
-        oqpy_program = aq_context.get_oqpy_program()
-        output = aq_context.get_output_parameter(name)
-        oqpy_program.set(output, input)
-
+    aq_context.register_output_parameter(name, value)
     return aq_types.wrap_value(value)

--- a/src/braket/experimental/autoqasm/program/program.py
+++ b/src/braket/experimental/autoqasm/program/program.py
@@ -451,6 +451,7 @@ class ProgramConversionContext:
         for parameter_name, parameter in self._input_parameters.items():
             # The variable names sometimes get overwritten by the initializer
             parameter.name = parameter_name
+            # TODO laurecap is this still necessary
             if parameter.name in root_oqpy_program.undeclared_vars:
                 root_oqpy_program.undeclared_vars[parameter.name]._needs_declaration = True
             else:

--- a/src/braket/experimental/autoqasm/program/program.py
+++ b/src/braket/experimental/autoqasm/program/program.py
@@ -401,7 +401,7 @@ class ProgramConversionContext:
         if value is None:
             return
 
-        if self.get_input_parameter(name):
+        if self.get_input_parameter(name) is not None:
             raise errors.NameConflict(
                 f"Your output parameter has the same name as an input parameter: '{name}'. "
                 "Please give them unique names."

--- a/src/braket/experimental/autoqasm/program/program.py
+++ b/src/braket/experimental/autoqasm/program/program.py
@@ -401,8 +401,7 @@ class ProgramConversionContext:
         if value is None:
             return
 
-        input = self.get_input_parameter(name)
-        if input is not None:
+        if self.get_input_parameter(name):
             raise errors.NameConflict(
                 f"Your output parameter has the same name as an input parameter: '{name}'. "
                 "Please give them unique names."

--- a/src/braket/experimental/autoqasm/program/program.py
+++ b/src/braket/experimental/autoqasm/program/program.py
@@ -408,15 +408,13 @@ class ProgramConversionContext:
                 "Please give them unique names."
             )
 
-        if isinstance(value, oqpy.BitVar):
-            value = copy.copy(value)
-            value.name = name
-            value.init_expression = "output"
-            self._output_parameters[name] = value
+        value_type = aq_types.var_type_from_oqpy(value)
+        type_class = aq_types.map_parameter_type(value_type)
+        if isinstance(value, aq_types.BitVar):
+            new_output = type_class("output", name=name, size=value.size)
         else:
-            value_type = aq_types.var_type_from_oqpy(value)
-            type_class = aq_types.map_parameter_type(value_type)
-            self._output_parameters[name] = type_class("output", name=name)
+            new_output = type_class("output", name=name)
+        self._output_parameters[name] = new_output
 
     def get_expression_var(self, expression: FreeParameterExpression) -> oqpy.FloatVar:
         """Return an oqpy.FloatVar that represents the provided expression.

--- a/src/braket/experimental/autoqasm/types/conversions.py
+++ b/src/braket/experimental/autoqasm/types/conversions.py
@@ -130,21 +130,6 @@ def _(node: Union[float, np.floating]):
     return aq_types.FloatVar(node)
 
 
-@wrap_value.register(FreeParameterExpression)
-def _(node: FreeParameterExpression):
-    aq_context = program.get_program_conversion_context()
-    if hasattr(node, "name"):
-        existing_param = aq_context.get_input_parameter(node.name)
-        if existing_param is not None:
-            return existing_param
-        else:
-            return aq_types.FloatVar(node.name)
-    else:
-        raise NotImplementedError(
-            "Returning expressions is not implemented yet"
-        )  # Requires oqpy 0.3.5
-
-
 @wrap_value.register
 def _(node: oqpy.base.Var):
     return node

--- a/src/braket/experimental/autoqasm/types/conversions.py
+++ b/src/braket/experimental/autoqasm/types/conversions.py
@@ -21,8 +21,7 @@ import numpy as np
 import oqpy
 from openpulse import ast
 
-from braket.circuits.free_parameter_expression import FreeParameterExpression
-from braket.experimental.autoqasm import errors, program
+from braket.experimental.autoqasm import errors
 from braket.experimental.autoqasm import types as aq_types
 
 

--- a/src/braket/experimental/autoqasm/types/types.py
+++ b/src/braket/experimental/autoqasm/types/types.py
@@ -110,7 +110,7 @@ class BitVar(oqpy.BitVar):
             *args, annotations=make_annotations_list(annotations), **kwargs
         )
         self.name = program.get_program_conversion_context().next_var_name(oqpy.BitVar)
-        if self.size:
+        if self.size and self.init_expression != "output":
             value = self.init_expression or 0
             self.init_expression = ast.BitstringLiteral(value, self.size)
 

--- a/test/unit_tests/braket/experimental/autoqasm/test_api.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_api.py
@@ -526,7 +526,7 @@ def test_measurement_qubit_discovery(ground_state_measurements) -> None:
 def test_simple_measurement(ground_state_measurements) -> None:
     """Test that a program with only measurements is generated correctly."""
     expected = """OPENQASM 3.0;
-output bit retval_;
+output bit[3] retval_;
 qubit[6] __qubits__;
 bit[3] __bit_0__ = "000";
 __bit_0__[0] = measure __qubits__[5];

--- a/test/unit_tests/braket/experimental/autoqasm/test_return.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_return.py
@@ -169,15 +169,14 @@ val_ = val;"""
     assert main.to_ir() == expected
 
 
-@pytest.mark.xfail(raises=TypeError)  # Needs OQPy 0.3.5
 def test_return_inputs():
     @aq.main
     def main(val1, val2):
         return val1 + val2
 
     expected = """OPENQASM 3.0;
-input float[64] val1;
-input float[64] val2;
+input float val1;
+input float val2;
 output float[64] retval_;
 retval_ = val1 + val2;"""
 

--- a/test/unit_tests/braket/experimental/autoqasm/test_return.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_return.py
@@ -229,7 +229,7 @@ def ghz(int[32] n) {
     }
 }
 input int[32] n;
-output bit retval_;
+output bit[3] retval_;
 qubit[10] __qubits__;
 ghz(n);
 bit[3] __bit_0__ = "000";

--- a/test/unit_tests/braket/experimental/autoqasm/test_return.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_return.py
@@ -87,7 +87,6 @@ b = __bit_0__;"""
     assert main.to_ir() == expected
 
 
-@pytest.mark.xfail(reason="Not implemented yet")
 def test_basic_arithmetic():
     @aq.main
     def main():
@@ -95,14 +94,14 @@ def test_basic_arithmetic():
         return val
 
     expected = """OPENQASM 3.0;
-input int[32] input_a;
+int[32] __int_0__ = 1;
+int[32] __int_1__ = 2;
 output int[32] val;
-val = 3;"""
+val = __int_0__ + __int_1__;"""
 
     assert main.to_ir() == expected
 
 
-@pytest.mark.xfail(reason="Not implemented yet")
 def test_expressions():
     @aq.main
     def main(input_a: int):
@@ -113,8 +112,7 @@ def test_expressions():
     expected = """OPENQASM 3.0;
 input int[32] input_a;
 output int[32] val;
-val = 1;
-val = val + input_a;"""
+val = 1 + input_a;"""
 
     assert main.to_ir() == expected
 
@@ -130,12 +128,12 @@ def test_expressions_and_control_flow():
 
     expected = """OPENQASM 3.0;
 output float[64] val;
-qubit[5] __qubits__;
+qubit[3] __qubits__;
 val = 0.5;
 for int i in [0:3 - 1] {
-    bit __bit_1__;
-    __bit_1__ = measure __qubits__[i];
-    val = val + __bit_1__;
+    bit __bit_0__;
+    __bit_0__ = measure __qubits__[i];
+    val = val + __bit_0__;
 }"""
 
     assert main.to_ir() == expected


### PR DESCRIPTION
*Issue #, if available:* #875

*Description of changes:*
Follow up on `return` statement support from AutoQASM `main` decorated functions

 - Name conflict error is raised rather than name mangling when input and output names are the same. New `NameConflict` error
 - Clean up output registration between `return_statements` and `program`
 - Simplify wordy parameter names for `register_input/output_parameter`. For example, `parameter_name` -> `name`
 - Fix issue where output `bit`s did not have the right size
    - Fix issue in `aq.types` where `"output"` init expression is overwritten for `BitVar`s

Follow ups after this:
 - returning tuples
 - more complicated expressions within control flow
 - a couple more lines need test coverage

*Testing done:*
new unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
