### PR TITLE
fix: increase timeout for tasks to avoid async polling timeout during…

### DIFF
--- a/test/unit_tests/braket/aws/test_aws_quantum_task.py
+++ b/test/unit_tests/braket/aws/test_aws_quantum_task.py
@@ -91,7 +91,7 @@ def quantum_task_quiet(aws_session):
 
 @pytest.fixture
 def circuit_task(aws_session):
-    return AwsQuantumTask("foo:bar:arn", aws_session, poll_timeout_seconds=2)
+    return AwsQuantumTask("foo:bar:arn", aws_session, poll_timeout_seconds=4)
 
 
 @pytest.fixture


### PR DESCRIPTION
… testing

*Issue #, if available:*

*Description of changes:*
On windows, async tasks hit the timeout (2 seconds). This gives more time for resources to free up and process the changes.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
