### PR TITLE
feat: Change AutoQASM allow_implicit_build default to False

### DIFF
--- a/examples/autoqasm/1_Getting_started_with_AutoQASM.ipynb
+++ b/examples/autoqasm/1_Getting_started_with_AutoQASM.ipynb
@@ -80,7 +80,7 @@
     }
    ],
    "source": [
-    "print(bell_state.to_ir())"
+    "print(bell_state.build().to_ir())"
    ]
   },
   {

--- a/examples/autoqasm/2_Expressing_classical_control_flow.ipynb
+++ b/examples/autoqasm/2_Expressing_classical_control_flow.ipynb
@@ -87,7 +87,7 @@
     "    bell(2, 3)\n",
     "\n",
     "\n",
-    "print(two_bell.to_ir())"
+    "print(two_bell.build().to_ir())"
    ]
   },
   {
@@ -232,7 +232,7 @@
     "        bell(i, i + 1)\n",
     "\n",
     "\n",
-    "print(multiple_bell.to_ir())"
+    "print(multiple_bell.build().to_ir())"
    ]
   },
   {

--- a/examples/autoqasm/4_Native_programming.ipynb
+++ b/examples/autoqasm/4_Native_programming.ipynb
@@ -68,7 +68,7 @@
     "    return measure([0, 1])\n",
     "\n",
     "\n",
-    "print(bell_state.to_ir())"
+    "print(bell_state.build().to_ir())"
    ]
   },
   {
@@ -114,7 +114,7 @@
     "    return measure([\"$0\", \"$1\"])\n",
     "\n",
     "\n",
-    "print(bell_state.to_ir())"
+    "print(bell_state.build().to_ir())"
    ]
   },
   {
@@ -126,9 +126,9 @@
     "\n",
     "## Device-specific validation\n",
     "\n",
-    "Bypassing the mapping and compilation is only the first step of native programming. Because native programming is intended for targeting a program to a specific device, we need to specify the target device in the AutoQASM program. We can accomplish this by adding a `device` argument to the `@aq.main` decorator, passing the ARN of the Amazon Braket device (or, optionally, a `braket.devices.Device` object) that we want to target.\n",
+    "Bypassing the mapping and compilation is only the first step of native programming. Because native programming is intended for targeting a program to a specific device, we need to specify the target device in the AutoQASM program. We can accomplish this by adding a `device` argument to the `build()` call, passing the ARN of the Amazon Braket device (or, optionally, a `braket.devices.Device` object) that we want to target.\n",
     "\n",
-    "Here we modify the program to target the `Devices.IonQ.Aria1` device. When building this program, AutoQASM will validate that (among other things) the contents of any `verbatim` blocks respect the native gate set and connectivity of the target device. "
+    "Here we target the `Devices.IonQ.Aria1` device. When building this program, AutoQASM will validate that (among other things) the contents of any `verbatim` blocks respect the native gate set and connectivity of the target device. "
    ]
   },
   {
@@ -146,13 +146,15 @@
     }
    ],
    "source": [
+    "@aq.main\n",
+    "def bell_state():\n",
+    "    with aq.verbatim():\n",
+    "        h(\"$0\")\n",
+    "        cnot(\"$0\", \"$1\")\n",
+    "    return measure([\"$0\", \"$1\"])\n",
+    "\n",
     "try:\n",
-    "    @aq.main(device=Devices.IonQ.Aria1)\n",
-    "    def bell_state():\n",
-    "        with aq.verbatim():\n",
-    "            h(\"$0\")\n",
-    "            cnot(\"$0\", \"$1\")\n",
-    "        return measure([\"$0\", \"$1\"])\n",
+    "    bell_state.build(device=Devices.IonQ.Aria1)\n",
     "except Exception as e:\n",
     "    print(\"ERROR:\", e)"
    ]
@@ -436,7 +438,7 @@
     "from ionq_gates import h, cnot\n",
     "\n",
     "\n",
-    "@aq.main(device=Devices.IonQ.Aria1)\n",
+    "@aq.main\n",
     "def bell_state():\n",
     "    with aq.verbatim():\n",
     "        h(\"$0\")\n",
@@ -444,7 +446,7 @@
     "    return measure([\"$0\", \"$1\"])\n",
     "\n",
     "\n",
-    "print(bell_state.to_ir())"
+    "print(bell_state.build(device=Devices.IonQ.Aria1).to_ir())"
    ]
   },
   {
@@ -482,7 +484,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.9.18"
   }
  },
  "nbformat": 4,

--- a/examples/autoqasm/5_Pulse_programming_and_dynamical_decoupling.ipynb
+++ b/examples/autoqasm/5_Pulse_programming_and_dynamical_decoupling.ipynb
@@ -107,7 +107,7 @@
     }
    ],
    "source": [
-    "print(idle.to_ir())"
+    "print(idle.build().to_ir())"
    ]
   },
   {
@@ -254,7 +254,7 @@
     }
    ],
    "source": [
-    "print(idle_with_dd.to_ir())"
+    "print(idle_with_dd.build().to_ir())"
    ]
   },
   {

--- a/examples/autoqasm/6_Customize_gate_calibrations.ipynb
+++ b/examples/autoqasm/6_Customize_gate_calibrations.ipynb
@@ -206,7 +206,7 @@
    "id": "9300f0f8",
    "metadata": {},
    "source": [
-    "Next, we will demonstrate how to attach `my_rx_cal` to the main quantum program `main_program`. The program is defined in the code block below."
+    "Next, we will demonstrate how to attach `my_rx_cal` to the main quantum program `my_program`. The program is defined in the code block below."
    ]
   },
   {
@@ -234,7 +234,7 @@
     "    rz(\"$1\", 0.123)\n",
     "    measure(\"$0\")\n",
     "\n",
-    "print(my_program.to_ir())"
+    "print(my_program.build().to_ir())"
    ]
   },
   {
@@ -242,7 +242,7 @@
    "id": "c7579516",
    "metadata": {},
    "source": [
-    "To attach gate calibrations to the program, call the `with_calibrations` method on `main_program` to create a new program with `my_rx_cal` attached, leaving the original intact. This allows you to experiment with different gate calibrations on the same program without the need to redefine the main program every time. \n",
+    "To attach gate calibrations to the program, call the `with_calibrations` method on the built program to create a new program with `my_rx_cal` attached, leaving the original intact. This allows you to experiment with different gate calibrations on the same program without the need to redefine the main program every time. \n",
     "\n",
     "In the printed OpenQASM script of the program, the gate definition for the `rx` gate becomes a `defcal` block."
    ]
@@ -276,7 +276,7 @@
     }
    ],
    "source": [
-    "custom_program = my_program.with_calibrations(my_rx_cal)\n",
+    "custom_program = my_program.build().with_calibrations(my_rx_cal)\n",
     "print(custom_program.to_ir())"
    ]
   },
@@ -346,7 +346,7 @@
     }
    ],
    "source": [
-    "custom_program = my_program.with_calibrations([my_rx_cal, my_rz_cal])\n",
+    "custom_program = my_program.build().with_calibrations([my_rx_cal, my_rz_cal])\n",
     "print(custom_program.to_ir())"
    ]
   },

