### PR TITLE
change: Replace usage of Optional and Union in AutoQASM type hints

### DIFF
--- a/src/braket/experimental/autoqasm/api.py
+++ b/src/braket/experimental/autoqasm/api.py
@@ -20,7 +20,7 @@ import functools
 import inspect
 from collections.abc import Callable
 from types import FunctionType
-from typing import Any, Iterable, Optional, Union, get_args
+from typing import Any, Iterable, get_args
 
 import openqasm3.ast as qasm_ast
 import oqpy.base
@@ -37,9 +37,9 @@ from braket.experimental.autoqasm.types import QubitIdentifierType as Qubit
 
 
 def main(
-    func: Optional[Callable] = None,
+    func: Callable | None = None,
     *,
-    num_qubits: Optional[int] = None,
+    num_qubits: int | None = None,
 ) -> aq_program.Program | Callable[..., aq_program.Program]:
     """Decorator that converts a function into a Program object containing the quantum program.
 
@@ -47,9 +47,9 @@ def main(
     function is called, and a new Program object is returned each time.
 
     Args:
-        func (Optional[Callable]): Decorated function. May be `None` in the case where decorator
+        func (Callable | None): Decorated function. May be `None` in the case where decorator
             is used with parentheses.
-        num_qubits (Optional[int]): Configuration to set the total number of qubits to declare in
+        num_qubits (int | None): Configuration to set the total number of qubits to declare in
             the program.
 
     Returns:
@@ -80,15 +80,15 @@ def main(
 
 
 def subroutine(
-    func: Optional[Callable] = None, annotations: Optional[str | Iterable[str]] = None
+    func: Callable | None = None, annotations: str | Iterable[str] | None = None
 ) -> Callable[..., aq_program.Program]:
     """Decorator that converts a function into a callable that will insert a subroutine into
     the quantum program.
 
     Args:
-        func (Optional[Callable]): Decorated function. May be `None` in the case where decorator
+        func (Callable | None): Decorated function. May be `None` in the case where decorator
             is used with parentheses.
-        annotations (Optional[str | Iterable[str]]): Annotations to be added to the subroutine.
+        annotations (str | Iterable[str] | None): Annotations to be added to the subroutine.
 
     Returns:
         Callable[..., Program]: A callable which returns the converted
@@ -103,11 +103,11 @@ def subroutine(
     )
 
 
-def gate(func: Optional[Callable] = None) -> Callable[..., None]:
+def gate(func: Callable | None = None) -> Callable[..., None]:
     """Decorator that converts a function into a callable gate definition.
 
     Args:
-        func (Optional[Callable]): Decorated function. May be `None` in the case where decorator
+        func (Callable | None): Decorated function. May be `None` in the case where decorator
             is used with parentheses.
 
     Returns:
@@ -139,21 +139,21 @@ def gate_calibration(*, implements: Callable, **kwargs) -> Callable[[], GateCali
 
 
 def _function_wrapper(
-    func: Optional[Callable],
+    func: Callable | None,
     *,
     converter_callback: Callable,
-    converter_args: Optional[dict[str, Any]] = None,
-) -> Callable[..., Optional[Union[aq_program.Program, GateCalibration]]]:
+    converter_args: dict[str, Any] | None = None,
+) -> Callable[..., aq_program.Program | GateCalibration | None]:
     """Wrapping and conversion logic around the user function `f`.
 
     Args:
-        func (Optional[Callable]): Decorated function. May be `None` in the case where decorator
+        func (Callable | None): Decorated function. May be `None` in the case where decorator
             is used with parentheses.
         converter_callback (Callable): The function converter, e.g., _convert_main.
-        converter_args (Optional[dict[str, Any]]): Extra arguments for the function converter.
+        converter_args (dict[str, Any] | None): Extra arguments for the function converter.
 
     Returns:
-        Callable[..., Optional[Union[Program, GateCalibration]]]: A callable which
+        Callable[..., Program | GateCalibration | None]: A callable which
         returns the converted construct, if any, when called.
     """
     if not (func and callable(func)):
@@ -489,7 +489,7 @@ def _make_return_instance_from_oqpy_return_type(return_type: Any) -> Any:
     return var_type()
 
 
-def _get_bitvar_size(node: qasm_ast.BitType) -> Optional[int]:
+def _get_bitvar_size(node: qasm_ast.BitType) -> int | None:
     if not isinstance(node, qasm_ast.BitType) or not node.size:
         return None
     return node.size.value
@@ -663,14 +663,14 @@ def _convert_calibration(
 
 def _validate_calibration_args(
     gate_function: Callable,
-    decorator_args: dict[str, Union[Qubit, float]],
+    decorator_args: dict[str, Qubit | float],
     func_args: aq_program.GateArgs,
 ) -> None:
     """Validate the arguments passed to the calibration decorator and function.
 
     Args:
         gate_function (Callable): The gate function which calibration is being defined.
