### PR TITLE
doc: Improve gphase unitary matrix definition in docstring

### DIFF
--- a/src/braket/circuits/gates.py
+++ b/src/braket/circuits/gates.py
@@ -278,7 +278,7 @@ class GPhase(AngledGate):
         `negctrl @ gphase(λ) q = x q; ctrl @ gphase(λ) q; x q`.
 
         Unitary matrix:
-    
+
             .. math:: \mathtt{gphase}(\gamma) = e^{i \gamma} I = \begin{bmatrix}
                         e^{i \gamma} & 0 \\
                         0 & e^{i \gamma} \end{bmatrix}.

--- a/src/braket/circuits/gates.py
+++ b/src/braket/circuits/gates.py
@@ -220,7 +220,9 @@ class GPhase(AngledGate):
 
     Unitary matrix:
 
-        .. math:: \mathtt{gphase}(\gamma) = e^(i \gamma) I_1.
+        .. math:: \mathtt{gphase}(\gamma) = e^{i \gamma} I = \begin{bmatrix}
+                    e^{i \gamma} & 0 \\
+                    0 & e^{i \gamma} \end{bmatrix}.
 
     Args:
         angle (Union[FreeParameterExpression, float]): angle in radians.
@@ -276,8 +278,10 @@ class GPhase(AngledGate):
         `negctrl @ gphase(λ) q = x q; ctrl @ gphase(λ) q; x q`.
 
         Unitary matrix:
-
-            .. math:: \mathtt{gphase}(\gamma) = e^(i \gamma) I_1.
+    
+            .. math:: \mathtt{gphase}(\gamma) = e^{i \gamma} I = \begin{bmatrix}
+                        e^{i \gamma} & 0 \\
+                        0 & e^{i \gamma} \end{bmatrix}.
 
         Args:
             angle (Union[FreeParameterExpression, float]): Phase in radians.


### PR DESCRIPTION
*Issue #, if available:*
LaTeX rendering is incorrect for gphase unitary matrix definition.

see: https://amazon-braket-sdk-python.readthedocs.io/en/latest/_apidoc/braket.circuits.gates.html#braket.circuits.gates.GPhase
![image](https://github.com/amazon-braket/amazon-braket-sdk-python/assets/3620100/1c70e23a-4df6-439d-86ab-f862d4502ad5)

*Description of changes:*
Fix LaTeX markup. Also add full matrix definition for consistency with other gates. With these changes, it looks like:
![image](https://github.com/amazon-braket/amazon-braket-sdk-python/assets/3620100/bcf9f80f-2e0c-4b77-bf29-308a8133cea8)

*Testing done:*
Validated rendered docs from PR output.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