--- a/src/braket/aws/aws_quantum_task.py
+++ b/src/braket/aws/aws_quantum_task.py
@@ -644,7 +644,9 @@ def _(
     *args,
     **kwargs,
 ) -> AwsQuantumTask:
-    openqasm_program = OpenQASMProgram(source=serializable_program.to_ir(ir_type=IRType.OPENQASM))
+    openqasm_program = OpenQASMProgram(
+        source=serializable_program.to_ir(ir_type=IRType.OPENQASM, allow_implicit_build=True)
+    )
     return _create_internal(
         openqasm_program,
         aws_session,

--- a/src/braket/circuits/serialization.py
+++ b/src/braket/circuits/serialization.py
@@ -38,7 +38,7 @@ class SerializableProgram(ABC):
     def to_ir(
         self,
         ir_type: IRType = IRType.OPENQASM,
-        allow_implicit_build: bool = True,
+        allow_implicit_build: bool = False,
     ) -> str:
         """Serializes the program into an intermediate representation.
 
@@ -46,7 +46,7 @@ class SerializableProgram(ABC):
             ir_type (IRType): The IRType to use for converting the program to its
                 IR representation. Defaults to IRType.OPENQASM.
             allow_implicit_build (bool): Whether to allow the program to be implicitly
-                built as a side effect of calling this function. Defaults to True.
+                built as a side effect of calling this function. Defaults to False.
 
         Raises:
             ValueError: Raised if the supplied `ir_type` is not supported.

--- a/src/braket/experimental/autoqasm/README.md
+++ b/src/braket/experimental/autoqasm/README.md
@@ -167,9 +167,9 @@ represent a quantum program equivalently in either format, but using AutoQASM
 allows one to also make use of Python, including the Amazon Braket SDK.
 
 AutoQASM can be seen as implementing a builder pattern for OpenQASM. It
-allows you serialize your program to OpenQASM with `Program.to_ir()`. The
-interface is not strongly tied to OpenQASM, so we could serialize to other
-formats in the future.
+allows you serialize your program to OpenQASM by calling `to_ir()` on the
+built program. The interface is not strongly tied to OpenQASM, so we could
+serialize to other formats in the future.
 
 ### 3. What is the relationship between AutoQASM and the Amazon Braket SDK?
 

--- a/src/braket/experimental/autoqasm/__init__.py
+++ b/src/braket/experimental/autoqasm/__init__.py
@@ -27,7 +27,7 @@ The basic usage of AutoQASM is as follows:
         return result
 
     program = my_program()
-    print(program.to_ir())
+    print(program.build().to_ir())
 
 The Python code above outputs the following OpenQASM program:
 

--- a/src/braket/experimental/autoqasm/doc/decorators.md
+++ b/src/braket/experimental/autoqasm/doc/decorators.md
@@ -51,7 +51,7 @@ def two_bell() -> None:
     bell(2, 3)
 ```
 
-Let's take a look at the serialized output from `two_bell.to_ir()`, which shows that the modularity of the subroutine is preserved.
+Let's take a look at the serialized output from `two_bell.build().to_ir()`, which shows that the modularity of the subroutine is preserved.
 
 ```
 OPENQASM 3.0;

--- a/src/braket/experimental/autoqasm/program/program.py
+++ b/src/braket/experimental/autoqasm/program/program.py
@@ -114,7 +114,7 @@ class MainProgram(SerializableProgram):
     def to_ir(
         self,
         ir_type: IRType = IRType.OPENQASM,
-        allow_implicit_build: bool = True,
+        allow_implicit_build: bool = False,
         serialization_properties: SerializationProperties = OpenQASMSerializationProperties(),
     ) -> str:
         """Serializes the program into an intermediate representation.
@@ -123,7 +123,7 @@ class MainProgram(SerializableProgram):
             ir_type (IRType): The IRType to use for converting the program to its
                 IR representation. Defaults to IRType.OPENQASM.
             allow_implicit_build (bool): Whether to allow the program to be implicitly
-                built as a side effect of calling this function. Defaults to True.
+                built as a side effect of calling this function. Defaults to False.
             serialization_properties (SerializationProperties): IR serialization configuration.
                 Default to OpenQASMSerializationProperties().
 

--- a/test/unit_tests/braket/experimental/autoqasm/test_annotations.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_annotations.py
@@ -53,7 +53,7 @@ def test_variable_annotations(
 """
         + f"{qasm_type} b = {qasm_value};"
     )
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 @pytest.mark.parametrize(
@@ -87,7 +87,7 @@ def test_subroutine_annotations(
 subroutine_test();"""
     )
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_range_annotations():
@@ -112,7 +112,7 @@ for int i in [0:5 - 1] {
     h __qubits__[i];
 }"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_verbatim_box_annotations():
@@ -138,4 +138,4 @@ box {
     cnot $0, $1;
 }"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected

--- a/test/unit_tests/braket/experimental/autoqasm/test_api.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_api.py
@@ -36,7 +36,7 @@ def _test_on_local_sim(program: aq.Program, inputs=None) -> None:
 def test_empty_function(empty_program) -> None:
     """Test that a function with no instructions generates an empty program."""
     expected = """OPENQASM 3.0;"""
-    assert empty_program.to_ir() == expected
+    assert empty_program.build().to_ir() == expected
 
 
 def test_sim_empty(empty_program) -> None:
@@ -54,7 +54,7 @@ def test_multiple_calls(empty_subroutine, bell_state_subroutine) -> None:
     """
 
     def count_function_calls(program: aq.Program, func_name: str) -> int:
-        return program.to_ir().count(f"{func_name}();")
+        return program.build().to_ir().count(f"{func_name}();")
 
     def empty_program_wrapper():
         empty_subroutine()
@@ -100,7 +100,7 @@ empty_function();
 bell_state();
 physical_bell();"""
 
-    assert call_subroutines.to_ir() == expected
+    assert call_subroutines.build().to_ir() == expected
 
     _test_on_local_sim(call_subroutines)
 
@@ -143,7 +143,7 @@ def recursive_h(int[32] q) {
 }
 qubit[6] __qubits__;
 recursive_h(5);"""
-    assert recursive_h_wrapper.to_ir() == expected
+    assert recursive_h_wrapper.build().to_ir() == expected
 
 
 def test_sim_recursive_h_wrapper(recursive_h_wrapper):
@@ -172,7 +172,7 @@ def recursive_h(int[32] q) {
 qubit[6] __qubits__;
 recursive_h(4);"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 @aq.subroutine
@@ -200,7 +200,7 @@ def bell_state_arbitrary_qubits(qubit q0, qubit q1) {
 qubit[4] __qubits__;
 bell_state_arbitrary_qubits(__qubits__[0], __qubits__[1]);
 bell_state_arbitrary_qubits(__qubits__[2], __qubits__[3]);"""
-    assert double_bell_state.to_ir() == expected
+    assert double_bell_state.build().to_ir() == expected
 
 
 def test_sim_double_bell(double_bell_state) -> None:
@@ -229,7 +229,7 @@ bit[2] __bit_0__ = "00";
 __bit_0__[0] = measure __qubits__[0];
 __bit_0__[1] = measure __qubits__[1];
 c = __bit_0__;"""
-    assert bell_measurement_undeclared.to_ir() == expected
+    assert bell_measurement_undeclared.build().to_ir() == expected
 
 
 def test_sim_bell_measurement_undeclared(bell_measurement_undeclared) -> None:
@@ -259,7 +259,7 @@ bit[2] __bit_1__ = "00";
 __bit_1__[0] = measure __qubits__[0];
 __bit_1__[1] = measure __qubits__[1];
 c = __bit_1__;"""
-    assert bell_measurement_declared.to_ir() == expected
+    assert bell_measurement_declared.build().to_ir() == expected
 
 
 def test_sim_bell_measurement_declared(bell_measurement_declared) -> None:
@@ -287,7 +287,7 @@ cnot __qubits__[0], __qubits__[1];
 bit __bit_0__;
 __bit_0__ = measure __qubits__[1];
 c = __bit_0__;"""
-    assert bell_partial_measurement.to_ir() == expected
+    assert bell_partial_measurement.build().to_ir() == expected
 
 
 def test_bell_measurement_invalid_declared_type() -> None:
@@ -357,7 +357,7 @@ bit[2] __bit_2__ = "00";
 __bit_2__[0] = measure $0;
 __bit_2__[1] = measure $1;
 c = __bit_2__;"""
-    assert measure_physical_qubits.to_ir() == expected
+    assert measure_physical_qubits.build().to_ir() == expected
 
 
 @pytest.fixture
@@ -380,7 +380,7 @@ h __qubits__[0];
 for int i in [0:4 - 1] {
     cnot __qubits__[i], __qubits__[i + 1];
 }"""
-    assert ghz_qasm_for_loop.to_ir() == expected
+    assert ghz_qasm_for_loop.build().to_ir() == expected
 
 
 def test_sim_ghz_qasm_for_loop(ghz_qasm_for_loop) -> None:
@@ -408,7 +408,7 @@ cnot __qubits__[0], __qubits__[1];
 cnot __qubits__[1], __qubits__[2];
 cnot __qubits__[2], __qubits__[3];
 cnot __qubits__[3], __qubits__[4];"""
-    assert ghz_py_for_loop.to_ir() == expected
+    assert ghz_py_for_loop.build().to_ir() == expected
 
 
 def test_sim_ghz_py_for_loop(ghz_py_for_loop) -> None:
@@ -457,7 +457,7 @@ qubit[2] __qubits__;
 bool __bool_0__;
 """
     expected += f"__bool_0__ = qasm_simple_condition({'true' if do_cnot else 'false'});"
-    assert build_qasm_simple_condition_wrapper(do_cnot).to_ir() == expected
+    assert build_qasm_simple_condition_wrapper(do_cnot).build().to_ir() == expected
 
 
 @pytest.mark.parametrize("do_cnot", [True, False])
@@ -502,7 +502,7 @@ if (__int_1__) {
 bit __bit_2__;
 __bit_2__ = measure __qubits__[1];
 return_value = __bit_2__;"""
-    assert qasm_inline_var_condition.to_ir() == expected
+    assert qasm_inline_var_condition.build().to_ir() == expected
 
 
 def test_sim_qasm_inline_var_condition(qasm_inline_var_condition) -> None:
@@ -524,7 +524,7 @@ def test_measurement_qubit_discovery(ground_state_measurements) -> None:
     """Test that qubits measured by integer are automatically discovered for the purpose
     of qubit declaration.
     """
-    assert "qubit[6] __qubits__;" in ground_state_measurements.to_ir()
+    assert "qubit[6] __qubits__;" in ground_state_measurements.build().to_ir()
 
 
 def test_simple_measurement(ground_state_measurements) -> None:
@@ -537,7 +537,7 @@ __bit_0__[0] = measure __qubits__[5];
 __bit_0__[1] = measure __qubits__[2];
 __bit_0__[2] = measure __qubits__[1];
 return_value = __bit_0__;"""
-    assert ground_state_measurements.to_ir() == expected
+    assert ground_state_measurements.build().to_ir() == expected
 
 
 def test_sim_simple_measurement() -> None:
@@ -575,7 +575,7 @@ def ground_state_measurements_subroutine() -> bit[3] {
 qubit[6] __qubits__;
 bit[3] __bit_1__ = "000";
 __bit_1__ = ground_state_measurements_subroutine();"""
-    assert ground_state_measurements_wrapper.to_ir() == expected
+    assert ground_state_measurements_wrapper.build().to_ir() == expected
 
 
 @pytest.fixture
@@ -608,7 +608,7 @@ if (__bit_0__) {
 bit __bit_1__;
 __bit_1__ = measure __qubits__[1];
 return_value = __bit_1__;"""
-    assert qasm_measurement_condition.to_ir() == expected
+    assert qasm_measurement_condition.build().to_ir() == expected
 
 
 def test_sim_measurement_condition(qasm_measurement_condition) -> None:
@@ -617,13 +617,13 @@ def test_sim_measurement_condition(qasm_measurement_condition) -> None:
 
 def test_virtual_int_qubit_decl(bell_state_program) -> None:
     """Tests for ex. h(0) -> qubit[1] __qubits__"""
-    qasm = bell_state_program.to_ir()
+    qasm = bell_state_program.build().to_ir()
     assert "\nqubit[2] __qubits__;" in qasm
 
 
 def test_py_int_qubit_decl(ghz_py_for_loop) -> None:
     """Tests for ex. i = 1; h(i) -> qubit[1] __qubits__"""
-    qasm = ghz_py_for_loop.to_ir()
+    qasm = ghz_py_for_loop.build().to_ir()
     assert "\nqubit[5] __qubits__;" in qasm
 
 
@@ -634,7 +634,7 @@ def test_physical_qubit_decl(physical_bell_subroutine) -> None:
     def main():
         physical_bell_subroutine()
 
-    assert "__qubits__" not in main.to_ir()
+    assert "__qubits__" not in main.build().to_ir()
 
 
 def test_invalid_physical_qubit_fails() -> None:
@@ -715,7 +715,7 @@ def test_bit_array_name() -> None:
     bit __bit_0__;
     __bit_0__ = measure __qubits__[0];
     return __bit_0__;"""
-    assert expected in my_program_wrapper.to_ir()
+    assert expected in my_program_wrapper.build().to_ir()
 
 
 @pytest.fixture
@@ -752,7 +752,7 @@ __bit_2__ = measure __qubits__[0];
 if (__bit_2__) {
     x __qubits__[0];
 }"""
-    assert reset.to_ir() == expected
+    assert reset.build().to_ir() == expected
 
 
 def test_program_simple_expr() -> None:
@@ -806,7 +806,7 @@ for int i in [0:5 - 1] {
         for i in aq.range(5):
             h(i)
 
-    assert prog.to_ir() == expected
+    assert prog.build().to_ir() == expected
 
 
 @aq.subroutine
@@ -837,7 +837,7 @@ for int i in [0:3 - 1] {
     bell(__qubits__[0], __qubits__[1]);
 }"""
 
-    assert bell_in_for_loop.to_ir() == expected
+    assert bell_in_for_loop.build().to_ir() == expected
 
 
 @pytest.fixture
@@ -873,7 +873,7 @@ int[32] b = 10;
 b = 15;
 float[64] c = 1.2;
 c = 3.4;"""
-    assert classical_variables_types.to_ir() == expected
+    assert classical_variables_types.build().to_ir() == expected
 
 
 def test_sim_classical_variables_types(classical_variables_types):
@@ -894,7 +894,7 @@ int[32] a = 1;
 a = 2;
 b = a;
 a = b;"""
-    assert prog.to_ir() == expected
+    assert prog.build().to_ir() == expected
 
 
 def test_assignment_measurement_results():
@@ -911,7 +911,7 @@ bit __bit_0__;
 __bit_0__ = measure __qubits__[0];
 a = __bit_0__;
 b = a;"""
-    assert prog.to_ir() == expected
+    assert prog.build().to_ir() == expected
 
 
 def test_nested_function():
@@ -936,7 +936,7 @@ cnot __qubits__[0], __qubits__[2];
 cnot __qubits__[0], __qubits__[3];
 cnot __qubits__[0], __qubits__[4];"""
 
-    assert make_ghz.to_ir() == expected
+    assert make_ghz.build().to_ir() == expected
 
 
 def test_double_decorated_function():
@@ -946,7 +946,7 @@ def test_double_decorated_function():
         pass
 
     expected = """OPENQASM 3.0;"""
-    assert empty_program.to_ir() == expected
+    assert empty_program.build().to_ir() == expected
 
 
 def test_to_ir_implicit_build(empty_program) -> None:
@@ -979,7 +979,7 @@ qubit[3] __qubits__;
 bit __bit_1__;
 __bit_1__ = tester(3);"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_subroutine_declared_after_main():
@@ -1003,7 +1003,7 @@ def my_subroutine() {
 qubit[2] __qubits__;
 my_subroutine();"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
     @aq.subroutine
     def my_subroutine() -> None:  # noqa: F811
@@ -1018,7 +1018,7 @@ def my_subroutine() {
 qubit[4] __qubits__;
 my_subroutine();"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_subroutine_args():
@@ -1086,7 +1086,7 @@ def nothing() {
 }
 nothing();"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_input_types():
@@ -1117,9 +1117,9 @@ if (__bool_0__) {
     rx(u + z) __qubits__[0];
 }"""
     assert (
-        multiple_input_types.to_ir()
-        == multiple_input_types_parens.to_ir()
-        == multiple_input_types_params.to_ir()
+        multiple_input_types.build().to_ir()
+        == multiple_input_types_parens.build().to_ir()
+        == multiple_input_types_params.build().to_ir()
         == expected_ir
     )
 
@@ -1134,7 +1134,7 @@ input int[32] q;
 input int[32] r;
 qubit[8] __qubits__;
 h __qubits__[2 * q + r];"""
-    assert circ.to_ir() == expected_ir
+    assert circ.build().to_ir() == expected_ir
 
 
 def test_input_qubit_indices_needs_num_qubits():

--- a/test/unit_tests/braket/experimental/autoqasm/test_devices.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_devices.py
@@ -295,5 +295,5 @@ def test_aws_device_run(
     }
     aws_session.create_quantum_task.assert_called_once()
     assert expected_run_call_args.items() <= run_call_args.items()
-    assert run_call_args_action["source"] == my_program.to_ir()
+    assert run_call_args_action["source"] == my_program.build().to_ir()
     assert run_call_args_action["inputs"] == inputs

--- a/test/unit_tests/braket/experimental/autoqasm/test_gate_calibrations.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_gate_calibrations.py
@@ -190,9 +190,9 @@ def test_gate_calibrations_bind_calibrations_not_inplace():
     def my_program():
         rx("$1", 1.0)
 
-    program_1 = my_program
+    program_1 = my_program.build()
     program_2 = my_program.build().with_calibrations(cal_1)
-    program_3 = my_program
+    program_3 = my_program.build()
 
     assert program_1.to_ir() == program_3.to_ir() != program_2.to_ir()
 

--- a/test/unit_tests/braket/experimental/autoqasm/test_gate_decorator.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_gate_decorator.py
@@ -39,7 +39,7 @@ gate empty_gate q {
 qubit[1] __qubits__;
 empty_gate __qubits__[0];"""
 
-    assert my_program.to_ir() == expected
+    assert my_program.build().to_ir() == expected
 
     _test_on_local_sim(my_program)
 
@@ -57,7 +57,7 @@ gate empty_gate q {
 qubit[1] __qubits__;
 empty_gate __qubits__[0];"""
 
-    assert my_program.to_ir() == expected
+    assert my_program.build().to_ir() == expected
 
 
 def test_gate_class() -> None:
@@ -110,7 +110,7 @@ gate my_gate(angle) q {
 qubit[1] __qubits__;
 my_gate(0.7853981633974483) __qubits__[0];"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_duplicate_gate_names_in_subroutine() -> None:
@@ -144,7 +144,7 @@ qubit[2] __qubits__;
 my_gate(0.7853981633974483) __qubits__[0];
 define_gate_in_subroutine();"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_incorrect_arg_count() -> None:
@@ -325,7 +325,7 @@ bit[2] __bit_0__ = "00";
 __bit_0__[0] = measure __qubits__[0];
 __bit_0__[1] = measure __qubits__[1];"""
 
-    assert my_program.to_ir() == expected
+    assert my_program.build().to_ir() == expected
 
     _test_on_local_sim(my_program)
 
@@ -357,4 +357,4 @@ qubit[4] __qubits__;
 subroutine(0, 1);
 subroutine(2, 3);"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected

--- a/test/unit_tests/braket/experimental/autoqasm/test_gate_definitions.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_gate_definitions.py
@@ -64,7 +64,7 @@ def test_bell_state_prep(bell_state_program) -> None:
 qubit[2] __qubits__;
 h __qubits__[0];
 cnot __qubits__[0], __qubits__[1];"""
-    actual_result = bell_state_program.to_ir()
+    actual_result = bell_state_program.build().to_ir()
     assert actual_result == expected
 
 
@@ -73,7 +73,7 @@ def test_physical_q_bell_state_prep(physical_bell_program) -> None:
     expected = """OPENQASM 3.0;
 h $0;
 cnot $0, $5;"""
-    actual_result = physical_bell_program.to_ir()
+    actual_result = physical_bell_program.build().to_ir()
     assert actual_result == expected
 
 

--- a/test/unit_tests/braket/experimental/autoqasm/test_operators.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_operators.py
@@ -106,7 +106,7 @@ if (__bool_0__) {
 }
 a = __int_3__;"""
 
-    assert cond_exp_assignment.to_ir() == expected
+    assert cond_exp_assignment.build().to_ir() == expected
 
 
 @pytest.mark.parametrize(
@@ -147,7 +147,7 @@ if (__bool_0__) {
     a = 2;
 }"""
 
-    assert branch_assignment_undeclared.to_ir() == expected
+    assert branch_assignment_undeclared.build().to_ir() == expected
 
 
 def test_branch_assignment_declared() -> None:
@@ -170,7 +170,7 @@ if (__bool_1__) {
     a = 7;
 }"""
 
-    assert branch_assignment_declared.to_ir() == expected
+    assert branch_assignment_declared.build().to_ir() == expected
 
 
 def for_body(i: aq.Qubit) -> None:
@@ -381,7 +381,7 @@ def do_and(bool a, bool b) -> bool {
 bool __bool_1__;
 __bool_1__ = do_and(true, false);"""
 
-    assert prog.to_ir() == expected
+    assert prog.build().to_ir() == expected
 
 
 def test_logical_op_or() -> None:
@@ -402,7 +402,7 @@ def do_or(bool a, bool b) -> bool {
 bool __bool_1__;
 __bool_1__ = do_or(true, false);"""
 
-    assert prog.to_ir() == expected
+    assert prog.build().to_ir() == expected
 
 
 def test_logical_op_not() -> None:
@@ -423,7 +423,7 @@ def do_not(bool a) -> bool {
 bool __bool_1__;
 __bool_1__ = do_not(true);"""
 
-    assert prog.to_ir() == expected
+    assert prog.build().to_ir() == expected
 
 
 def test_logical_op_eq() -> None:
@@ -444,7 +444,7 @@ def do_eq(int[32] a, int[32] b) -> bool {
 bool __bool_1__;
 __bool_1__ = do_eq(1, 2);"""
 
-    assert prog.to_ir() == expected
+    assert prog.build().to_ir() == expected
 
 
 def test_logical_op_not_eq() -> None:
@@ -465,7 +465,7 @@ def do_not_eq(int[32] a, int[32] b) -> bool {
 bool __bool_1__;
 __bool_1__ = do_not_eq(1, 2);"""
 
-    assert prog.to_ir() == expected
+    assert prog.build().to_ir() == expected
 
 
 def test_logical_ops_py() -> None:
@@ -484,7 +484,7 @@ def test_logical_ops_py() -> None:
 
     expected = """OPENQASM 3.0;"""
 
-    assert prog.to_ir() == expected
+    assert prog.build().to_ir() == expected
 
 
 def test_comparison_lt() -> None:
@@ -507,7 +507,7 @@ __bool_1__ = a < 1;
 if (__bool_1__) {
     h __qubits__[0];
 }"""
-    assert prog.to_ir() == expected
+    assert prog.build().to_ir() == expected
 
 
 def test_comparison_gt() -> None:
@@ -530,7 +530,7 @@ __bool_1__ = a > 1;
 if (__bool_1__) {
     h __qubits__[0];
 }"""
-    assert prog.to_ir() == expected
+    assert prog.build().to_ir() == expected
 
 
 def test_comparison_ops_py() -> None:
@@ -549,7 +549,7 @@ def test_comparison_ops_py() -> None:
         assert all([c, d, not e, not f, h])
 
     expected = """OPENQASM 3.0;"""
-    assert prog.to_ir() == expected
+    assert prog.build().to_ir() == expected
 
 
 @pytest.mark.parametrize(
@@ -642,7 +642,7 @@ bit[6] a = "000000";
 bit b = 1;
 a[3] = b;"""
 
-    assert slice.to_ir() == expected
+    assert slice.build().to_ir() == expected
 
 
 def test_slice_bits_w_measure() -> None:
@@ -663,7 +663,7 @@ __bit_1__ = measure __qubits__[0];
 c = __bit_1__;
 b0[3] = c;"""
 
-    assert measure_to_slice.to_ir() == expected
+    assert measure_to_slice.build().to_ir() == expected
 
 
 @pytest.mark.parametrize(
@@ -807,7 +807,7 @@ qubit[1] __qubits__;
 {} __qubits__[0];""".format(
         "h" if value else "x"
     )
-    assert test_control_flow.to_ir() == expected
+    assert test_control_flow.build().to_ir() == expected
 
 
 def test_py_while() -> None:
@@ -826,7 +826,7 @@ qubit[1] __qubits__;
 h __qubits__[0];
 h __qubits__[0];"""
 
-    assert test_control_flow.to_ir() == expected
+    assert test_control_flow.build().to_ir() == expected
 
 
 def test_py_assert() -> None:
@@ -850,7 +850,7 @@ def test_py_assert() -> None:
     def test_assert():
         assert true_var
 
-    test_assert.to_ir()  # does not raise an exception
+    test_assert.build().to_ir()  # does not raise an exception
 
     @aq.main
     def test_assert_false():
@@ -883,4 +883,4 @@ def test_py_list_ops() -> None:
         c = np.stack([a, a])
         assert np.array_equal(c, [[2, 3, 4], [2, 3, 4]])
 
-    assert test_list_ops.to_ir()
+    assert test_list_ops.build().to_ir()

--- a/test/unit_tests/braket/experimental/autoqasm/test_parameters.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_parameters.py
@@ -72,7 +72,7 @@ qubit[1] __qubits__;
 rx(theta) __qubits__[0];
 bit __bit_0__;
 __bit_0__ = measure __qubits__[0];"""
-    assert simple_parametric.to_ir() == expected
+    assert simple_parametric.build().to_ir() == expected
 
 
 def test_simple_parametric_fp(simple_parametric_fp):
@@ -84,7 +84,7 @@ qubit[1] __qubits__;
 rx(theta) __qubits__[0];
 bit __bit_0__;
 __bit_0__ = measure __qubits__[0];"""
-    assert simple_parametric_fp.to_ir() == expected
+    assert simple_parametric_fp.build().to_ir() == expected
 
 
 def test_sim_simple(simple_parametric):
@@ -126,7 +126,7 @@ bit[2] __bit_0__ = "00";
 __bit_0__[0] = measure __qubits__[0];
 __bit_0__[1] = measure __qubits__[1];
 c = __bit_0__;"""
-    assert multi_parametric.to_ir() == expected
+    assert multi_parametric.build().to_ir() == expected
 
 
 def test_sim_multi_param(multi_parametric):
@@ -156,7 +156,7 @@ rx(theta) __qubits__[1];
 cnot __qubits__[0], __qubits__[1];
 rx(theta) __qubits__[0];
 rx(alpha) __qubits__[1];"""
-    assert parametric.to_ir() == expected
+    assert parametric.build().to_ir() == expected
 
 
 @pytest.mark.xfail(
@@ -183,7 +183,7 @@ def rx_alpha(int[32] qubit) {
 input float[64] alpha;
 qubit[3] __qubits__;
 rx_alpha(2);"""
-    assert parametric.to_ir() == expected
+    assert parametric.build().to_ir() == expected
 
 
 def test_captured_parameter():
@@ -202,7 +202,7 @@ input float alpha;
 qubit[2] __qubits__;
 rz(alpha) __qubits__[0];
 rx(alpha) __qubits__[1];"""
-    assert parametric.to_ir() == expected
+    assert parametric.build().to_ir() == expected
 
 
 def test_multi_angle_gates():
@@ -218,7 +218,7 @@ def test_multi_angle_gates():
 input float phi;
 qubit[5] __qubits__;
 ms(phi, phi, 0.5) __qubits__[0], __qubits__[2];"""
-    assert parametric.to_ir() == expected
+    assert parametric.build().to_ir() == expected
 
 
 def test_sim_multi_angle():
@@ -245,7 +245,7 @@ def test_parameters_passed_as_main_arg():
 input float my_phi;
 qubit[2] __qubits__;
 cphaseshift(my_phi) __qubits__[0], __qubits__[1];"""
-    assert parametric.to_ir() == expected
+    assert parametric.build().to_ir() == expected
 
 
 def test_simple_subroutine_arg():
@@ -266,7 +266,7 @@ def silly_rz(float[64] theta) {
 input float alpha;
 qubit[1] __qubits__;
 silly_rz(alpha);"""
-    assert parametric.to_ir() == expected
+    assert parametric.build().to_ir() == expected
 
 
 def test_parameters_passed_as_subroutine_arg():
@@ -290,7 +290,7 @@ input float beta;
 qubit[5] __qubits__;
 silly_ms(1, alpha, 0.707);
 silly_ms(3, 0.5, beta);"""
-    assert parametric.to_ir() == expected
+    assert parametric.build().to_ir() == expected
 
 
 def test_sim_subroutine_arg():
@@ -325,7 +325,7 @@ gate rx_theta(theta) q {
 input float θ;
 qubit[3] __qubits__;
 rx_theta(θ) __qubits__[2];"""
-    assert parametric.to_ir() == expected
+    assert parametric.build().to_ir() == expected
 
 
 def test_parametric_pulse_cals():
@@ -371,10 +371,10 @@ rx(alpha) __qubits__[0];
 bit __bit_0__;
 __bit_0__ = measure __qubits__[0];"""
 
-    assert parametric.to_ir() == unbound_expected
+    assert parametric.build().to_ir() == unbound_expected
     bound_prog = parametric.build().make_bound_program({"alpha": 0.5})
     # Original program unchanged
-    assert parametric.to_ir() == unbound_expected
+    assert parametric.build().to_ir() == unbound_expected
     assert bound_prog.to_ir() == bound_template.format(0.5)
     # Can rebind
     bound_prog = parametric.build().make_bound_program({"alpha": 0.432143})
@@ -479,7 +479,7 @@ def test_bind_empty_program():
     def empty_program():
         pass
 
-    qasm = empty_program.to_ir()
+    qasm = empty_program.build().to_ir()
     bound_program1 = empty_program.build().make_bound_program({}).to_ir()
     bound_program2 = empty_program.build().make_bound_program({"alpha": 0.5}).to_ir()
     assert qasm == bound_program1 == bound_program2
@@ -575,7 +575,7 @@ if (__bool_2__) {
 }
 bit __bit_3__;
 __bit_3__ = measure __qubits__[0];"""
-    assert parametric.to_ir() == expected
+    assert parametric.build().to_ir() == expected
 
 
 def test_lt_condition():
@@ -604,7 +604,7 @@ if (__bool_1__) {
 }
 bit __bit_2__;
 __bit_2__ = measure __qubits__[0];"""
-    assert parametric.to_ir() == expected
+    assert parametric.build().to_ir() == expected
 
 
 def test_parameter_in_predicate_in_subroutine():
@@ -634,7 +634,7 @@ qubit[1] __qubits__;
 sub(val);
 bit __bit_1__;
 __bit_1__ = measure __qubits__[0];"""
-    assert parametric.to_ir() == expected
+    assert parametric.build().to_ir() == expected
 
 
 def test_eq_condition():
@@ -666,7 +666,7 @@ if (__bool_0__) {
 }
 bit __bit_2__;
 __bit_2__ = measure __qubits__[0];"""
-    assert parametric.to_ir() == expected
+    assert parametric.build().to_ir() == expected
 
 
 def test_sim_conditional_stmts():
@@ -716,7 +716,7 @@ if (__bool_0__) {
 }
 bit __bit_1__;
 __bit_1__ = measure __qubits__[0];"""
-    assert parametric.to_ir() == expected
+    assert parametric.build().to_ir() == expected
 
 
 def test_param_or():
@@ -741,7 +741,7 @@ if (__bool_0__) {
 }
 bit __bit_1__;
 __bit_1__ = measure __qubits__[0];"""
-    assert parametric.to_ir() == expected
+    assert parametric.build().to_ir() == expected
 
 
 def test_param_and():
@@ -764,7 +764,7 @@ if (__bool_0__) {
 }
 bit __bit_1__;
 __bit_1__ = measure __qubits__[0];"""
-    assert parametric.to_ir() == expected
+    assert parametric.build().to_ir() == expected
 
 
 def test_param_and_float():
@@ -787,7 +787,7 @@ if (__bool_0__) {
 }
 bit __bit_1__;
 __bit_1__ = measure __qubits__[0];"""
-    assert parametric.to_ir() == expected
+    assert parametric.build().to_ir() == expected
 
 
 def test_param_not():
@@ -809,7 +809,7 @@ if (__bool_0__) {
 }
 bit __bit_1__;
 __bit_1__ = measure __qubits__[0];"""
-    assert parametric.to_ir() == expected
+    assert parametric.build().to_ir() == expected
 
 
 def test_parameter_binding_conditions():
@@ -859,8 +859,8 @@ gpi(2 * theta) __qubits__[0];"""
 input float theta;
 qubit[1] __qubits__;
 gpi(2.0 * theta) __qubits__[0];"""
-    assert parametric.to_ir() == expected_1
-    assert parametric_fp.to_ir() == expected_2
+    assert parametric.build().to_ir() == expected_1
+    assert parametric_fp.build().to_ir() == expected_2
 
 
 def test_sim_expressions():
@@ -886,7 +886,7 @@ input float alpha;
 input float theta;
 qubit[1] __qubits__;
 gpi(alpha * theta) __qubits__[0];"""
-    assert parametric.to_ir() == expected
+    assert parametric.build().to_ir() == expected
 
 
 def test_bound_parameter_expressions():
@@ -937,7 +937,7 @@ def rotate(float[64] theta) {
 input float alpha;
 qubit[1] __qubits__;
 rotate(2 * alpha);"""
-    assert parametric.to_ir() == expected
+    assert parametric.build().to_ir() == expected
 
 
 def test_gate_parameter_expressions():
@@ -958,7 +958,7 @@ gate rotate(theta) q {
 input float alpha;
 qubit[1] __qubits__;
 rotate(2 * alpha) __qubits__[0];"""
-    assert parametric.to_ir() == expected
+    assert parametric.build().to_ir() == expected
 
 
 def test_conditional_parameter_expressions():
@@ -980,7 +980,7 @@ if (__bool_0__) {
 }
 bit __bit_1__;
 __bit_1__ = measure __qubits__[0];"""
-    assert parametric.to_ir() == expected
+    assert parametric.build().to_ir() == expected
 
 
 def test_parameter_expressions_range_index():
@@ -1000,5 +1000,5 @@ for int _ in [0:2 * n - 1] {
 }
 bit __bit_0__;
 __bit_0__ = measure __qubits__[0];"""
-    assert two_n_hs.to_ir() == expected
+    assert two_n_hs.build().to_ir() == expected
     _test_parametric_on_local_sim(two_n_hs, {"n": 3})

--- a/test/unit_tests/braket/experimental/autoqasm/test_pragmas.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_pragmas.py
@@ -52,7 +52,7 @@ box {
     cnot $1, $2;
 }"""
 
-    assert program_func.to_ir() == expected
+    assert program_func.build().to_ir() == expected
 
 
 def test_nested_verbatim_box() -> None:

--- a/test/unit_tests/braket/experimental/autoqasm/test_program.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_program.py
@@ -114,7 +114,7 @@ return_value = __bit_0__;"""
         )
 
     for i, (scale, angle) in enumerate(itertools.product(scales, angles)):
-        assert programs[i].to_ir() == expected(scale, angle)
+        assert programs[i].build().to_ir() == expected(scale, angle)
 
 
 @patch("builtins.print")

--- a/test/unit_tests/braket/experimental/autoqasm/test_pulse.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_pulse.py
@@ -64,7 +64,7 @@ def test_mix_gate_pulse() -> None:
         }
         """
     ).strip()
-    assert my_program.to_ir() == expected
+    assert my_program.build().to_ir() == expected
 
 
 def test_merge_cal_box() -> None:
@@ -84,7 +84,7 @@ def test_merge_cal_box() -> None:
         }
         """
     ).strip()
-    assert my_program.to_ir() == expected
+    assert my_program.build().to_ir() == expected
 
 
 @pytest.mark.parametrize(
@@ -203,7 +203,7 @@ def test_pulse_freeparameter() -> None:
         }
         """
     ).strip()
-    assert my_program.to_ir() == expected
+    assert my_program.build().to_ir() == expected
 
 
 def test_pulse_freeparameter_bound() -> None:
@@ -252,4 +252,4 @@ def test_pulse_freeparameter_condition() -> None:
         }
         """
     ).strip()
-    assert my_program.to_ir() == expected
+    assert my_program.build().to_ir() == expected

--- a/test/unit_tests/braket/experimental/autoqasm/test_return.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_return.py
@@ -30,7 +30,7 @@ def test_float_lit():
 output float[64] return_value;
 return_value = 1.5;"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_int_lit():
@@ -42,7 +42,7 @@ def test_int_lit():
 output int[32] return_value;
 return_value = 1;"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_named_value():
@@ -55,7 +55,7 @@ def test_named_value():
 output int[32] output_name;
 output_name = 1;"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_return_measure():
@@ -70,7 +70,7 @@ bit __bit_0__;
 __bit_0__ = measure __qubits__[0];
 return_value = __bit_0__;"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_named_measure():
@@ -86,7 +86,7 @@ bit __bit_0__;
 __bit_0__ = measure __qubits__[0];
 b = __bit_0__;"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_basic_arithmetic():
@@ -101,7 +101,7 @@ int[32] __int_1__ = 2;
 output int[32] val;
 val = __int_0__ + __int_1__;"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_expressions():
@@ -116,7 +116,7 @@ input int[32] input_a;
 output int[32] val;
 val = 1 + input_a;"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_return_tuple():
@@ -130,7 +130,7 @@ output int[32] return_value1;
 return_value0 = 1;
 return_value1 = 2;"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_return_list_floats():
@@ -144,7 +144,7 @@ output float[64] return_value1;
 return_value0 = 11.1;
 return_value1 = 2.222;"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_return_multi_meas():
@@ -173,7 +173,7 @@ return_value0 = a;
 return_value1 = b;
 return_value2 = __bit_2__;"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_return_multi_types():
@@ -196,7 +196,7 @@ return_value0 = a;
 return_value1 = true;
 return_value2 = 1.11;"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_name_collisions():
@@ -219,7 +219,7 @@ input float val2;
 output float[64] return_value;
 return_value = val1 + val2;"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_return_ints():
@@ -233,7 +233,7 @@ input int[32] val2;
 output int[32] return_value;
 return_value = val1 + val2;"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_return_bools():
@@ -249,7 +249,7 @@ bool __bool_0__;
 __bool_0__ = val1 || val2;
 return_value = __bool_0__;"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_return_bits():
@@ -272,7 +272,7 @@ __bit_1__ = measure __qubits__[1];
 b1 = __bit_1__;
 return_value = b0 + b1;"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_returns_with_subroutine():
@@ -298,7 +298,7 @@ int[32] __int_1__;
 __int_1__ = helper();
 val = __int_1__;"""
 
-    assert ret_test.to_ir() == expected
+    assert ret_test.build().to_ir() == expected
 
 
 def test_return_measure_range():
@@ -330,7 +330,7 @@ __bit_0__[1] = measure __qubits__[1];
 __bit_0__[2] = measure __qubits__[2];
 return_value = __bit_0__;"""
 
-    assert program.to_ir() == expected
+    assert program.build().to_ir() == expected
 
 
 def test_return_pulse_capture():
@@ -353,4 +353,4 @@ cal {
 return_value0 = __bit_0__;
 return_value1 = __bit_1__;"""
 
-    assert program.to_ir() == expected
+    assert program.build().to_ir() == expected

--- a/test/unit_tests/braket/experimental/autoqasm/test_serialization_config.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_serialization_config.py
@@ -41,7 +41,7 @@ def test_openqasm_serialization_properties_auto_defcalgrammar() -> None:
         }
         """
     ).strip()
-    qasm = my_program.to_ir(
+    qasm = my_program.build().to_ir(
         serialization_properties=OpenQASMSerializationProperties(auto_defcalgrammar=True)
     )
     assert qasm == expected_true
@@ -54,7 +54,7 @@ def test_openqasm_serialization_properties_auto_defcalgrammar() -> None:
         }
         """
     ).strip()
-    qasm = my_program.to_ir(
+    qasm = my_program.build().to_ir(
         serialization_properties=OpenQASMSerializationProperties(auto_defcalgrammar=False)
     )
     assert qasm == expected_false
@@ -77,7 +77,7 @@ def test_openqasm_serialization_properties_include_externs() -> None:
         }
         """
     ).strip()
-    qasm = my_program.to_ir(
+    qasm = my_program.build().to_ir(
         serialization_properties=OpenQASMSerializationProperties(include_externs=True)
     )
     assert qasm == expected_true
@@ -91,7 +91,7 @@ def test_openqasm_serialization_properties_include_externs() -> None:
         }
         """
     ).strip()
-    qasm = my_program.to_ir(
+    qasm = my_program.build().to_ir(
         serialization_properties=OpenQASMSerializationProperties(include_externs=False)
     )
     assert qasm == expected_false

--- a/test/unit_tests/braket/experimental/autoqasm/test_transpiler.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_transpiler.py
@@ -89,10 +89,10 @@ cnot __qubits__[1], __qubits__[3];"""
         bell_partial_no_num_qubits.build()
 
     bell_partial = aq.main(num_qubits=4)(functools.partial(bell, 1))
-    assert bell_partial.to_ir() == expected_partial
+    assert bell_partial.build().to_ir() == expected_partial
 
     bell_noarg_partial = aq.main(functools.partial(bell, 1, 3))
-    assert bell_noarg_partial.to_ir() == expected_no_arg_partial
+    assert bell_noarg_partial.build().to_ir() == expected_no_arg_partial
 
 
 def test_classmethod() -> None:
@@ -113,8 +113,8 @@ qubit[2] __qubits__;
 h __qubits__[q0];
 cnot __qubits__[q0], __qubits__[q1];"""
 
-    assert aq.main(num_qubits=2)(MyClass.bell).to_ir() == expected
-    assert aq.main(num_qubits=2)(MyClass().bell).to_ir() == expected
+    assert aq.main(num_qubits=2)(MyClass.bell).build().to_ir() == expected
+    assert aq.main(num_qubits=2)(MyClass().bell).build().to_ir() == expected
 
 
 def test_with_verbose_logging() -> None:

--- a/test/unit_tests/braket/experimental/autoqasm/test_types.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_types.py
@@ -64,7 +64,7 @@ bit __bit_1__;
 __bit_1__ = ret_test();
 return_value = __bit_1__;"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_return_int():
@@ -89,7 +89,7 @@ int[32] __int_1__;
 __int_1__ = ret_test();
 return_value = __int_1__;"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_return_float():
@@ -114,7 +114,7 @@ float[64] __float_1__;
 __float_1__ = ret_test();
 return_value = __float_1__;"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_return_bool():
@@ -139,7 +139,7 @@ bool __bool_1__;
 __bool_1__ = ret_test();
 return_value = __bool_1__;"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_return_bin_expr():
@@ -166,7 +166,7 @@ int[32] __int_2__;
 __int_2__ = add(a, b);
 return_value = __int_2__;"""
 
-    assert ret_test.to_ir() == expected
+    assert ret_test.build().to_ir() == expected
 
 
 def test_return_none():
@@ -178,7 +178,7 @@ def test_return_none():
 
     expected = "OPENQASM 3.0;"
 
-    assert ret_test.to_ir() == expected
+    assert ret_test.build().to_ir() == expected
 
 
 def test_declare_array():
@@ -199,7 +199,7 @@ array[int[32], 3] b = {4, 5, 6};
 b[2] = 14;
 b = a;"""
 
-    assert declare_array.to_ir() == expected
+    assert declare_array.build().to_ir() == expected
 
 
 def test_invalid_array_assignment():
@@ -294,7 +294,7 @@ int[32] __int_1__;
 __int_1__ = helper();
 return_value = __int_1__;"""
 
-    assert ret_test.to_ir() == expected
+    assert ret_test.build().to_ir() == expected
 
 
 def test_map_bool():
@@ -313,7 +313,7 @@ def annotation_test(bool input) {
 }
 annotation_test(true);"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_map_int():
@@ -332,7 +332,7 @@ def annotation_test(int[32] input) {
 }
 annotation_test(1);"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_map_float():
@@ -351,7 +351,7 @@ def annotation_test(float[64] input) {
 }
 annotation_test(1.0);"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_map_qubit():
@@ -371,7 +371,7 @@ def annotation_test(qubit input) {
 qubit[2] __qubits__;
 annotation_test(__qubits__[1]);"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_map_array():
@@ -408,7 +408,7 @@ def annotation_test(bit input) {
 bit a = 1;
 annotation_test(a);"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_map_other_unnamed_arg():
@@ -428,7 +428,7 @@ def annotation_test(bit input) {
 bit __bit_0__ = 1;
 annotation_test(__bit_0__);"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_map_and_assign_arg():
@@ -452,7 +452,7 @@ def assign_param(int[32] c) {
 int[32] c = 0;
 assign_param(c);"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_unnamed_retval_python_type() -> None:
@@ -476,7 +476,7 @@ int[32] __int_1__;
 __int_1__ = retval_test();
 return_value = __int_1__;"""
 
-    assert caller.to_ir() == expected_qasm
+    assert caller.build().to_ir() == expected_qasm
 
 
 def test_unnamed_retval_qasm_type() -> None:
@@ -500,7 +500,7 @@ bit __bit_1__;
 __bit_1__ = retval_test();
 return_value = __bit_1__;"""
 
-    assert caller.to_ir() == expected_qasm
+    assert caller.build().to_ir() == expected_qasm
 
 
 def test_recursive_unassigned_retval_python_type() -> None:
@@ -525,7 +525,7 @@ def retval_recursive() -> int[32] {
 int[32] __int_3__;
 __int_3__ = retval_recursive();"""
 
-    assert main.to_ir() == expected_qasm
+    assert main.build().to_ir() == expected_qasm
 
 
 def test_recursive_assigned_retval_python_type() -> None:
@@ -552,7 +552,7 @@ def retval_recursive() -> int[32] {
 int[32] __int_3__;
 __int_3__ = retval_recursive();"""
 
-    assert main.to_ir() == expected_qasm
+    assert main.build().to_ir() == expected_qasm
 
 
 def test_recursive_retval_expression_python_type() -> None:
@@ -588,7 +588,7 @@ float[64] __float_4__;
 __float_4__ = retval_recursive();
 return_value = __float_4__;"""
 
-    assert caller.to_ir() == expected_qasm
+    assert caller.build().to_ir() == expected_qasm
 
 
 def test_recursive_oqpy_type() -> None:
@@ -603,7 +603,7 @@ def test_recursive_oqpy_type() -> None:
     def main():
         retval_recursive()
 
-    assert "-> bit" in main.to_ir()
+    assert "-> bit" in main.build().to_ir()
 
 
 def test_error_for_tuple_param() -> None:
@@ -655,7 +655,7 @@ def ret_test() -> bool {
 bool __bool_1__;
 __bool_1__ = ret_test();"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_ignore_ret_typehint_list():
@@ -708,7 +708,7 @@ qubit[4] __qubits__;
 float[64] __float_1__;
 __float_1__ = ret_test();"""
 
-    assert main.to_ir() == expected
+    assert main.build().to_ir() == expected
 
 
 def test_param_array_list_missing_arg():


### PR DESCRIPTION
*Issue #, if available:*
Follow-up from #841 with mechanical changes needed to change `allow_implicit_build` default to `False`.

*Description of changes:*
The vast majority of the changes are converting lines like `program.to_ir()` to `program.build().to_ir()`.

*Testing done:*
`tox` passes locally, including `tox -e notebooks`.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