-        decorator_args (dict[str, Union[Qubit, float]]): The calibration decorator arguments.
+        decorator_args (dict[str, Qubit | float]): The calibration decorator arguments.
         func_args (aq_program.GateArgs): The gate function arguments.
     """
     gate_args = _get_gate_args(gate_function)

--- a/src/braket/experimental/autoqasm/errors.py
+++ b/src/braket/experimental/autoqasm/errors.py
@@ -14,7 +14,7 @@
 """Errors raised in the AutoQASM build process."""
 
 
-from typing import Optional
+from __future__ import annotations
 
 
 class AutoQasmError(Exception):
@@ -90,7 +90,7 @@ class InsufficientQubitCountError(AutoQasmError):
 class UnsupportedConditionalExpressionError(AutoQasmError):
     """Conditional expressions which return values are not supported."""
 
-    def __init__(self, true_type: Optional[type], false_type: Optional[type]):
+    def __init__(self, true_type: type | None, false_type: type | None):
         if_type = true_type.__name__ if true_type else "None"
         else_type = false_type.__name__ if false_type else "None"
         self.message = """\

--- a/src/braket/experimental/autoqasm/operators/comparisons.py
+++ b/src/braket/experimental/autoqasm/operators/comparisons.py
@@ -14,7 +14,9 @@
 
 """Operators for comparison operators: <, <=, >, and >=."""
 
-from typing import Any, Union
+from __future__ import annotations
+
+from typing import Any
 
 from braket.experimental.autoqasm import program
 from braket.experimental.autoqasm import types as aq_types
@@ -22,7 +24,7 @@ from braket.experimental.autoqasm import types as aq_types
 from .utils import _register_and_convert_parameters
 
 
-def lt_(a: Any, b: Any) -> Union[bool, aq_types.BoolVar]:
+def lt_(a: Any, b: Any) -> bool | aq_types.BoolVar:
     """Functional form of "<".
 
     Args:
@@ -30,7 +32,7 @@ def lt_(a: Any, b: Any) -> Union[bool, aq_types.BoolVar]:
         b (Any): The second expression.
 
     Returns:
-        Union[bool, BoolVar]: Whether the first expression is less than the second.
+        bool | BoolVar: Whether the first expression is less than the second.
     """
     if aq_types.is_qasm_type(a) or aq_types.is_qasm_type(b):
         return _aq_lt(a, b)
@@ -48,7 +50,7 @@ def _aq_lt(a: Any, b: Any) -> aq_types.BoolVar:
     return result
 
 
-def lteq_(a: Any, b: Any) -> Union[bool, aq_types.BoolVar]:
+def lteq_(a: Any, b: Any) -> bool | aq_types.BoolVar:
     """Functional form of "<=".
 
     Args:
@@ -56,7 +58,7 @@ def lteq_(a: Any, b: Any) -> Union[bool, aq_types.BoolVar]:
         b (Any): The second expression.
 
     Returns:
-        Union[bool, BoolVar]: Whether the first expression is less than or equal to the second.
+        bool | BoolVar: Whether the first expression is less than or equal to the second.
     """
     if aq_types.is_qasm_type(a) or aq_types.is_qasm_type(b):
         return _aq_lteq(a, b)
@@ -74,7 +76,7 @@ def _aq_lteq(a: Any, b: Any) -> aq_types.BoolVar:
     return result
 
 
-def gt_(a: Any, b: Any) -> Union[bool, aq_types.BoolVar]:
+def gt_(a: Any, b: Any) -> bool | aq_types.BoolVar:
     """Functional form of ">".
 
     Args:
@@ -82,7 +84,7 @@ def gt_(a: Any, b: Any) -> Union[bool, aq_types.BoolVar]:
         b (Any): The second expression.
 
     Returns:
-        Union[bool, BoolVar]: Whether the first expression is greater than the second.
+        bool | BoolVar: Whether the first expression is greater than the second.
     """
     if aq_types.is_qasm_type(a) or aq_types.is_qasm_type(b):
         return _aq_gt(a, b)
