### PR TITLE
fix: Error when FreeParameters are named QASM types

### DIFF
--- a/src/braket/parametric/free_parameter.py
+++ b/src/braket/parametric/free_parameter.py
@@ -20,8 +20,8 @@ from sympy import Symbol
 
 from braket.parametric.free_parameter_expression import FreeParameterExpression
 
-PREDEFINED_VARIABLE_NAMES = ["b", "q"]
-QASM_RESERVED_WORDS = [
+PREDEFINED_VARIABLE_NAMES = {"b", "q"}
+QASM_RESERVED_WORDS = {
     "OPENQASM",
     "include",
     "defcalgrammar",
@@ -74,7 +74,7 @@ QASM_RESERVED_WORDS = [
     "barrier",
     "true",
     "false",
-]
+}
 
 
 class FreeParameter(FreeParameterExpression):
@@ -152,12 +152,12 @@ class FreeParameter(FreeParameterExpression):
             raise ValueError("FreeParameter names must start with a letter or an underscore")
         if name in PREDEFINED_VARIABLE_NAMES:
             raise ValueError(
-                f"FreeParameter names must not be one of predefined variables: "
+                f"FreeParameter names must not be one of the Braket reserved variable names: "
                 f"{PREDEFINED_VARIABLE_NAMES}."
             )
         if name in QASM_RESERVED_WORDS:
             raise ValueError(
-                f"FreeParameter names must not be one of qasm reserved words: "
+                f"FreeParameter names must not be one of the OpenQASM or OpenPulse keywords: "
                 f"{QASM_RESERVED_WORDS}."
             )
         self._name = Symbol(name)

--- a/src/braket/parametric/free_parameter.py
+++ b/src/braket/parametric/free_parameter.py
@@ -152,11 +152,13 @@ class FreeParameter(FreeParameterExpression):
             raise ValueError("FreeParameter names must start with a letter or an underscore")
         if name in PREDEFINED_VARIABLE_NAMES:
             raise ValueError(
-                f"FreeParameter names must not be one of predefined variables: {PREDEFINED_VARIABLE_NAMES}."
+                f"FreeParameter names must not be one of predefined variables: "
+                f"{PREDEFINED_VARIABLE_NAMES}."
             )
         if name in QASM_RESERVED_WORDS:
             raise ValueError(
-                f"FreeParameter names must not be one of qasm reserved words: {QASM_RESERVED_WORDS}."
+                f"FreeParameter names must not be one of qasm reserved words: "
+                f"{QASM_RESERVED_WORDS}."
             )
         self._name = Symbol(name)
 

--- a/src/braket/parametric/free_parameter.py
+++ b/src/braket/parametric/free_parameter.py
@@ -20,6 +20,62 @@ from sympy import Symbol
 
 from braket.parametric.free_parameter_expression import FreeParameterExpression
 
+PREDEFINED_VARIABLE_NAMES = ["b", "q"]
+QASM_RESERVED_WORDS = [
+    "OPENQASM",
+    "include",
+    "defcalgrammar",
+    "def",
+    "cal",
+    "defcal",
+    "gate",
+    "extern",
+    "box",
+    "let",
+    "break",
+    "continue",
+    "if",
+    "else",
+    "end",
+    "return",
+    "for",
+    "while",
+    "in",
+    "pragma",
+    "input",
+    "output",
+    "const",
+    "readonly",
+    "mutable",
+    "qreg",
+    "qubit",
+    "creg",
+    "bool",
+    "bit",
+    "int",
+    "uint",
+    "float",
+    "angle",
+    "complex",
+    "array",
+    "void",
+    "duration",
+    "stretch",
+    "gphase",
+    "inv",
+    "pow",
+    "ctrl",
+    "negctrl",
+    "dim",
+    "durationof",
+    "delay",
+    "reset",
+    "measure",
+    "barrier",
+    "true",
+    "false",
+]
+
 
 class FreeParameter(FreeParameterExpression):
     """Class 'FreeParameter'
@@ -94,6 +150,14 @@ class FreeParameter(FreeParameterExpression):
             raise TypeError("FreeParameter names must be strings")
         if not name[0].isalpha() and name[0] != "_":
             raise ValueError("FreeParameter names must start with a letter or an underscore")
+        if name in PREDEFINED_VARIABLE_NAMES:
+            raise ValueError(
+                f"FreeParameter names must not be one of predefined variables: {PREDEFINED_VARIABLE_NAMES}."
+            )
+        if name in QASM_RESERVED_WORDS:
+            raise ValueError(
+                f"FreeParameter names must not be one of qasm reserved words: {QASM_RESERVED_WORDS}."
+            )
         self._name = Symbol(name)
 
     def to_dict(self) -> dict:

--- a/src/braket/parametric/free_parameter.py
+++ b/src/braket/parametric/free_parameter.py
@@ -21,6 +21,10 @@ from sympy import Symbol
 from braket.parametric.free_parameter_expression import FreeParameterExpression
 
 PREDEFINED_VARIABLE_NAMES = {"b", "q"}
+
+# The reserved words are picked from below
+# https://github.com/openqasm/openqasm/blob/main/source/grammar/qasm3Lexer.g4
+# https://github.com/openqasm/openpulse-python/blob/main/source/grammar/openpulseLexer.g4
 QASM_RESERVED_WORDS = {
     "OPENQASM",
     "include",
@@ -74,6 +78,9 @@ QASM_RESERVED_WORDS = {
     "barrier",
     "true",
     "false",
+    "waveform",
+    "port",
+    "frame",
 }
 
 

--- a/test/unit_tests/braket/circuits/test_ascii_circuit_diagram.py
+++ b/test/unit_tests/braket/circuits/test_ascii_circuit_diagram.py
@@ -741,19 +741,19 @@ def test_noise_multi_probabilities():
 
 def test_noise_multi_probabilities_with_parameter():
     a = FreeParameter("a")
-    b = FreeParameter("b")
     c = FreeParameter("c")
-    circ = Circuit().h(0).x(1).pauli_channel(1, a, b, c)
+    d = FreeParameter("d")
+    circ = Circuit().h(0).x(1).pauli_channel(1, a, c, d)
     expected = (
         "T  : |     0     |",
         "                  ",
         "q0 : -H-----------",
         "                  ",
-        "q1 : -X-PC(a,b,c)-",
+        "q1 : -X-PC(a,c,d)-",
         "",
         "T  : |     0     |",
         "",
-        "Unassigned parameters: [a, b, c].",
+        "Unassigned parameters: [a, c, d].",
     )
     _assert_correct_diagram(circ, expected)
 

--- a/test/unit_tests/braket/circuits/test_gates.py
+++ b/test/unit_tests/braket/circuits/test_gates.py
@@ -1069,8 +1069,8 @@ def test_bind_values_pulse_gate():
     frame = Frame("user_frame", Port("device_port_x", 1e-9), 1e9)
     gate = Gate.PulseGate(
         PulseSequence()
-        .set_frequency(frame, FreeParameter("a") + FreeParameter("b"))
-        .delay(frame, FreeParameter("c")),
+        .set_frequency(frame, FreeParameter("a") + FreeParameter("c"))
+        .delay(frame, FreeParameter("d")),
         qubit_count,
     )
 
@@ -1084,8 +1084,8 @@ def test_bind_values_pulse_gate():
     assert a_bound_ir == "\n".join(
         [
             "cal {",
-            "    set_frequency(user_frame, 3.0 + b);",
-            "    delay[c * 1s] user_frame;",
+            "    set_frequency(user_frame, 3.0 + c);",
+            "    delay[d * 1s] user_frame;",
             "}",
         ]
     )

--- a/test/unit_tests/braket/circuits/test_noises.py
+++ b/test/unit_tests/braket/circuits/test_noises.py
@@ -483,10 +483,10 @@ def test_parameter_binding(parameterized_noise, params, expected_noise):
 
 
 def test_parameterized_noise():
-    noise = Noise.PauliChannel(FreeParameter("a"), 0.2, FreeParameter("b"))
+    noise = Noise.PauliChannel(FreeParameter("a"), 0.2, FreeParameter("d"))
     assert noise.probX == FreeParameter("a")
     assert noise.probY == 0.2
-    assert noise.probZ == FreeParameter("b")
+    assert noise.probZ == FreeParameter("d")
 
 
 # Additional Unitary noise tests

--- a/test/unit_tests/braket/circuits/test_unicode_circuit_diagram.py
+++ b/test/unit_tests/braket/circuits/test_unicode_circuit_diagram.py
@@ -853,20 +853,20 @@ def test_noise_multi_probabilities():
 
 def test_noise_multi_probabilities_with_parameter():
     a = FreeParameter("a")
-    b = FreeParameter("b")
     c = FreeParameter("c")
-    circ = Circuit().h(0).x(1).pauli_channel(1, a, b, c)
+    d = FreeParameter("d")
+    circ = Circuit().h(0).x(1).pauli_channel(1, a, c, d)
     expected = (
         "T  : │         0         │",
         "      ┌───┐               ",
         "q0 : ─┤ H ├───────────────",
         "      └───┘               ",
         "      ┌───┐ ┌───────────┐ ",
-        "q1 : ─┤ X ├─┤ PC(a,b,c) ├─",
+        "q1 : ─┤ X ├─┤ PC(a,c,d) ├─",
         "      └───┘ └───────────┘ ",
         "T  : │         0         │",
         "",
-        "Unassigned parameters: [a, b, c].",
+        "Unassigned parameters: [a, c, d].",
     )
     _assert_correct_diagram(circ, expected)
 

--- a/test/unit_tests/braket/parametric/test_free_parameter.py
+++ b/test/unit_tests/braket/parametric/test_free_parameter.py
@@ -67,3 +67,19 @@ def test_sub_successful(free_parameter):
 
 def test_sub_wrong_param(free_parameter):
     assert free_parameter.subs({"alpha": 1}) == FreeParameter("theta")
+
+
+@pytest.mark.parametrize("param_name", ["for", "qubit"])
+def test_error_raised_when_reserved_keyword_used(param_name):
+    with pytest.raises(
+        ValueError, match="FreeParameter names must not be one of qasm reserved words:"
+    ):
+        FreeParameter(param_name)
+
+
+@pytest.mark.parametrize("param_name", ["b", "q"])
+def test_error_raised_when_predefined_variable_used(param_name):
+    with pytest.raises(
+        ValueError, match="FreeParameter names must not be one of predefined variables:"
+    ):
+        FreeParameter(param_name)

--- a/test/unit_tests/braket/parametric/test_free_parameter.py
+++ b/test/unit_tests/braket/parametric/test_free_parameter.py
@@ -72,7 +72,8 @@ def test_sub_wrong_param(free_parameter):
 @pytest.mark.parametrize("param_name", ["for", "qubit"])
 def test_error_raised_when_reserved_keyword_used(param_name):
     with pytest.raises(
-        ValueError, match="FreeParameter names must not be one of qasm reserved words:"
+        ValueError,
+        match="FreeParameter names must not be one of the OpenQASM or OpenPulse keywords: ",
     ):
         FreeParameter(param_name)
 
@@ -80,6 +81,7 @@ def test_error_raised_when_reserved_keyword_used(param_name):
 @pytest.mark.parametrize("param_name", ["b", "q"])
 def test_error_raised_when_predefined_variable_used(param_name):
     with pytest.raises(
-        ValueError, match="FreeParameter names must not be one of predefined variables:"
+        ValueError,
+        match="FreeParameter names must not be one of the Braket reserved variable names: ",
     ):
         FreeParameter(param_name)

--- a/test/unit_tests/braket/parametric/test_free_parameter_expression.py
+++ b/test/unit_tests/braket/parametric/test_free_parameter_expression.py
@@ -165,7 +165,7 @@ def test_sub_return_expression():
 @pytest.mark.parametrize(
     "param, kwargs, expected_value, expected_type",
     [
-        (FreeParameter("a") + 2 * FreeParameter("b"), {"a": 0.1, "b": 0.3}, 0.7, float),
+        (FreeParameter("a") + 2 * FreeParameter("d"), {"a": 0.1, "d": 0.3}, 0.7, float),
         (FreeParameter("x"), {"y": 1}, FreeParameter("x"), FreeParameter),
         (FreeParameter("y"), {"y": -0.1}, -0.1, float),
         (2 * FreeParameter("i"), {"i": 1}, 2.0, float),

--- a/test/unit_tests/braket/pulse/test_pulse_sequence.py
+++ b/test/unit_tests/braket/pulse/test_pulse_sequence.py
@@ -81,7 +81,7 @@ def test_pulse_sequence_with_user_defined_frame(user_defined_frame):
 
 
 def test_pulse_sequence_make_bound_pulse_sequence(predefined_frame_1, predefined_frame_2):
-    param = FreeParameter("a") + 2 * FreeParameter("b")
+    param = FreeParameter("a") + 2 * FreeParameter("c")
     pulse_sequence = (
         PulseSequence()
         .set_frequency(predefined_frame_1, param)
@@ -135,14 +135,14 @@ def test_pulse_sequence_make_bound_pulse_sequence(predefined_frame_1, predefined
             " sigma_dg * 1s, 0.2, 1, false);",
             "    waveform constant_wf = constant(length_c * 1s, 2.0 + 0.3im);",
             "    waveform arb_wf = {1.0 + 0.4im, 0, 0.3, 0.1 + 0.2im};",
-            "    set_frequency(predefined_frame_1, a + 2.0 * b);",
-            "    shift_frequency(predefined_frame_1, a + 2.0 * b);",
-            "    set_phase(predefined_frame_1, a + 2.0 * b);",
-            "    shift_phase(predefined_frame_1, -1.0 * a + -2.0 * b);",
-            "    set_scale(predefined_frame_1, a + 2.0 * b);",
+            "    set_frequency(predefined_frame_1, a + 2.0 * c);",
+            "    shift_frequency(predefined_frame_1, a + 2.0 * c);",
+            "    set_phase(predefined_frame_1, a + 2.0 * c);",
+            "    shift_phase(predefined_frame_1, -1.0 * a + -2.0 * c);",
+            "    set_scale(predefined_frame_1, a + 2.0 * c);",
             "    psb[0] = capture_v0(predefined_frame_1);",
-            "    delay[(a + 2.0 * b) * 1s] predefined_frame_1, predefined_frame_2;",
-            "    delay[(a + 2.0 * b) * 1s] predefined_frame_1;",
+            "    delay[(a + 2.0 * c) * 1s] predefined_frame_1, predefined_frame_2;",
+            "    delay[(a + 2.0 * c) * 1s] predefined_frame_1;",
             "    delay[1.0ms] predefined_frame_1;",
             "    barrier predefined_frame_1, predefined_frame_2;",
             "    play(predefined_frame_1, gauss_wf);",
@@ -156,7 +156,7 @@ def test_pulse_sequence_make_bound_pulse_sequence(predefined_frame_1, predefined
     assert pulse_sequence.to_ir() == expected_str_unbound
     assert pulse_sequence.parameters == {
         FreeParameter("a"),
-        FreeParameter("b"),
+        FreeParameter("c"),
         FreeParameter("length_g"),
         FreeParameter("length_dg"),
         FreeParameter("sigma_g"),
@@ -164,9 +164,9 @@ def test_pulse_sequence_make_bound_pulse_sequence(predefined_frame_1, predefined
         FreeParameter("length_c"),
     }
     b_bound = pulse_sequence.make_bound_pulse_sequence(
-        {"b": 2, "length_g": 1e-3, "length_dg": 3e-3, "sigma_dg": 0.4, "length_c": 4e-3}
+        {"c": 2, "length_g": 1e-3, "length_dg": 3e-3, "sigma_dg": 0.4, "length_c": 4e-3}
     )
-    b_bound_call = pulse_sequence(b=2, length_g=1e-3, length_dg=3e-3, sigma_dg=0.4, length_c=4e-3)
+    b_bound_call = pulse_sequence(c=2, length_g=1e-3, length_dg=3e-3, sigma_dg=0.4, length_c=4e-3)
     expected_str_b_bound = "\n".join(
         [
             "OPENQASM 3.0;",


### PR DESCRIPTION
*Issue:* Fixes #603 

*Description of changes:*
- The choice of name in `FreeParameter` is restricted now. Any _**SDK predefined variables**_ or _**OpenQasm reserved identifiers**_ cannot be used to as names of `FreeParameter`.
- OpenQasm reserved identifiers are picked from the grammar documentation of [OpenQasm](https://github.com/openqasm/openqasm/blob/main/source/grammar/qasm3Lexer.g4) and [OpenPulse](https://github.com/openqasm/openpulse-python/blob/main/source/grammar/openpulseLexer.g4). Only words from below sections are picked as it is more likely that user might use such names.
  - Language keywords
  - Types
  - Builtin identifiers and operations

*Testing done:*
Unit test has been added.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [X] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [X] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
