### PR TITLE
test: add in the protocol for the ssl context

### DIFF
--- a/test/unit_tests/braket/jobs/test_hybrid_job.py
+++ b/test/unit_tests/braket/jobs/test_hybrid_job.py
@@ -5,7 +5,7 @@ import sys
 import tempfile
 from logging import getLogger
 from pathlib import Path
-from ssl import SSLContext, PROTOCOL_TLS_CLIENT
+from ssl import PROTOCOL_TLS_CLIENT, SSLContext
 from unittest.mock import MagicMock, patch
 
 import job_module

--- a/test/unit_tests/braket/jobs/test_hybrid_job.py
+++ b/test/unit_tests/braket/jobs/test_hybrid_job.py
@@ -5,7 +5,7 @@ import sys
 import tempfile
 from logging import getLogger
 from pathlib import Path
-from ssl import SSLContext
+from ssl import SSLContext, PROTOCOL_TLS_CLIENT
 from unittest.mock import MagicMock, patch
 
 import job_module
@@ -488,7 +488,7 @@ def test_decorator_pos_only_args(
 
 
 def test_serialization_error(aws_session):
-    ssl_context = SSLContext()
+    ssl_context = SSLContext(protocol=PROTOCOL_TLS_CLIENT)
 
     @hybrid_job(device=None, aws_session=aws_session)
     def fails_serialization():


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Not specifying the protocol for `ssl.SSLContext` is deprecated.

*Testing done:*
`tox -e unit-tests`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