@@ -100,7 +102,7 @@ def _aq_gt(a: Any, b: Any) -> aq_types.BoolVar:
     return result
 
 
-def gteq_(a: Any, b: Any) -> Union[bool, aq_types.BoolVar]:
+def gteq_(a: Any, b: Any) -> bool | aq_types.BoolVar:
     """Functional form of ">=".
 
     Args:
@@ -108,7 +110,7 @@ def gteq_(a: Any, b: Any) -> Union[bool, aq_types.BoolVar]:
         b (Any): The second expression.
 
     Returns:
-        Union[bool, BoolVar]: Whether the first expression is greater than or equal to the second.
+        bool | BoolVar: Whether the first expression is greater than or equal to the second.
     """
     if aq_types.is_qasm_type(a) or aq_types.is_qasm_type(b):
         return _aq_gteq(a, b)

--- a/src/braket/experimental/autoqasm/operators/conditional_expressions.py
+++ b/src/braket/experimental/autoqasm/operators/conditional_expressions.py
@@ -14,8 +14,10 @@
 
 """Operators for conditional expressions (e.g. the ternary if statement)."""
 
+from __future__ import annotations
+
 from collections.abc import Callable
-from typing import Any, Optional
+from typing import Any
 
 import oqpy.base
 
@@ -25,7 +27,7 @@ from braket.experimental.autoqasm.errors import UnsupportedConditionalExpression
 
 
 def if_exp(
-    cond: Any, if_true: Callable[[], Any], if_false: Callable[[], Any], expr_repr: Optional[str]
+    cond: Any, if_true: Callable[[], Any], if_false: Callable[[], Any], expr_repr: str | None
 ) -> Any:
     """Implements a conditional if expression.
 
@@ -33,7 +35,7 @@ def if_exp(
         cond (Any): The condition of the if clause.
         if_true (Callable[[], Any]): The function to run if the condition is true.
         if_false (Callable[[], Any]): The function to run if the condition is false.
-        expr_repr (Optional[str]): The conditional expression represented as a string.
+        expr_repr (str | None): The conditional expression represented as a string.
 
     Returns:
         Any: The value returned from the conditional expression.
@@ -48,8 +50,8 @@ def _oqpy_if_exp(
     cond: Any,
     if_true: Callable[[None], Any],
     if_false: Callable[[None], Any],
-    expr_repr: Optional[str],
-) -> Optional[oqpy.base.Var]:
+    expr_repr: str | None,
+) -> oqpy.base.Var | None:
     """Overload of if_exp that stages an oqpy conditional."""
     result_var = None
     program_conversion_context = aq_program.get_program_conversion_context()

--- a/src/braket/experimental/autoqasm/operators/control_flow.py
+++ b/src/braket/experimental/autoqasm/operators/control_flow.py
@@ -14,8 +14,10 @@
 
 """Operators for control flow constructs (e.g. if, for, while)."""
 
+from __future__ import annotations
+
 from collections.abc import Callable, Iterable
-from typing import Any, Optional, Union
+from typing import Any
 
 import oqpy.base
 
@@ -24,8 +26,8 @@ from braket.experimental.autoqasm.types import Range, is_qasm_type
 
 
 def for_stmt(
-    iter: Union[Iterable, oqpy.Range, oqpy.Qubit],
-    extra_test: Optional[Callable[[], Any]],
+    iter: Iterable | oqpy.Range | oqpy.Qubit,
+    extra_test: Callable[[], Any] | None,
     body: Callable[[Any], None],
     get_state: Any,
     set_state: Any,
@@ -35,8 +37,8 @@ def for_stmt(
     """Implements a for loop.
 
     Args:
-        iter (Union[Iterable, Range, Qubit]): The iterable to be looped over.
-        extra_test (Optional[Callable[[], Any]]): A function to cause the loop to break if true.
+        iter (Iterable | Range | Qubit): The iterable to be looped over.
+        extra_test (Callable[[], Any] | None): A function to cause the loop to break if true.
         body (Callable[[Any], None]): The body of the for loop.
         get_state (Any): Unused.
         set_state (Any): Unused.
