### PR TITLE
fix: use the first available device for bad reservation_arn

### DIFF
--- a/test/integ_tests/test_reservation_arn.py
+++ b/test/integ_tests/test_reservation_arn.py
@@ -56,10 +56,13 @@ def test_create_task_via_reservation_arn_on_simulator(reservation_arn):
         )
 
 
-def test_create_job_via_invalid_reservation_arn_on_qpu(aws_session, reservation_arn):
+def test_create_job_via_invalid_reservation_arn_on_qpu(
+    aws_session, reservation_arn, braket_devices
+):
     with pytest.raises(ClientError, match="Reservation arn is invalid"):
+        online_dev = next(dev for dev in braket_devices if dev.is_available and dev.type == "QPU")
         AwsQuantumJob.create(
-            device=Devices.IonQ.Harmony,
+            device=online_dev.arn,
             source_module="test/integ_tests/job_test_script.py",
             entry_point="job_test_script:start_here",
             wait_until_complete=True,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Grab the first QPU so we do not try to use an offline one.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
