### PR TITLE
feat: add off_center to erf_square

### DIFF
--- a/src/braket/pulse/waveforms.py
+++ b/src/braket/pulse/waveforms.py
@@ -510,7 +510,7 @@ class ErfSquareWaveform(Waveform, Parameterizable):
         length: Union[float, FreeParameterExpression],
         width: Union[float, FreeParameterExpression],
         sigma: Union[float, FreeParameterExpression],
-        off_center: Union[float, FreeParameterExpression],
+        off_center: Union[float, FreeParameterExpression] = 0,
         amplitude: Union[float, FreeParameterExpression] = 1,
         zero_at_edges: bool = False,
         id: Optional[str] = None,
@@ -532,7 +532,7 @@ class ErfSquareWaveform(Waveform, Parameterizable):
                 the edges rise and fall.
             off_center (Union[float, FreeParameterExpression]): Shift the smoothed square waveform
                 earlier or later in time. When positive, the smoothed square is shifted later
-                (to the right), otherwise earlier (to the left).
+                (to the right), otherwise earlier (to the left). Defaults to 0.
             amplitude (Union[float, FreeParameterExpression]): The amplitude of the waveform
                 envelope. Defaults to 1.
             zero_at_edges (bool): Whether the waveform is scaled such that it has zero value at the

--- a/test/unit_tests/braket/pulse/ast/test_approximation_parser.py
+++ b/test/unit_tests/braket/pulse/ast/test_approximation_parser.py
@@ -696,7 +696,7 @@ def test_play_drag_gaussian_waveforms(port):
 def test_play_erf_square_waveforms(port):
     frame1 = Frame(frame_id="frame1", port=port, frequency=1e8, phase=0, is_predefined=False)
     erf_square_wf_ZaE_False = ErfSquareWaveform(
-        length=1e-8, width=8e-9, sigma=1e-9, amplitude=0.8, zero_at_edges=False
+        length=1e-8, width=8e-9, sigma=1e-9, off_center=0.0, amplitude=0.8, zero_at_edges=False
     )
     pulse_seq = PulseSequence().play(frame1, erf_square_wf_ZaE_False)
 
@@ -733,7 +733,7 @@ def test_play_erf_square_waveforms(port):
 def test_play_erf_square_waveforms_zero_at_edges(port):
     frame1 = Frame(frame_id="frame1", port=port, frequency=1e8, phase=0, is_predefined=False)
     erf_square_wf_ZaE_True = ErfSquareWaveform(
-        length=1e-8, width=8e-9, sigma=1e-9, amplitude=0.8, zero_at_edges=True
+        length=1e-8, width=8e-9, sigma=1e-9, off_center=0.0, amplitude=0.8, zero_at_edges=True
     )
     pulse_seq = PulseSequence().play(frame1, erf_square_wf_ZaE_True)
 
@@ -750,6 +750,43 @@ def test_play_erf_square_waveforms_zero_at_edges(port):
             complex(0.7979691964131336),
             complex(0.731709291296886),
             complex(0.36585464564844294),
+        ],
+        dtype=np.complex128,
+    )
+
+    expected_amplitudes = {"frame1": TimeSeries()}
+    expected_frequencies = {"frame1": TimeSeries()}
+    expected_phases = {"frame1": TimeSeries()}
+
+    for t, v in zip(times, values):
+        expected_amplitudes["frame1"].put(t, v)
+        expected_frequencies["frame1"].put(t, 1e8)
+        expected_phases["frame1"].put(t, 0)
+
+    parser = _ApproximationParser(program=pulse_seq._program, frames=to_dict(frame1))
+    verify_results(parser, expected_amplitudes, expected_frequencies, expected_phases)
+
+
+def test_play_erf_square_waveforms_off_center(port):
+    frame1 = Frame(frame_id="frame1", port=port, frequency=1e8, phase=0, is_predefined=False)
+    erf_square_wf_ZaE_False = ErfSquareWaveform(
+        length=1e-8, width=8e-9, sigma=1e-9, off_center=-2e-9, amplitude=0.8, zero_at_edges=False
+    )
+    pulse_seq = PulseSequence().play(frame1, erf_square_wf_ZaE_False)
+
+    times = np.arange(0, 1e-8, port.dt)
+    values = np.array(
+        [
+            complex(0.7370803285436436),
+            complex(0.7981289183125405),
+            complex(0.7999911761342559),
+            complex(0.8),
+            complex(0.7999911761342559),
+            complex(0.7981289183125405),
+            complex(0.7370803285436436),
+            complex(0.4000000061669036),
+            complex(0.0629196837901632),
+            complex(0.0018710940212660543),
         ],
         dtype=np.complex128,
     )

