### PR TITLE
fix: stop generating a QubitSet for each call of qubit_count and qubits

### DIFF
--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -489,8 +489,7 @@ class Circuit:
                     for parameter in free_params:
                         self._parameters.add(FreeParameter(parameter.name))
         self._moments.add(instructions_to_add)
-        for qubit in _flatten(self._moments.qubits):
-            self._qubits.add(qubit)
+        self._qubits.update(self._moments.qubits)
 
         return self
 

--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -1,4 +1,4 @@
-# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# C/pyright Amazon.com Inc. or its affiliates. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"). You
 # may not use this file except in compliance with the License. A copy of
@@ -72,10 +72,9 @@ AddableTypes = TypeVar("AddableTypes", SubroutineReturn, SubroutineCallable)
 
 def _flatten(other: Any) -> Any:
     if isinstance(other, Iterable) and not isinstance(other, str):
-        for item in other:
-            yield from _flatten(item)
+        return [a for i in other for a in _flatten(i)]
     else:
-        yield other
+        return [other]
 
 
 class Circuit:
@@ -413,8 +412,7 @@ class Circuit:
     def _add_to_qubit_observable_set(self, result_type: ResultType) -> None:
         if isinstance(result_type, ObservableResultType) and result_type.target:
             self._qubit_observable_set.update(result_type.target)
-            for qubit in _flatten(self._qubit_observable_set):
-                self._qubits.add(qubit)
+            self._qubits.update(_flatten(result_type.target))
 
     def add_instruction(
         self,

--- a/src/braket/circuits/moments.py
+++ b/src/braket/circuits/moments.py
@@ -76,8 +76,8 @@ class Moments(Mapping[MomentsKey, Instruction]):
     method.
 
     Args:
-        instructions (Iterable[Instruction] | None): Instructions to initialize self.
-            Default = None.
+        instructions (Iterable[Instruction]): Instructions to initialize self.
+            Default = [].
 
     Examples:
         >>> moments = Moments()
@@ -102,7 +102,7 @@ class Moments(Mapping[MomentsKey, Instruction]):
             Value: Instruction('operator': H, 'target': QubitSet([Qubit(1)]))
     """
 
-    def __init__(self, instructions: Iterable[Instruction] | None = None):
+    def __init__(self, instructions: Iterable[Instruction] = []):
         self._moments: OrderedDict[MomentsKey, Instruction] = OrderedDict()
         self._max_times: dict[Qubit, int] = {}
         self._qubits = QubitSet()
@@ -110,7 +110,7 @@ class Moments(Mapping[MomentsKey, Instruction]):
         self._time_all_qubits = -1
         self._number_gphase_in_current_moment = 0
 
-        self.add(instructions or [])
+        self.add(instructions)
 
     @property
     def depth(self) -> int:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Reduce overhead of creating new qubit sets each time we call qubits or qubit_set

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