@@ -54,7 +56,7 @@ def for_stmt(
 
 
 def _oqpy_for_stmt(
-    iter: Union[oqpy.Range, oqpy.Qubit],
+    iter: oqpy.Range | oqpy.Qubit,
     body: Callable[[Any], None],
     opts: dict,
 ) -> None:

--- a/src/braket/experimental/autoqasm/operators/data_structures.py
+++ b/src/braket/experimental/autoqasm/operators/data_structures.py
@@ -14,9 +14,11 @@
 
 """Operators for other data structures (e.g. list)."""
 
+from __future__ import annotations
+
 import collections
 from collections.abc import Iterable
-from typing import Any, Optional
+from typing import Any
 
 
 class ListPopOpts(collections.namedtuple("ListPopOpts", ("element_dtype", "element_shape"))):
@@ -41,12 +43,12 @@ def list_append(target: list, element: Any) -> list:
     return target
 
 
-def list_pop(target: list, element: Optional[Any], opts: ListPopOpts) -> tuple:
+def list_pop(target: list, element: Any, opts: ListPopOpts) -> tuple:
     """The list pop function.
 
     Args:
         target (list): An entity that supports append semantics.
-        element (Optional[Any]): The element index to pop. If None, pops the last element.
+        element (Any): The element index to pop. If None, pops the last element.
         opts (ListPopOpts): Metadata about the converted pop operation.
 
     Returns:
@@ -69,11 +71,11 @@ def list_stack(target: list, opts: ListStackOpts) -> list:
     return opts.original_call(target)
 
 
-def new_list(iterable: Optional[Iterable] = None) -> list:
+def new_list(iterable: Iterable | None = None) -> list:
     """The list constructor.
 
     Args:
-        iterable (Optional[Iterable]): Optional elements to fill the list with. Defaults to None.
+        iterable (Iterable | None): Optional elements to fill the list with. Defaults to None.
 
     Returns:
         list: A list-like object. The exact return value depends on the initial elements.

--- a/src/braket/experimental/autoqasm/operators/logical.py
+++ b/src/braket/experimental/autoqasm/operators/logical.py
@@ -14,7 +14,9 @@
 
 """Operators for logical boolean operators (e.g. not, and, or)."""
 
-from typing import Any, Callable, Union
+from __future__ import annotations
+
+from typing import Any, Callable
 
 import oqpy.base
 from openpulse import ast
@@ -25,7 +27,7 @@ from braket.experimental.autoqasm import types as aq_types
 from .utils import _register_and_convert_parameters
 
 
-def and_(a: Callable[[], Any], b: Callable[[], Any]) -> Union[bool, aq_types.BoolVar]:
+def and_(a: Callable[[], Any], b: Callable[[], Any]) -> bool | aq_types.BoolVar:
     """Functional form of "and".
 
     Args:
@@ -33,7 +35,7 @@ def and_(a: Callable[[], Any], b: Callable[[], Any]) -> Union[bool, aq_types.Boo
         b (Callable[[], Any]): Callable that returns the second expression.
 
     Returns:
-        Union[bool, BoolVar]: Whether both expressions are true.
+        bool | BoolVar: Whether both expressions are true.
     """
     a = a()
     b = b()
@@ -57,7 +59,7 @@ def _py_and(a: Any, b: Any) -> bool:
     return a and b
 
 
-def or_(a: Callable[[], Any], b: Callable[[], Any]) -> Union[bool, aq_types.BoolVar]:
+def or_(a: Callable[[], Any], b: Callable[[], Any]) -> bool | aq_types.BoolVar:
     """Functional form of "or".
 
     Args:
@@ -65,7 +67,7 @@ def or_(a: Callable[[], Any], b: Callable[[], Any]) -> Union[bool, aq_types.Bool
         b (Callable[[], Any]): Callable that returns the second expression.
 
     Returns:
-        Union[bool, BoolVar]: Whether either expression is true.
+        bool | BoolVar: Whether either expression is true.
     """
     a = a()
     b = b()
@@ -89,14 +91,14 @@ def _py_or(a: Any, b: Any) -> bool:
     return a or b
 
 
-def not_(a: Any) -> Union[bool, aq_types.BoolVar]:
+def not_(a: Any) -> bool | aq_types.BoolVar:
     """Functional form of "not".
 
     Args:
         a (Any): Expression to negate.
 
     Returns:
-        Union[bool, BoolVar]: Whether the expression is false.
+        bool | BoolVar: Whether the expression is false.
     """
     if aq_types.is_qasm_type(a):
         return _oqpy_not(a)
@@ -118,7 +120,7 @@ def _py_not(a: Any) -> bool:
     return not a
 
 
-def eq(a: Any, b: Any) -> Union[bool, aq_types.BoolVar]:
+def eq(a: Any, b: Any) -> bool | aq_types.BoolVar:
     """Functional form of "equal".
 
     Args:
@@ -126,7 +128,7 @@ def eq(a: Any, b: Any) -> Union[bool, aq_types.BoolVar]:
         b (Any): Second expression to compare.
 
     Returns:
-        Union[bool, BoolVar]: Whether the expressions are equal.
+        bool | BoolVar: Whether the expressions are equal.
     """
     if aq_types.is_qasm_type(a) or aq_types.is_qasm_type(b):
         return _oqpy_eq(a, b)
@@ -148,7 +150,7 @@ def _py_eq(a: Any, b: Any) -> bool:
     return a == b
 
 
-def not_eq(a: Any, b: Any) -> Union[bool, aq_types.BoolVar]:
+def not_eq(a: Any, b: Any) -> bool | aq_types.BoolVar:
     """Functional form of "not equal".
 
     Args:
@@ -156,7 +158,7 @@ def not_eq(a: Any, b: Any) -> Union[bool, aq_types.BoolVar]:
         b (Any): Second expression to compare.
 
     Returns:
-        Union[bool, BoolVar]: Whether the expressions are not equal.
+        bool | BoolVar: Whether the expressions are not equal.
     """
     if aq_types.is_qasm_type(a) or aq_types.is_qasm_type(b):
         return _oqpy_not_eq(a, b)

--- a/src/braket/experimental/autoqasm/operators/utils.py
+++ b/src/braket/experimental/autoqasm/operators/utils.py
@@ -14,7 +14,9 @@
 
 "Utility methods for operators."
 
-from typing import Any, Union
+from __future__ import annotations
+
+from typing import Any
 
 from braket.experimental.autoqasm import program
 from braket.experimental.autoqasm import types as aq_types
@@ -22,7 +24,7 @@ from braket.experimental.autoqasm import types as aq_types
 
 def _register_and_convert_parameters(
     *args: tuple[Any],
-) -> Union[list[aq_types.FloatVar], aq_types.FloatVar]:
+) -> list[aq_types.FloatVar] | aq_types.FloatVar:
     """Adds FreeParameters to the program conversion context parameter registry, and
     returns the associated FloatVar objects.
 
@@ -32,7 +34,7 @@ def _register_and_convert_parameters(
     FloatVars are more compatible with the program conversion operations.
 
     Returns:
-        Union[list[FloatVar], FloatVar]: FloatVars for program conversion.
+        list[FloatVar] | FloatVar: FloatVars for program conversion.
     """
     program_conversion_context = program.get_program_conversion_context()
     program_conversion_context.register_args(args)

