### PR TITLE
feature: Add support for returning tuples of values from aq.main

### DIFF
--- a/src/braket/experimental/autoqasm/operators/assignments.py
+++ b/src/braket/experimental/autoqasm/operators/assignments.py
@@ -15,7 +15,7 @@
 """Operators for assignment statements."""
 
 import copy
-from typing import Any
+from typing import Any, Iterable
 
 import oqpy
 import oqpy.base
@@ -40,18 +40,12 @@ def assign_for_output(target_name: str, value: Any) -> Any:
         Any: Assignment value with updated name attribute if the value is an
         `oqpy` type. Otherwise, it returns unchanged assignment value.
     """
-    aq_context = program.get_program_conversion_context()
-
-    is_value_name_used = isinstance(value, oqpy.base.Var) and aq_context.is_var_name_used(
-        value.name
-    )
-
+    if value is None:
+        return None
     value = types.wrap_value(value)
 
+    aq_context = program.get_program_conversion_context()
     oqpy_program = aq_context.get_oqpy_program()
-
-    if not isinstance(value, (oqpy.base.OQPyExpression, oqpy.base.Var)):
-        return value
 
     if isinstance(value, oqpy.base.OQPyExpression) and not isinstance(
         value, oqpy.base.Var
@@ -62,6 +56,28 @@ def assign_for_output(target_name: str, value: Any) -> Any:
         oqpy_program.set(target, value)
         return target
 
+    if isinstance(value, Iterable):
+        retvals = []
+        for i, item in enumerate(value):
+            retvals.append(_add_assignment(f"{target_name}{i}", item))
+        return retvals
+    else:
+        return _add_assignment(target_name, value)
+
+
+def _add_assignment(target_name: str, value: Any) -> Any:
+    """Adds a statement to the underlying oqpy program that assigns `target_name`
+    to the `value`.
+
+    Args:
+        target_name (str): The name of assignment target.
+        value (Any): The value of assignment.
+
+    Returns:
+        Any: Value of the assignment.
+    """
+    aq_context = program.get_program_conversion_context()
+    oqpy_program = aq_context.get_oqpy_program()
     target = copy.copy(value)
     target.init_expression = None
     target.name = target_name
@@ -70,6 +86,9 @@ def assign_for_output(target_name: str, value: Any) -> Any:
         # Avoid statements like `a = a;`
         return value
 
+    is_value_name_used = isinstance(value, oqpy.base.Var) and aq_context.is_var_name_used(
+        value.name
+    )
     if is_value_name_used or value.init_expression is None:
         oqpy_program.set(target, value)
     else:

--- a/src/braket/experimental/autoqasm/operators/assignments.py
+++ b/src/braket/experimental/autoqasm/operators/assignments.py
@@ -15,7 +15,8 @@
 """Operators for assignment statements."""
 
 import copy
-from typing import Any, Iterable
+from collections.abc import Iterable
+from typing import Any
 
 import oqpy
 import oqpy.base

--- a/src/braket/experimental/autoqasm/operators/return_statements.py
+++ b/src/braket/experimental/autoqasm/operators/return_statements.py
@@ -14,7 +14,8 @@
 
 """Operations to override return statement behavior."""
 
-from typing import Any, Iterable
+from collections.abc import Iterable
+from typing import Any
 
 from braket.experimental.autoqasm import program
 from braket.experimental.autoqasm import types as aq_types

--- a/src/braket/experimental/autoqasm/operators/return_statements.py
+++ b/src/braket/experimental/autoqasm/operators/return_statements.py
@@ -14,7 +14,7 @@
 
 """Operations to override return statement behavior."""
 
-from typing import Any
+from typing import Any, Iterable
 
 from braket.experimental.autoqasm import program
 from braket.experimental.autoqasm import types as aq_types
@@ -31,5 +31,10 @@ def return_output_from_main(name: str, value: Any) -> Any:
         Any: Returns the same value that is being returned in the statement.
     """
     aq_context = program.get_program_conversion_context()
