### PR TITLE
fix: remove job creation test with qpu

### DIFF
--- a/test/integ_tests/test_reservation_arn.py
+++ b/test/integ_tests/test_reservation_arn.py
@@ -18,7 +18,6 @@ from botocore.exceptions import ClientError
 from test_create_quantum_job import decorator_python_version
 
 from braket.aws import AwsDevice
-from braket.aws.aws_quantum_job import AwsQuantumJob
 from braket.circuits import Circuit
 from braket.devices import Devices
 from braket.jobs import get_job_device_arn, hybrid_job
@@ -52,19 +51,6 @@ def test_create_task_via_reservation_arn_on_simulator(reservation_arn):
         device.run(
             circuit,
             shots=10,
-            reservation_arn=reservation_arn,
-        )
-
-
-def test_create_job_via_invalid_reservation_arn_on_qpu(aws_session, reservation_arn):
-    with pytest.raises(ClientError, match="Reservation arn is invalid"):
-        AwsQuantumJob.create(
-            device=Devices.IonQ.Harmony,
-            source_module="test/integ_tests/job_test_script.py",
-            entry_point="job_test_script:start_here",
-            wait_until_complete=True,
-            aws_session=aws_session,
-            hyperparameters={"test_case": "completed"},
             reservation_arn=reservation_arn,
         )
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Removing this test and this should be part of backend testing and we shouldn't be creating jobs with QPUs.

*Testing done:*
tox

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
