### PR TITLE
fix: prevent repeated measurements on a qubit

### DIFF
--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -13,6 +13,7 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from collections.abc import Callable, Iterable
 from numbers import Number
 from typing import Any, Optional, TypeVar, Union
@@ -762,10 +763,16 @@ class Circuit:
 
         if target_qubits:
             # Check if the target_qubits are already measured
-            if self._measure_targets and all(
-                target in self._measure_targets for target in target_qubits
+            if (
+                self._measure_targets
+                and any(target in self._measure_targets for target in target_qubits)
+                or len(target_qubits) != len(set(target_qubits))
             ):
-                intersection = set(target_qubits) & set(self._measure_targets)
+                intersection = (
+                    set(target_qubits) & set(self._measure_targets)
+                    if self._measure_targets
+                    else [qubit for qubit, count in Counter(target_qubits).items() if count > 1]
+                )
                 raise ValueError(
                     f"cannot measure the same qubit(s) {', '.join(map(str, intersection))} "
                     "more than once."

--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -763,19 +763,22 @@ class Circuit:
 
         if target_qubits:
             # Check if the target_qubits are already measured
-            if (
-                self._measure_targets
-                and any(target in self._measure_targets for target in target_qubits)
-                or len(target_qubits) != len(set(target_qubits))
+            if self._measure_targets and any(
+                target in self._measure_targets for target in target_qubits
             ):
-                intersection = (
-                    set(target_qubits) & set(self._measure_targets)
-                    if self._measure_targets
-                    else [qubit for qubit, count in Counter(target_qubits).items() if count > 1]
-                )
+                intersection = set(target_qubits) & set(self._measure_targets)
                 raise ValueError(
                     f"cannot measure the same qubit(s) {', '.join(map(str, intersection))} "
                     "more than once."
+                )
+            # Check if there are repeated qubits in the same measurement
+            if len(target_qubits) != len(set(target_qubits)):
+                intersection = [
+                    qubit for qubit, count in Counter(target_qubits).items() if count > 1
+                ]
+                raise ValueError(
+                    f"cannot repeat qubit(s) {', '.join(map(str, intersection))} "
+                    "in the same measurement."
                 )
             self._add_measure(target_qubits=target_qubits)
         else:

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -725,7 +725,7 @@ def test_measure_same_qubit_twice_with_list():
 
 
 def test_measure_same_qubit_twice_with_one_measure():
-    message = "cannot measure the same qubit\\(s\\) 0 more than once."
+    message = "cannot repeat qubit\\(s\\) 0 in the same measurement."
     with pytest.raises(ValueError, match=message):
         Circuit().h(0).cnot(0, 1).measure([0, 0, 0])
 

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -718,6 +718,18 @@ def test_measure_same_qubit_twice():
         Circuit().h(0).cnot(0, 1).measure(0).measure(1).measure(0)
 
 
+def test_measure_same_qubit_twice_with_list():
+    message = "cannot measure the same qubit\\(s\\) 0 more than once."
+    with pytest.raises(ValueError, match=message):
+        Circuit().h(0).cnot(0, 1).measure(0).measure([0, 1])
+
+
+def test_measure_same_qubit_twice_with_one_measure():
+    message = "cannot measure the same qubit\\(s\\) 0 more than once."
+    with pytest.raises(ValueError, match=message):
+        Circuit().h(0).cnot(0, 1).measure([0, 0, 0])
+
+
 def test_measure_empty_measure_after_measure_with_targets():
     message = "cannot measure the same qubit\\(s\\) 0, 1 more than once."
     with pytest.raises(ValueError, match=message):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently, the following circuits are allowed where a qubit appears to be measured more than once:
```
circ = Circuit().h(0).cnot(0, 1).rx(0, 0.9).ry(1, 0.2).measure([0,0,0,0])

circ = Circuit().h(0).cnot(0, 1).measure([1]).measure([0,1])
```
A qubit can only be measured once so we should raise an error for repeated qubits in a measure instruction.


*Testing done:*
`tox` and `tox -e integ-tests`
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
