### PR TITLE
feature: Support AutoQASM return statements for pulse

### DIFF
--- a/src/braket/experimental/autoqasm/pulse/pulse.py
+++ b/src/braket/experimental/autoqasm/pulse/pulse.py
@@ -138,11 +138,8 @@ def capture_v0(frame: Frame) -> BitVar:
     pulse_sequence = PulseSequence()
     pulse_sequence._program = aq_context.get_oqpy_program(mode=aq_program.ProgramMode.PULSE)
 
-    if aq_context._calibration_definitions_processing:
+    with oqpy.Cal(pulse_sequence._program):
         return _add_sequence()
-    else:
-        with oqpy.Cal(pulse_sequence._program):
-            return _add_sequence()
 
 
 def delay(

--- a/test/unit_tests/braket/experimental/autoqasm/test_return.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_return.py
@@ -342,14 +342,14 @@ def test_return_pulse_capture():
 
     expected = """OPENQASM 3.0;
 bit __bit_0__;
-bit __bit_2__;
+bit __bit_1__;
 output bit retval_0;
 output bit retval_1;
 cal {
     __bit_0__ = capture_v0(frame1);
-    __bit_2__ = capture_v0(frame1);
+    __bit_1__ = capture_v0(frame1);
 }
 retval_0 = __bit_0__;
-retval_1 = __bit_2__;"""
+retval_1 = __bit_1__;"""
 
     assert program.to_ir() == expected

--- a/test/unit_tests/braket/experimental/autoqasm/test_return.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_return.py
@@ -17,6 +17,8 @@ import pytest
 
 import braket.experimental.autoqasm as aq
 from braket.experimental.autoqasm.instructions import measure
+from braket.experimental.autoqasm.pulse import capture_v0
+from braket.pulse import Frame, Port
 
 
 def test_float_lit():
@@ -326,5 +328,28 @@ __bit_0__[0] = measure __qubits__[0];
 __bit_0__[1] = measure __qubits__[1];
 __bit_0__[2] = measure __qubits__[2];
 return_value = __bit_0__;"""
+
+    assert program.to_ir() == expected
+
+
+def test_return_pulse_capture():
+    port = Port(port_id="device_port_x0", dt=1e-9, properties={})
+    frame = Frame(frame_id="frame1", frequency=2e9, port=port, phase=0, is_predefined=True)
+
+    @aq.main
+    def program():
+        return capture_v0(frame), capture_v0(frame)
+
+    expected = """OPENQASM 3.0;
+bit __bit_0__;
+bit __bit_2__;
+output bit retval_0;
+output bit retval_1;
+cal {
+    __bit_0__ = capture_v0(frame1);
+    __bit_2__ = capture_v0(frame1);
+}
+retval_0 = __bit_0__;
+retval_1 = __bit_2__;"""
 
     assert program.to_ir() == expected

--- a/test/unit_tests/braket/experimental/autoqasm/test_return.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_return.py
@@ -343,13 +343,13 @@ def test_return_pulse_capture():
     expected = """OPENQASM 3.0;
 bit __bit_0__;
 bit __bit_1__;
-output bit retval_0;
-output bit retval_1;
+output bit return_value0;
+output bit return_value1;
 cal {
     __bit_0__ = capture_v0(frame1);
     __bit_1__ = capture_v0(frame1);
 }
-retval_0 = __bit_0__;
-retval_1 = __bit_1__;"""
+return_value0 = __bit_0__;
+return_value1 = __bit_1__;"""
 
     assert program.to_ir() == expected


### PR DESCRIPTION
*Issue #, if available:* #875

*Description of changes:*

Support AutoQASM return statements for `pulse.capture_v0` instruction

Example:
```
@aq.main
def program():
    return capture_v0(frame)
```

*Testing done:*
New unit test

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
