### PR TITLE
fix: add measure qubit targets in braket_program_context

### DIFF
--- a/src/braket/circuits/braket_program_context.py
+++ b/src/braket/circuits/braket_program_context.py
@@ -170,3 +170,7 @@ class BraketProgramContext(AbstractProgramContext):
         for index, qubit in enumerate(target):
             instruction = Instruction(Measure(index=index), qubit)
             self._circuit.add_instruction(instruction)
+            if self._circuit._measure_targets:
+                self._circuit._measure_targets.append(qubit)
+            else:
+                self._circuit._measure_targets = [qubit]

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -839,18 +839,14 @@ def test_from_ir_round_trip_transformation():
                 "qubit[2] q;",
                 "h q[0];",
                 "cnot q[0], q[1];",
-                "b[0] = measure q[0];",
-                "b[1] = measure q[1];",
+                "b = measure q;",
             ]
         ),
         inputs={},
     )
-    new_ir = circuit.to_ir("OPENQASM")
-    new_circuit = Circuit.from_ir(new_ir)
 
-    assert new_ir == ir
-    assert Circuit.from_ir(source=ir.source, inputs=ir.inputs) == circuit
-    assert new_circuit == circuit
+    assert Circuit.from_ir(ir) == Circuit.from_ir(circuit.to_ir("OPENQASM"))
+    assert circuit.to_ir("OPENQASM") == Circuit.from_ir(ir).to_ir("OPENQASM")
 
 
 def test_add_with_instruction_with_default(cnot_instr):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently, when a measure instruction is added in `braket_program_context.py` it is not added to the circuit's `measure_targets` which results in measure instructions getting added twice. 

*Changes made*
- `addMeasure` will now add the qubit targets to the Circuit's `measure_targets`
- updated the round trip test to properly check that the OpenQASM ir gets translated correctly

To reproduce the issue this solves:
```
qasm = """
OPENQASM 3.0;

def ghz(int[32] n) {
    h q[0];
    for int i in [0:n - 1] {
        cnot q[i], q[i + 1];
    }
}

int[32] n = 5;
bit[n + 1] c;
qubit[n + 1] q;

ghz(n);

c = measure q;
"""
circuit = Circuit.from_ir(qasm)
print(sv1.run(circuit, shots=1000).result().measurement_counts)
```
returns a ValidationException: `An error occurred (ValidationException) when calling the CreateQuantumTask operation: [line 16] qubit q[0] is already measured or captured. Cannot perform a new operation on it`
since the measurements are added twice.


*Testing done:*
`tox` and `tox -e integ-tests`

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
