### PR TITLE
fix: Update AwsQuantumTask.__init__ signature

### DIFF
--- a/src/braket/_sdk/_version.py
+++ b/src/braket/_sdk/_version.py
@@ -15,4 +15,4 @@
 Version number (major.minor.patch[-label])
 """
 
-__version__ = "1.90.0"
+__version__ = "1.90.1.dev0"

--- a/src/braket/aws/aws_quantum_task.py
+++ b/src/braket/aws/aws_quantum_task.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+import warnings
 from functools import singledispatch
 from logging import Logger, getLogger
 from typing import Any, ClassVar, Optional, Union
@@ -233,7 +234,6 @@ class AwsQuantumTask(QuantumTask):
         poll_interval_seconds: float = DEFAULT_RESULTS_POLL_INTERVAL,
         logger: Logger = getLogger(__name__),
         quiet: bool = False,
-        *args,
         **kwargs,
     ):
         """Initializes an `AwsQuantumTask`.
@@ -262,6 +262,11 @@ class AwsQuantumTask(QuantumTask):
             >>> result = task.result()
             GateModelQuantumTaskResult(...)
         """
+        if kwargs:
+            warnings.warn(
+                f"AwsQuantumTask.__init__ received unknown keyword args: {list(kwargs.keys())}"
+            )
+
         self._arn: str = arn
         self._aws_session: AwsSession = aws_session or AwsQuantumTask._aws_session_for_task_arn(
             task_arn=arn

--- a/src/braket/aws/aws_quantum_task.py
+++ b/src/braket/aws/aws_quantum_task.py
@@ -233,6 +233,8 @@ class AwsQuantumTask(QuantumTask):
         poll_interval_seconds: float = DEFAULT_RESULTS_POLL_INTERVAL,
         logger: Logger = getLogger(__name__),
         quiet: bool = False,
+        *args,
+        **kwargs,
     ):
         """Initializes an `AwsQuantumTask`.
 

--- a/test/unit_tests/braket/aws/test_aws_quantum_task.py
+++ b/test/unit_tests/braket/aws/test_aws_quantum_task.py
@@ -15,6 +15,7 @@ import asyncio
 import json
 import threading
 import time
+import warnings
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -202,6 +203,17 @@ def test_id_getter(arn, aws_session):
 @pytest.mark.xfail(raises=AttributeError)
 def test_no_id_setter(quantum_task):
     quantum_task.id = 123
+
+
+def test_no_unknown_kwargs_no_warnings(arn, aws_session):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        AwsQuantumTask(arn, aws_session)
+
+
+def test_unknown_kwarg_warning(arn, aws_session):
+    with pytest.warns(UserWarning):
+        AwsQuantumTask(arn, aws_session, unknown_kwarg=123)
 
 
 def test_metadata(quantum_task):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Prevent `AwsQuantumTask.__init__` from throwing an exception if additional `kwargs` are passed in. One downstream scenario this unblocks is in Qiskit-Braket provider, which passes through `kwargs` from the Qiskit layer, some of which may be unknown to the Braket SDK. (Specifically, when using the Braket backend for `EstimatorV2` in Qiskit, an unknown kwarg `seed_simulator` is passed - which blocks that use case. Thanks to @speller26 for debugging and flagging this.)

*Testing done:*
`tox` passes. Also verified the Braket backend from Qiskit-Braket provider works correctly when used with Qiskit's `EstimatorV2`.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
