### PR TITLE
from_ir method for AnalogHamiltonianSimulation #971

### DIFF
--- a/test/unit_tests/braket/ahs/test_analog_hamiltonian_simulation.py
+++ b/test/unit_tests/braket/ahs/test_analog_hamiltonian_simulation.py
@@ -103,6 +103,21 @@ def test_to_ir_invalid_hamiltonian(register):
     ahs.to_ir()
 
 
+def test_from_ir(register, driving_field, local_detuning):
+    hamiltonian = driving_field + local_detuning
+    ahs = AnalogHamiltonianSimulation(register=register, hamiltonian=hamiltonian)
+    problem = json.loads(ahs.to_ir().json())
+    assert ahs == AnalogHamiltonianSimulation.from_ir(Program(setup=problem['setup'], hamiltonian=problem['hamiltonian']))
+
+
+def test_from_ir_empty():
+    hamiltonian = Mock()
+    hamiltonian.terms = []
+    ahs = AnalogHamiltonianSimulation(register=AtomArrangement(), hamiltonian=hamiltonian)
+    problem = json.loads(ahs.to_ir().json())
+    assert ahs == AnalogHamiltonianSimulation.from_ir(Program(setup=problem['setup'], hamiltonian=problem['hamiltonian']))
+
+
 @pytest.mark.xfail(raises=DiscretizationError)
 def test_invalid_action():
     action = Mock()


### PR DESCRIPTION
*Issue #, if available:*
#971 
*Description of changes:*
Add `from_ir` method for AnalogHamiltonianSimulation
*Testing done:*
Ini order to test `from_ir` an `__equal__` method is added to check if two instances of an `AnalogHamiltonianSimulation` object are the same.
## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ x] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