--- a/src/braket/experimental/autoqasm/program/pragmas.py
+++ b/src/braket/experimental/autoqasm/program/pragmas.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 
 import contextlib
 from enum import Enum
-from typing import Iterable, Optional
+from typing import Iterable
 
 from braket.device_schema import DeviceActionType
 from braket.experimental.autoqasm import errors, program
@@ -46,7 +46,7 @@ class PragmaType(str, Enum):
 
 
 @contextlib.contextmanager
-def verbatim(annotations: Optional[str | Iterable[str]] = None) -> None:
+def verbatim(annotations: str | Iterable[str] | None = None) -> None:
     """Context management protocol that, when used with a `with` statement, wraps the code block
     in a verbatim block.
 
@@ -54,7 +54,7 @@ def verbatim(annotations: Optional[str | Iterable[str]] = None) -> None:
     programmed without compilation or modification of any sort.
 
     Args:
-        annotations (Optional[str | Iterable[str]]): Annotations for the box.
+        annotations (str | Iterable[str] | None): Annotations for the box.
 
     Raises:
         errors.VerbatimBlockNotAllowed: If a verbatim block is not allowed at this point in

--- a/src/braket/experimental/autoqasm/program/serialization_properties.py
+++ b/src/braket/experimental/autoqasm/program/serialization_properties.py
@@ -11,17 +11,17 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass
 class OpenQASMSerializationProperties:
-    auto_defcalgrammar: Optional[bool] = False
+    auto_defcalgrammar: bool | None = False
     """Whether to automatically include defcalgrammar when pulses are used. Default to False."""
 
-    include_externs: Optional[bool] = False
+    include_externs: bool | None = False
     """Whether to include externs. Default to False."""
 
 

--- a/src/braket/experimental/autoqasm/pulse/pulse.py
+++ b/src/braket/experimental/autoqasm/pulse/pulse.py
@@ -14,7 +14,7 @@
 
 """Pulse instructions that apply to frames or qubits."""
 
-from typing import Union
+from __future__ import annotations
 
 import oqpy
 
@@ -143,17 +143,17 @@ def capture_v0(frame: Frame) -> BitVar:
 
 
 def delay(
-    qubits_or_frames: Union[Frame, list[Frame], QubitIdentifierType, list[QubitIdentifierType]],
-    duration: Union[float, oqpy.FloatVar, FreeParameterExpression],
+    qubits_or_frames: Frame | list[Frame] | QubitIdentifierType | list[QubitIdentifierType],
+    duration: float | oqpy.FloatVar | FreeParameterExpression,
 ) -> None:
     """Adds an instruction to advance the frame clock by the specified `duration` value.
 
     Args:
-        qubits_or_frames (Union[Frame, list[Frame], QubitIdentifierType, list[QubitIdentifierType]]):
+        qubits_or_frames (Frame | list[Frame] | QubitIdentifierType | list[QubitIdentifierType]):
             Qubits or frame(s) on which the delay needs to be introduced.
-        duration (Union[float, FloatVar, FreeParameterExpression]): Value (in seconds) defining the
+        duration (float | FloatVar | FreeParameterExpression): Value (in seconds) defining the
             duration of the delay.
-    """  # noqa: E501
+    """
     if not isinstance(qubits_or_frames, list):
         qubits_or_frames = [qubits_or_frames]
     if all(is_qubit_identifier_type(q) for q in qubits_or_frames):
@@ -164,16 +164,16 @@ def delay(
 
 
 def barrier(
-    qubits_or_frames: Union[Frame, list[Frame], QubitIdentifierType, list[QubitIdentifierType]]
+    qubits_or_frames: Frame | list[Frame] | QubitIdentifierType | list[QubitIdentifierType],
 ) -> None:
     """Adds an instruction to align the frame clocks to the latest time across all the specified
     frames. When applied on qubits, it prevents compilations across the barrier, if the compiler
     supports barrier.
 
     Args:
-        qubits_or_frames (Union[Frame, list[Frame], QubitIdentifierType, list[QubitIdentifierType]]):
+        qubits_or_frames (Frame | list[Frame] | QubitIdentifierType | list[QubitIdentifierType]):
             Qubits or frame(s) on which the barrier needs to be introduced.
-    """  # noqa: E501
+    """
     if not isinstance(qubits_or_frames, list):
         qubits_or_frames = [qubits_or_frames]
     if all(is_qubit_identifier_type(q) for q in qubits_or_frames):

--- a/src/braket/experimental/autoqasm/types/conversions.py
+++ b/src/braket/experimental/autoqasm/types/conversions.py
@@ -13,9 +13,11 @@
 
 """Type conversions between Python and the autoqasm representation for types."""
 
+from __future__ import annotations
+
 import typing
 from functools import singledispatch
-from typing import Any, Union
+from typing import Any
 
 import numpy as np
 import oqpy
@@ -77,11 +79,11 @@ def var_type_from_ast_type(ast_type: ast.ClassicalType) -> type:
     raise NotImplementedError
 
 
-def var_type_from_oqpy(expr_or_var: Union[oqpy.base.OQPyExpression, oqpy.base.Var]) -> type:
+def var_type_from_oqpy(expr_or_var: oqpy.base.OQPyExpression | oqpy.base.Var) -> type:
     """Returns the AutoQASM variable type corresponding to the provided OQPy object.
 
     Args:
-        expr_or_var (Union[OQPyExpression, Var]): An OQPy expression or variable.
+        expr_or_var (OQPyExpression | Var): An OQPy expression or variable.
 
     Returns:
         type: The corresponding AutoQASM variable type.
@@ -125,13 +127,13 @@ def _(node: bool):
 
 @wrap_value.register(int)
 @wrap_value.register(np.integer)
-def _(node: Union[int, np.integer]):
+def _(node: int | np.integer):
     return aq_types.IntVar(node)
 
 
 @wrap_value.register(float)
 @wrap_value.register(np.floating)
-def _(node: Union[float, np.floating]):
+def _(node: float | np.floating):
     return aq_types.FloatVar(node)
 
 

--- a/src/braket/experimental/autoqasm/types/types.py
+++ b/src/braket/experimental/autoqasm/types/types.py
@@ -16,7 +16,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import Any, List, Optional, Union, get_args
+from typing import Any, List, Union, get_args
 
 import oqpy
 import oqpy.base
@@ -51,7 +51,7 @@ def is_qasm_type(val: Any) -> bool:
     return isinstance(val, qasm_types)
 
 
-def make_annotations_list(annotations: Optional[str | Iterable[str]]) -> List[str]:
+def make_annotations_list(annotations: str | Iterable[str] | None) -> List[str]:
     return [annotations] if isinstance(annotations, str) else annotations or []
 
 
@@ -76,17 +76,17 @@ class Range(oqpy.Range):
     def __init__(
         self,
         start: int,
-        stop: Optional[int] = None,
-        step: Optional[int] = 1,
-        annotations: Optional[str | Iterable[str]] = None,
+        stop: int | None = None,
+        step: int | None = 1,
+        annotations: str | Iterable[str] | None = None,
     ):
         """Creates a range definition.
 
         Args:
             start (int): Start of the range.
-            stop (Optional[int]): End of the range. Defaults to None.
-            step (Optional[int]): Step of the range. Defaults to 1.
-            annotations (Optional[str | Iterable[str]]): Annotations for the range.
+            stop (int | None): End of the range. Defaults to None.
+            step (int | None): Step of the range. Defaults to 1.
+            annotations (str | Iterable[str] | None): Annotations for the range.
         """
         if stop is None:
             stop = start
@@ -96,7 +96,7 @@ class Range(oqpy.Range):
 
 
 class ArrayVar(oqpy.ArrayVar):
-    def __init__(self, *args, annotations: Optional[str | Iterable[str]] = None, **kwargs):
+    def __init__(self, *args, annotations: str | Iterable[str] | None = None, **kwargs):
         if (
             program.get_program_conversion_context().subroutines_processing
             or not program.get_program_conversion_context().at_function_root_scope
@@ -111,7 +111,7 @@ class ArrayVar(oqpy.ArrayVar):
 
 
 class BitVar(oqpy.BitVar):
-    def __init__(self, *args, annotations: Optional[str | Iterable[str]] = None, **kwargs):
+    def __init__(self, *args, annotations: str | Iterable[str] | None = None, **kwargs):
         super(BitVar, self).__init__(
             *args, annotations=make_annotations_list(annotations), **kwargs
         )
@@ -122,7 +122,7 @@ class BitVar(oqpy.BitVar):
 
 
 class BoolVar(oqpy.BoolVar):
-    def __init__(self, *args, annotations: Optional[str | Iterable[str]] = None, **kwargs):
+    def __init__(self, *args, annotations: str | Iterable[str] | None = None, **kwargs):
         super(BoolVar, self).__init__(
             *args, annotations=make_annotations_list(annotations), **kwargs
         )
@@ -130,7 +130,7 @@ class BoolVar(oqpy.BoolVar):
 
 
 class FloatVar(oqpy.FloatVar):
-    def __init__(self, *args, annotations: Optional[str | Iterable[str]] = None, **kwargs):
+    def __init__(self, *args, annotations: str | Iterable[str] | None = None, **kwargs):
         super(FloatVar, self).__init__(
             *args, annotations=make_annotations_list(annotations), **kwargs
         )
@@ -138,7 +138,7 @@ class FloatVar(oqpy.FloatVar):
 
 
 class IntVar(oqpy.IntVar):
-    def __init__(self, *args, annotations: Optional[str | Iterable[str]] = None, **kwargs):
+    def __init__(self, *args, annotations: str | Iterable[str] | None = None, **kwargs):
         super(IntVar, self).__init__(
             *args, annotations=make_annotations_list(annotations), **kwargs
         )


### PR DESCRIPTION
*Issue #, if available:*
[Convert all AutoQASM code to use new-style Python annotations (via `from __future__ import annotations`)
](https://github.com/orgs/amazon-braket/projects/2/views/1?pane=issue&itemId=57874367)

*Description of changes:*
Replace usage of `Optional` and `Union` in type hints with the more modern syntax.

*Testing done:*
`tox` passes.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