-    aq_context.register_output_parameter(name, value)
-    return aq_types.wrap_value(value)
+    if isinstance(value, Iterable):
+        for i, item in enumerate(value):
+            aq_context.register_output_parameter(f"{name}{i}", item)
+        return aq_types.wrap_value(tuple(value))
+    else:
+        aq_context.register_output_parameter(name, value)
+        return aq_types.wrap_value(value)

--- a/src/braket/experimental/autoqasm/types/conversions.py
+++ b/src/braket/experimental/autoqasm/types/conversions.py
@@ -112,6 +112,12 @@ def wrap_value(node: Any) -> Any:
     raise NotImplementedError(node)
 
 
+@wrap_value.register(tuple)
+def _(node: tuple):
+    wrapped_nodes = tuple(wrap_value(item) for item in node)
+    return wrapped_nodes
+
+
 @wrap_value.register(bool)
 def _(node: bool):
     return aq_types.BoolVar(node)

--- a/test/unit_tests/braket/experimental/autoqasm/test_return.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_return.py
@@ -139,17 +139,30 @@ for int i in [0:3 - 1] {
     assert main.to_ir() == expected
 
 
-@pytest.mark.xfail(reason="Not implemented yet")
 def test_return_tuple():
     @aq.main
     def main():
         return 1, 2
 
     expected = """OPENQASM 3.0;
-output int[32] retval1_;
-output int[32] retval2_;
-retval1_ = 1;
-retval2_ = 2;"""
+output int[32] retval_0;
+output int[32] retval_1;
+retval_0 = 1;
+retval_1 = 2;"""
+
+    assert main.to_ir() == expected
+
+
+def test_return_list_floats():
+    @aq.main
+    def main():
+        return [11.1, 2.222]
+
+    expected = """OPENQASM 3.0;
+output float[64] retval_0;
+output float[64] retval_1;
+retval_0 = 11.1;
+retval_1 = 2.222;"""
 
     assert main.to_ir() == expected
 

--- a/test/unit_tests/braket/experimental/autoqasm/test_return.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_return.py
@@ -167,6 +167,58 @@ retval_1 = 2.222;"""
     assert main.to_ir() == expected
 
 
+def test_return_multi_meas():
+    @aq.main
+    def main():
+        a = measure(0)
+        b = measure(1)
+        return a, b, measure(2)
+
+    expected = """OPENQASM 3.0;
+bit a;
+bit b;
+output bit retval_0;
+output bit retval_1;
+output bit retval_2;
+qubit[3] __qubits__;
+bit __bit_0__;
+__bit_0__ = measure __qubits__[0];
+a = __bit_0__;
+bit __bit_1__;
+__bit_1__ = measure __qubits__[1];
+b = __bit_1__;
+bit __bit_2__;
+__bit_2__ = measure __qubits__[2];
+retval_0 = a;
+retval_1 = b;
+retval_2 = __bit_2__;"""
+
+    assert main.to_ir() == expected
+
+
+def test_return_multi_types():
+    @aq.main
+    def main():
+        a = measure(0)
+        b = 1.11
+        return a, True, b
+
+    expected = """OPENQASM 3.0;
+bit a;
+output bit retval_0;
+output bool retval_1;
+output float[64] retval_2;
+qubit[1] __qubits__;
+bit __bit_0__;
+__bit_0__ = measure __qubits__[0];
+a = __bit_0__;
+retval_0 = a;
+retval_1 = true;
+retval_2 = 1.11;"""
+
+    assert main.to_ir() == expected
+
+
 def test_name_collisions():
     with pytest.raises(aq.errors.NameConflict):
 


### PR DESCRIPTION
*Issue #, if available:* #875

*Description of changes:*

Support returning tuples, e.g.

```
@aq.main
def main():
    return measure(0), True, 1.23
```

*Testing done:*
New unit tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
