### PR TITLE
change: Return observable target if absent for RT

### DIFF
--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -319,8 +319,8 @@ class Circuit:
             observable = Circuit._extract_observable(result_type_to_add)
             # We can skip this for now for AdjointGradient (the only subtype of this
             # type) because AdjointGradient can only be used when `shots=0`, and the
-            # qubit_observable_mapping is used to generate basis rotation instrunctions
-            # and make sure the observables are simultaneously commuting for `shots>0` mode.
+            # qubit_observable_mapping is used to generate basis rotation instructions
+            # and make sure the observables mutually commute for `shots>0` mode.
             supports_basis_rotation_instructions = not isinstance(
                 result_type_to_add, ObservableParameterResultType
             )

--- a/src/braket/circuits/observable.py
+++ b/src/braket/circuits/observable.py
@@ -40,20 +40,18 @@ class Observable(QuantumOperator):
         self, qubit_count: int, ascii_symbols: Sequence[str], targets: QubitSetInput | None = None
     ):
         super().__init__(qubit_count=qubit_count, ascii_symbols=ascii_symbols)
-        if targets is not None:
-            targets = QubitSet(targets)
+        targets = QubitSet(targets)
+        if targets:
             if (num_targets := len(targets)) != qubit_count:
                 raise ValueError(
                     f"Length of target {num_targets} does not match qubit count {qubit_count}"
                 )
-            self._targets = targets
-        else:
-            self._targets = None
+        self._targets = targets
         self._coef = 1
 
     def _unscaled(self) -> Observable:
         return Observable(
-            qubit_count=self.qubit_count, ascii_symbols=self.ascii_symbols, targets=self.targets
+            qubit_count=self.qubit_count, ascii_symbols=self.ascii_symbols, targets=self._targets
         )
 
     def to_ir(
@@ -207,7 +205,7 @@ class Observable(QuantumOperator):
     def __repr__(self) -> str:
         return (
             f"{self.name}('qubit_count': {self._qubit_count})"
-            if self._targets is None
+            if not self._targets
             else f"{self.name}('qubit_count': {self._qubit_count}, 'target': {self._targets})"
         )
 

--- a/src/braket/circuits/observables.py
+++ b/src/braket/circuits/observables.py
@@ -322,9 +322,9 @@ class TensorProduct(Observable):
             f"{'@'.join([obs.ascii_symbols[0] for obs in unscaled_factors])}"
         )
         all_targets = [factor.targets for factor in unscaled_factors]
-        if all(targets is None for targets in all_targets):
-            merged_targets = None
-        elif all(targets is not None for targets in all_targets):
+        if not any(all_targets):
+            merged_targets = QubitSet()
+        elif all(all_targets):
             flat_targets = [qubit for target in all_targets for qubit in target]
             merged_targets = QubitSet(flat_targets)
             if len(merged_targets) != len(flat_targets):

--- a/src/braket/circuits/observables.py
+++ b/src/braket/circuits/observables.py
@@ -508,9 +508,9 @@ class Sum(Observable):
         self._summands = tuple(flattened_observables)
         qubit_count = max(flattened_observables, key=lambda obs: obs.qubit_count).qubit_count
         all_targets = [observable.targets for observable in flattened_observables]
-        if all(targets is None for targets in all_targets):
-            targets = None
-        elif all(targets is not None for targets in all_targets):
+        if not any(all_targets):
+            targets = QubitSet()
+        elif all(all_targets):
             targets = all_targets
         else:
             raise ValueError("Cannot mix terms with and without targets")

--- a/src/braket/circuits/result_type.py
+++ b/src/braket/circuits/result_type.py
@@ -243,7 +243,7 @@ class ObservableResultType(ResultType):
 
     @property
     def target(self) -> QubitSet:
-        return self._target
+        return self._target or self._observable.targets
 
     @target.setter
     def target(self, target: QubitSetInput) -> None:

--- a/src/braket/circuits/result_types.py
+++ b/src/braket/circuits/result_types.py
@@ -218,7 +218,7 @@ class AdjointGradient(ObservableParameterResultType):
 
     def _to_openqasm(self, serialization_properties: OpenQASMSerializationProperties) -> str:
         observable_ir = self.observable.to_ir(
-            target=self.target,
+            target=self._target,
             ir_type=IRType.OPENQASM,
             serialization_properties=serialization_properties,
         )
@@ -477,7 +477,7 @@ class Expectation(ObservableResultType):
 
     def _to_openqasm(self, serialization_properties: OpenQASMSerializationProperties) -> str:
         observable_ir = self.observable.to_ir(
-            target=self.target,
+            target=self._target,
             ir_type=IRType.OPENQASM,
             serialization_properties=serialization_properties,
         )
@@ -552,7 +552,7 @@ class Sample(ObservableResultType):
 
     def _to_openqasm(self, serialization_properties: OpenQASMSerializationProperties) -> str:
         observable_ir = self.observable.to_ir(
-            target=self.target,
+            target=self._target,
             ir_type=IRType.OPENQASM,
             serialization_properties=serialization_properties,
         )
@@ -632,7 +632,7 @@ class Variance(ObservableResultType):
 
     def _to_openqasm(self, serialization_properties: OpenQASMSerializationProperties) -> str:
         observable_ir = self.observable.to_ir(
-            target=self.target,
+            target=self._target,
             ir_type=IRType.OPENQASM,
             serialization_properties=serialization_properties,
         )

--- a/test/unit_tests/braket/circuits/test_result_type.py
+++ b/test/unit_tests/braket/circuits/test_result_type.py
@@ -18,6 +18,7 @@ from braket.circuits import Observable, ObservableResultType, ResultType
 from braket.circuits.free_parameter import FreeParameter
 from braket.circuits.result_type import ObservableParameterResultType
 from braket.circuits.serialization import IRType
+from braket.registers import QubitSet
 
 
 @pytest.fixture
@@ -166,6 +167,15 @@ def test_obs_rt_repr():
         str(a1)
         == "ObservableResultType(observable=X('qubit_count': 1), target=QubitSet([Qubit(0)]))"
     )
+
+
+def test_obs_rt_target():
+    assert ObservableResultType(
+        ascii_symbols=["Obs"], observable=Observable.X(), target=1
+    ).target == QubitSet(1)
+    assert ObservableResultType(
+        ascii_symbols=["Obs"], observable=Observable.X(1)
+    ).target == QubitSet(1)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Also changed `Observable` to teturn `QubitSet` for absent observable target

*Issue #, if available:*

*Description of changes:*

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
