### PR TITLE
doc: correct gphase matrix representation

### DIFF
--- a/src/braket/circuits/gates.py
+++ b/src/braket/circuits/gates.py
@@ -220,9 +220,8 @@ class GPhase(AngledGate):
 
     Unitary matrix:
 
-        .. math:: \mathtt{gphase}(\gamma) = e^{i \gamma} I = \begin{bmatrix}
-                    e^{i \gamma} & 0 \\
-                    0 & e^{i \gamma} \end{bmatrix}.
+        .. math:: \mathtt{gphase}(\gamma) = e^{i \gamma} I_1 = \begin{bmatrix}
+                    e^{i \gamma} \end{bmatrix}.
 
     Args:
         angle (Union[FreeParameterExpression, float]): angle in radians.
@@ -279,9 +278,8 @@ class GPhase(AngledGate):
 
         Unitary matrix:
 
-            .. math:: \mathtt{gphase}(\gamma) = e^{i \gamma} I = \begin{bmatrix}
-                        e^{i \gamma} & 0 \\
-                        0 & e^{i \gamma} \end{bmatrix}.
+            .. math:: \mathtt{gphase}(\gamma) = e^{i \gamma} I_1 = \begin{bmatrix}
+                        e^{i \gamma} \end{bmatrix}.
 
         Args:
             angle (Union[FreeParameterExpression, float]): Phase in radians.


### PR DESCRIPTION
*Issue #, if available:*
Fixing a documentation mistake in #944.

*Description of changes:*
Represent global phase as a 1x1 matrix rather than 2x2.

*Testing done:*
Verifying rendered docs for PR.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
