### PR TITLE
fix: Support single-register measurements in `from_ir`

### DIFF
--- a/src/braket/circuits/braket_program_context.py
+++ b/src/braket/circuits/braket_program_context.py
@@ -167,5 +167,6 @@ class BraketProgramContext(AbstractProgramContext):
         Args:
             target (tuple[int]): the target qubits to be measured.
         """
-        instruction = Instruction(Measure(), list(target))
-        self._circuit.add_instruction(instruction)
+        for index, qubit in enumerate(target):
+            instruction = Instruction(Measure(index=index), qubit)
+            self._circuit.add_instruction(instruction)

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -799,6 +799,24 @@ def test_from_ir_with_measure():
     assert Circuit.from_ir(source=ir.source, inputs=ir.inputs) == expected_circ
 
 
+def test_from_ir_with_single_measure():
+    ir = OpenQasmProgram(
+        source="\n".join(
+            [
+                "OPENQASM 3.0;",
+                "bit[2] b;",
+                "qubit[2] q;",
+                "h q[0];",
+                "cnot q[0], q[1];",
+                "b = measure q;",
+            ]
+        ),
+        inputs={},
+    )
+    expected_circ = Circuit().h(0).cnot(0, 1).measure(0).measure(1)
+    assert Circuit.from_ir(source=ir.source, inputs=ir.inputs) == expected_circ
+
+
 def test_add_with_instruction_with_default(cnot_instr):
     circ = Circuit().add(cnot_instr)
     assert circ == Circuit().add_instruction(cnot_instr)

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -817,6 +817,30 @@ def test_from_ir_with_single_measure():
     assert Circuit.from_ir(source=ir.source, inputs=ir.inputs) == expected_circ
 
 
+def test_from_ir_round_trip_transformation():
+    circuit = Circuit().h(0).cnot(0, 1).measure(0).measure(1)
+    ir = OpenQasmProgram(
+        source="\n".join(
+            [
+                "OPENQASM 3.0;",
+                "bit[2] b;",
+                "qubit[2] q;",
+                "h q[0];",
+                "cnot q[0], q[1];",
+                "b[0] = measure q[0];",
+                "b[1] = measure q[1];",
+            ]
+        ),
+        inputs={},
+    )
+    new_ir = circuit.to_ir("OPENQASM")
+    new_circuit = Circuit.from_ir(new_ir)
+
+    assert new_ir == ir
+    assert Circuit.from_ir(source=ir.source, inputs=ir.inputs) == circuit
+    assert new_circuit == circuit
+
+
 def test_add_with_instruction_with_default(cnot_instr):
     circ = Circuit().add(cnot_instr)
     assert circ == Circuit().add_instruction(cnot_instr)


### PR DESCRIPTION
*Issue #, if available:*
Currently, the statement `b = measure q` in an OpenQASM program results in the following error:

`ValueError: Operator qubit count 1 must be equal to size of target qubit set QubitSet([Qubit(0), Qubit(1)])`

This is because a `measure` instruction is always a 1 qubit instruction but right now, [all the targets get added](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/src/braket/circuits/braket_program_context.py#L170) to the measure instruction even if there are more than 1 qubit measured. 

To reproduce this issue:
```
bell_qasm = """
OPENQASM 3;

qubit[2] q;
bit[2] c;

h q[0];
cnot q[0], q[1];

c = measure q;
"""

from braket.circuits import Circuit
print(Circuit.from_ir(bell_qasm))
```
*Description of changes:*
- Add a loop to add a single measure instruction for each qubit target. 
- Add a test to prevent this error in the future

*Testing done:*
`tox` and `tox -e integ-tests`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
