### PR TITLE
feat: Raise an error when an AutoQASM program is nested inside another program

### DIFF
--- a/src/braket/experimental/autoqasm/errors.py
+++ b/src/braket/experimental/autoqasm/errors.py
@@ -118,3 +118,7 @@ class UnsupportedSubroutineReturnType(AutoQasmError):
 
 class NameConflict(AutoQasmError):
     """Name conflict between user-named variables."""
+
+
+class NestedMainProgramError(AutoQasmError):
+    """Main program nested inside another main program."""

--- a/src/braket/experimental/autoqasm/transpiler/transpiler.py
+++ b/src/braket/experimental/autoqasm/transpiler/transpiler.py
@@ -121,7 +121,6 @@ class PyToOqpy(transpiler.PyToPy):
             Lambda | FunctionDef: The root of the transformed AST.
         """
         unsupported_features_checker.verify(node)
-        # TODO (#809): add forbidden_aq_program_usage_checker.verify(node)
         node = self._initial_analysis(node, ctx)
 
         # autograph converters

--- a/test/unit_tests/braket/experimental/autoqasm/test_api.py
+++ b/test/unit_tests/braket/experimental/autoqasm/test_api.py
@@ -1055,9 +1055,8 @@ def test_direct_subroutine_call_no_args():
         bell()
 
 
-@pytest.mark.xfail(reason="(#809) will fix by adding a checker to the transpiler")
 def test_main_from_main():
-    """Can't call main from main!"""
+    """Can't build main from within another main!"""
 
     @aq.main(num_qubits=2)
     def bell(q0: int, q1: int) -> None:
@@ -1066,9 +1065,9 @@ def test_main_from_main():
 
     @aq.main
     def main():
-        bell(0, 1)
+        bell.build()
 
-    with pytest.raises(errors.AutoQasmTypeError):
+    with pytest.raises(errors.NestedMainProgramError):
         main.build()
 
 


### PR DESCRIPTION
*Issue #, if available:*
#809 

*Description of changes:*
Raise a `NestedMainProgramError` if the user attempts to build an AutoQASM program from within the context of another AutoQASM program.

*Testing done:*
`tox` passes. Test previously marked `xfail` is now passing.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
