### PR TITLE
fix: increase tol value for our integ tests

### DIFF
--- a/test/integ_tests/gate_model_device_testing_utils.py
+++ b/test/integ_tests/gate_model_device_testing_utils.py
@@ -27,7 +27,7 @@ from braket.tasks import GateModelQuantumTaskResult
 
 
 def get_tol(shots: int) -> Dict[str, float]:
-    return {"atol": 0.1, "rtol": 0.15} if shots else {"atol": 0.01, "rtol": 0}
+    return {"atol": 0.2, "rtol": 0.3} if shots else {"atol": 0.01, "rtol": 0}
 
 
 def qubit_ordering_testing(device: Device, run_kwargs: Dict[str, Any]):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I'm doubling the tol value for our tests. The performance should be tuned and maintained on the backend - not as part of our github integ tests.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
