### PR TITLE
fix: allow for braket endpoint to be set within the jobs

### DIFF
--- a/test/integ_tests/conftest.py
+++ b/test/integ_tests/conftest.py
@@ -36,6 +36,8 @@ def pytest_configure_node(node):
     """xdist hook"""
     node.workerinput["JOB_COMPLETED_NAME"] = job_complete_name
     node.workerinput["JOB_FAILED_NAME"] = job_fail_name
+    if os.getenv("BRAKET_ENDPOINT"):
+        node.workerinput["BRAKET_ENDPOINT"] = os.getenv("BRAKET_ENDPOINT")
 
 
 def pytest_xdist_node_collection_finished(ids):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Allow users to set the env variable for `BRAKET_ENDPOINT` and execute the tests using this endpoint.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