--- a/test/unit_tests/braket/pulse/test_pulse_sequence.py
+++ b/test/unit_tests/braket/pulse/test_pulse_sequence.py
@@ -18,6 +18,7 @@ from braket.pulse import (
     ArbitraryWaveform,
     ConstantWaveform,
     DragGaussianWaveform,
+    ErfSquareWaveform,
     Frame,
     GaussianWaveform,
     Port,
@@ -119,6 +120,16 @@ def test_pulse_sequence_make_bound_pulse_sequence(predefined_frame_1, predefined
             predefined_frame_2,
             ArbitraryWaveform([complex(1, 0.4), 0, 0.3, complex(0.1, 0.2)], id="arb_wf"),
         )
+        .play(
+            predefined_frame_1,
+            ErfSquareWaveform(
+                length=FreeParameter("length_es"),
+                width=FreeParameter("width_es"),
+                sigma=2e-9,
+                off_center=8e-9,
+                id="erf_square_wf",
+            ),
+        )
         .capture_v0(predefined_frame_2)
     )
     expected_str_unbound = "\n".join(
@@ -135,6 +146,8 @@ def test_pulse_sequence_make_bound_pulse_sequence(predefined_frame_1, predefined
             " sigma_dg * 1s, 0.2, 1, false);",
             "    waveform constant_wf = constant(length_c * 1s, 2.0 + 0.3im);",
             "    waveform arb_wf = {1.0 + 0.4im, 0, 0.3, 0.1 + 0.2im};",
+            "    waveform erf_square_wf = erf_square(length_es * 1s, width_es * 1s, 2.0ns,"
+            " 8.0ns, 1, false);",
             "    set_frequency(predefined_frame_1, a + 2.0 * c);",
             "    shift_frequency(predefined_frame_1, a + 2.0 * c);",
             "    set_phase(predefined_frame_1, a + 2.0 * c);",
@@ -149,6 +162,7 @@ def test_pulse_sequence_make_bound_pulse_sequence(predefined_frame_1, predefined
             "    play(predefined_frame_2, drag_gauss_wf);",
             "    play(predefined_frame_1, constant_wf);",
             "    play(predefined_frame_2, arb_wf);",
+            "    play(predefined_frame_1, erf_square_wf);",
             "    psb[1] = capture_v0(predefined_frame_2);",
             "}",
         ]
@@ -162,11 +176,29 @@ def test_pulse_sequence_make_bound_pulse_sequence(predefined_frame_1, predefined
         FreeParameter("sigma_g"),
         FreeParameter("sigma_dg"),
         FreeParameter("length_c"),
+        FreeParameter("width_es"),
+        FreeParameter("length_es"),
     }
     b_bound = pulse_sequence.make_bound_pulse_sequence(
-        {"c": 2, "length_g": 1e-3, "length_dg": 3e-3, "sigma_dg": 0.4, "length_c": 4e-3}
+        {
+            "c": 2,
+            "length_g": 1e-3,
+            "length_dg": 3e-3,
+            "sigma_dg": 0.4,
+            "length_c": 4e-3,
+            "length_es": 20e-9,
+            "width_es": 12e-9,
+        }
     )
-    b_bound_call = pulse_sequence(c=2, length_g=1e-3, length_dg=3e-3, sigma_dg=0.4, length_c=4e-3)
+    b_bound_call = pulse_sequence(
+        c=2,
+        length_g=1e-3,
+        length_dg=3e-3,
+        sigma_dg=0.4,
+        length_c=4e-3,
+        length_es=20e-9,
+        width_es=12e-9,
+    )
     expected_str_b_bound = "\n".join(
         [
             "OPENQASM 3.0;",
@@ -177,6 +209,7 @@ def test_pulse_sequence_make_bound_pulse_sequence(predefined_frame_1, predefined
             "    waveform drag_gauss_wf = drag_gaussian(3.0ms, 400.0ms, 0.2, 1, false);",
             "    waveform constant_wf = constant(4.0ms, 2.0 + 0.3im);",
             "    waveform arb_wf = {1.0 + 0.4im, 0, 0.3, 0.1 + 0.2im};",
+            "    waveform erf_square_wf = erf_square(20.0ns, 12.0ns, 2.0ns, 8.0ns, 1, false);",
             "    set_frequency(predefined_frame_1, a + 4.0);",
             "    shift_frequency(predefined_frame_1, a + 4.0);",
             "    set_phase(predefined_frame_1, a + 4.0);",
@@ -191,6 +224,7 @@ def test_pulse_sequence_make_bound_pulse_sequence(predefined_frame_1, predefined
             "    play(predefined_frame_2, drag_gauss_wf);",
             "    play(predefined_frame_1, constant_wf);",
             "    play(predefined_frame_2, arb_wf);",
+            "    play(predefined_frame_1, erf_square_wf);",
             "    psb[1] = capture_v0(predefined_frame_2);",
             "}",
         ]
@@ -209,6 +243,7 @@ def test_pulse_sequence_make_bound_pulse_sequence(predefined_frame_1, predefined
             "    waveform drag_gauss_wf = drag_gaussian(3.0ms, 400.0ms, 0.2, 1, false);",
             "    waveform constant_wf = constant(4.0ms, 2.0 + 0.3im);",
             "    waveform arb_wf = {1.0 + 0.4im, 0, 0.3, 0.1 + 0.2im};",
+            "    waveform erf_square_wf = erf_square(20.0ns, 12.0ns, 2.0ns, 8.0ns, 1, false);",
             "    set_frequency(predefined_frame_1, 5.0);",
             "    shift_frequency(predefined_frame_1, 5.0);",
             "    set_phase(predefined_frame_1, 5.0);",
@@ -223,6 +258,7 @@ def test_pulse_sequence_make_bound_pulse_sequence(predefined_frame_1, predefined
             "    play(predefined_frame_2, drag_gauss_wf);",
             "    play(predefined_frame_1, constant_wf);",
             "    play(predefined_frame_2, arb_wf);",
+            "    play(predefined_frame_1, erf_square_wf);",
             "    psb[1] = capture_v0(predefined_frame_2);",
             "}",
         ]
@@ -302,6 +338,16 @@ def test_pulse_sequence_to_ir(predefined_frame_1, predefined_frame_2):
             predefined_frame_2,
             ArbitraryWaveform([complex(1, 0.4), 0, 0.3, complex(0.1, 0.2)], id="arb_wf"),
         )
+        .play(
+            predefined_frame_1,
+            ErfSquareWaveform(
+                length=32e-9,
+                width=20e-9,
+                sigma=2e-9,
+                off_center=8e-9,
+                id="erf_square_wf",
+            ),
+        )
         .capture_v0(predefined_frame_2)
     )
     expected_str = "\n".join(
@@ -313,6 +359,7 @@ def test_pulse_sequence_to_ir(predefined_frame_1, predefined_frame_2):
             "    waveform drag_gauss_wf = drag_gaussian(3.0ms, 400.0ms, 0.2, 1, false);",
             "    waveform constant_wf = constant(4.0ms, 2.0 + 0.3im);",
             "    waveform arb_wf = {1.0 + 0.4im, 0, 0.3, 0.1 + 0.2im};",
+            "    waveform erf_square_wf = erf_square(32.0ns, 20.0ns, 2.0ns, 8.0ns, 1, false);",
             "    set_frequency(predefined_frame_1, 3000000000.0);",
             "    shift_frequency(predefined_frame_1, 1000000000.0);",
             "    set_phase(predefined_frame_1, -0.5);",
@@ -328,6 +375,7 @@ def test_pulse_sequence_to_ir(predefined_frame_1, predefined_frame_2):
             "    play(predefined_frame_2, drag_gauss_wf);",
             "    play(predefined_frame_1, constant_wf);",
             "    play(predefined_frame_2, arb_wf);",
+            "    play(predefined_frame_1, erf_square_wf);",
             "    psb[1] = capture_v0(predefined_frame_2);",
             "}",
         ]


### PR DESCRIPTION
*Description of changes:*
Add an `off_center` parameter to allow offsetting the smoothed square toward left or right in a erf_square waveform.

*Testing done:*
tox

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
