### PR TITLE
fix: Replace pkg_resources with importlib.metadata

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,7 +1,6 @@
 """Sphinx configuration."""
 
 import datetime
-
 from importlib.metadata import version
 
 # Sphinx configuration below.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -2,11 +2,11 @@
 
 import datetime
 
-import pkg_resources
+from importlib.metadata import version
 
 # Sphinx configuration below.
 project = "amazon-braket-sdk"
-version = pkg_resources.require(project)[0].version
+version = version(project)
 release = version
 copyright = "{}, Amazon.com".format(datetime.datetime.now().year)
 

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         "openpulse",
         "openqasm3",
         "sympy",
+        "backports.entry-points-selectable",
     ],
     extras_require={
         "test": [

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,6 @@ setup(
         "amazon-braket-schemas>=1.21.0",
         "amazon-braket-default-simulator>=1.21.2",
         "oqpy~=0.3.5",
-        "setuptools",
         "backoff",
         "boltons",
         "boto3>=1.28.53",

--- a/src/braket/devices/local_simulator.py
+++ b/src/braket/devices/local_simulator.py
@@ -13,8 +13,8 @@
 
 from __future__ import annotations
 
+import sys
 from functools import singledispatchmethod
-from importlib.metadata import entry_points
 from itertools import repeat
 from multiprocessing import Pool
 from os import cpu_count
@@ -37,6 +37,11 @@ from braket.tasks.analog_hamiltonian_simulation_quantum_task_result import (
 )
 from braket.tasks.local_quantum_task import LocalQuantumTask
 from braket.tasks.local_quantum_task_batch import LocalQuantumTaskBatch
+
+if sys.version_info.minor == 9:
+    from backports.entry_points_selectable import entry_points
+else:
+    from importlib.metadata import entry_points
 
 _simulator_devices = {entry.name: entry for entry in entry_points(group="braket.simulators")}
 

--- a/src/braket/devices/local_simulator.py
+++ b/src/braket/devices/local_simulator.py
@@ -14,12 +14,11 @@
 from __future__ import annotations
 
 from functools import singledispatchmethod
+from importlib.metadata import entry_points
 from itertools import repeat
 from multiprocessing import Pool
 from os import cpu_count
 from typing import Any, Optional, Union
-
-from importlib.metadata import entry_points
 
 from braket.ahs.analog_hamiltonian_simulation import AnalogHamiltonianSimulation
 from braket.annealing.problem import Problem
@@ -39,9 +38,7 @@ from braket.tasks.analog_hamiltonian_simulation_quantum_task_result import (
 from braket.tasks.local_quantum_task import LocalQuantumTask
 from braket.tasks.local_quantum_task_batch import LocalQuantumTaskBatch
 
-_simulator_devices = {
-    entry.name: entry for entry in entry_points(group="braket.simulators")
-}
+_simulator_devices = {entry.name: entry for entry in entry_points(group="braket.simulators")}
 
 
 class LocalSimulator(Device):

--- a/src/braket/devices/local_simulator.py
+++ b/src/braket/devices/local_simulator.py
@@ -19,7 +19,7 @@ from multiprocessing import Pool
 from os import cpu_count
 from typing import Any, Optional, Union
 
-import pkg_resources
+from importlib.metadata import entry_points
 
 from braket.ahs.analog_hamiltonian_simulation import AnalogHamiltonianSimulation
 from braket.annealing.problem import Problem
@@ -40,7 +40,7 @@ from braket.tasks.local_quantum_task import LocalQuantumTask
 from braket.tasks.local_quantum_task_batch import LocalQuantumTaskBatch
 
 _simulator_devices = {
-    entry.name: entry for entry in pkg_resources.iter_entry_points("braket.simulators")
+    entry.name: entry for entry in entry_points(group="braket.simulators")
 }
 
 


### PR DESCRIPTION
*Description of changes:*

`pkg_resources` is deprecated since setuptools > 67.5.  Import in `src/braket/devices/local_simulator.py` would cause the following warning
```
DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
```
It might be good to replace `pkg_resources` with other Python built-in modules, like `importlib.metadata`.


*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
