### PR TITLE
Remove xfail test that has new bug report

### DIFF
--- a/test/unit_tests/braket/experimental/autoqasm/test_return.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_return.py
@@ -117,28 +117,6 @@ val = 1 + input_a;"""
     assert main.to_ir() == expected
 
 
-@pytest.mark.xfail(reason="Not implemented yet")
-def test_expressions_and_control_flow():
-    @aq.main(num_qubits=3)
-    def main():
-        val = 0.5
-        for i in aq.range(3):
-            val = val + measure(i)
-        return val
-
-    expected = """OPENQASM 3.0;
-output float[64] val;
-qubit[3] __qubits__;
-val = 0.5;
-for int i in [0:3 - 1] {
-    bit __bit_0__;
-    __bit_0__ = measure __qubits__[i];
-    val = val + __bit_0__;
-}"""
-
-    assert main.to_ir() == expected
-
-
 def test_return_tuple():
     @aq.main
     def main():


### PR DESCRIPTION
*Issue #, if available:*

Bug report: https://github.com/orgs/amazon-braket/projects/2/views/1?filterQuery=bug&pane=issue&itemId=54041940

*Description of changes:*

This test was added for testing `return` statements for AutoQASM, but the bug pre-dates this feature. There are other situations where this bug also appears, as described in the bug report linked above. I propose removing the xfail test in favor of the bug being tracked as usual with the other issues on the AutoQASM board.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
