### PR TITLE
fix: Pass through inputs for SerializableProgram simulation

### DIFF
--- a/src/braket/devices/local_simulator.py
+++ b/src/braket/devices/local_simulator.py
@@ -290,8 +290,9 @@ class LocalSimulator(Device):
         return program
 
     @_construct_payload.register
-    def _(self, program: SerializableProgram, _inputs, _shots):
-        return OpenQASMProgram(source=program.to_ir(ir_type=IRType.OPENQASM))
+    def _(self, program: SerializableProgram, inputs: Optional[dict[str, float]], _shots):
+        inputs_copy = inputs.copy() if inputs is not None else {}
+        return OpenQASMProgram(source=program.to_ir(ir_type=IRType.OPENQASM), inputs=inputs_copy)
 
     @_construct_payload.register
     def _(self, program: AnalogHamiltonianSimulation, _inputs, _shots):

--- a/test/unit_tests/braket/devices/test_local_simulator.py
+++ b/test/unit_tests/braket/devices/test_local_simulator.py
@@ -588,13 +588,30 @@ def test_run_serializable_program_model():
             source="""
 qubit[2] q;
 bit[2] c;
-
 h q[0];
 cnot q[0], q[1];
-
 c = measure q;
 """
         )
+    )
+    assert task.result() == GateModelQuantumTaskResult.from_object(GATE_MODEL_RESULT)
+
+
+def test_run_serializable_program_model_with_inputs():
+    dummy = DummySerializableProgramSimulator()
+    sim = LocalSimulator(dummy)
+    task = sim.run(
+        DummySerializableProgram(
+            source="""
+input float a;
+qubit[2] q;
+bit[2] c;
+h q[0];
+cnot q[0], q[1];
+c = measure q;
+"""
+        ),
+        inputs={"a": 0.1},
     )
     assert task.result() == GateModelQuantumTaskResult.from_object(GATE_MODEL_RESULT)
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Properly pass through `inputs` when simulating a `SerializableProgram` instance.

*Testing done:*
`tox` passes.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
