### PR TITLE
fix: Set user agent in Boto3 config object

### DIFF
--- a/src/braket/aws/aws_session.py
+++ b/src/braket/aws/aws_session.py
@@ -72,7 +72,10 @@ class AwsSession:
                 f"Braket Client region is '{braket_client.meta.region_name}'."
             )
 
-        self._config = config
+        self._update_user_agent()
+        self._config = Config(user_agent_extra=self._braket_user_agents)
+        if config:
+            self._config = self._config.merge(config)
 
         if braket_client:
             self.boto_session = boto_session or boto3.Session(
@@ -86,14 +89,10 @@ class AwsSession:
             self.braket_client = self.boto_session.client(
                 "braket", config=self._config, endpoint_url=os.environ.get("BRAKET_ENDPOINT")
             )
-        self._update_user_agent()
         self._custom_default_bucket = bool(default_bucket)
         self._default_bucket = default_bucket or os.environ.get("AMZN_BRAKET_OUT_S3_BUCKET")
         self.braket_client.meta.events.register(
             "before-sign.braket.CreateQuantumTask", self._add_cost_tracker_count_handler
-        )
-        self.braket_client.meta.events.register(
-            "before-sign.braket", self._add_braket_user_agents_handler
         )
 
         self._iam = None
@@ -201,14 +200,11 @@ class AwsSession:
         if user_agent not in self._braket_user_agents:
             self._braket_user_agents = f"{self._braket_user_agents} {user_agent}"
 
-    def _add_braket_user_agents_handler(self, request: awsrequest.AWSRequest, **kwargs) -> None:
-        try:
-            initial_user_agent = request.headers["User-Agent"]
-            request.headers.replace_header(
-                "User-Agent", f"{initial_user_agent} {self._braket_user_agents}"
-            )
-        except KeyError:
-            request.headers.add_header("User-Agent", self._braket_user_agents)
+        new_user_agent_config = Config(user_agent_extra=self._braket_user_agents)
+        updated_config = self.braket_client._client_config.merge(new_user_agent_config)
+        self.braket_client = self.boto_session.client(
+            "braket", config=updated_config, endpoint_url=os.environ.get("BRAKET_ENDPOINT")
+        )
 
     @staticmethod
     def _add_cost_tracker_count_handler(request: awsrequest.AWSRequest, **kwargs) -> None:

--- a/src/braket/aws/aws_session.py
+++ b/src/braket/aws/aws_session.py
@@ -78,13 +78,16 @@ class AwsSession:
             self._config = self._config.merge(config)
 
         if braket_client:
-            if braket_client._client_config:
-                self._config = self._config.merge(braket_client._client_config)
-            braket_client._client_config = self._config
+            braket_client._client_config = (
+                self._config.merge(braket_client._client_config)
+                if braket_client._client_config
+                else self._config
+            )
             self.boto_session = boto_session or boto3.Session(
                 region_name=braket_client.meta.region_name
             )
             self.braket_client = braket_client
+            self._config = braket_client._client_config
         else:
             self.boto_session = boto_session or boto3.Session(
                 region_name=os.environ.get("AWS_REGION")

--- a/src/braket/aws/aws_session.py
+++ b/src/braket/aws/aws_session.py
@@ -76,13 +76,10 @@ class AwsSession:
         self._config = Config(user_agent_extra=self._braket_user_agents)
         if config:
             self._config = self._config.merge(config)
-        if braket_client and braket_client._client_config:
-            self._config = self._config.merge(braket_client._client_config)
-
-        if self._config._user_provided_options["user_agent_extra"]:
-            self._braket_user_agents = self._config._user_provided_options["user_agent_extra"]
 
         if braket_client:
+            if braket_client._client_config:
+                self._config = self._config.merge(braket_client._client_config)
             braket_client._client_config = self._config
             self.boto_session = boto_session or boto3.Session(
                 region_name=braket_client.meta.region_name
@@ -95,6 +92,7 @@ class AwsSession:
             self.braket_client = self.boto_session.client(
                 "braket", config=self._config, endpoint_url=os.environ.get("BRAKET_ENDPOINT")
             )
+        self._braket_user_agents = self._config._user_provided_options["user_agent_extra"]
         self._custom_default_bucket = bool(default_bucket)
         self._default_bucket = default_bucket or os.environ.get("AMZN_BRAKET_OUT_S3_BUCKET")
         self.braket_client.meta.events.register(

--- a/test/unit_tests/braket/aws/test_aws_session.py
+++ b/test/unit_tests/braket/aws/test_aws_session.py
@@ -44,9 +44,18 @@ def boto_session():
 
 
 @pytest.fixture
+def boto_config():
+    _boto_config = Mock()
+    _boto_config._user_provided_options = {}
+    return _boto_config
+
+
+@pytest.fixture
 def braket_client():
     _braket_client = Mock()
     _braket_client.meta.region_name = "us-west-2"
+    _braket_client._client_config = Mock()
+    _braket_client._client_config._user_provided_options = {}
     return _braket_client
 
 
@@ -167,31 +176,31 @@ def throttling_response():
 
 
 def test_initializes_boto_client_if_required(boto_session):
-    AwsSession(boto_session=boto_session)
-    boto_session.client.assert_any_call("braket", config=None, endpoint_url=None)
+    aws_session = AwsSession(boto_session=boto_session)
+    boto_session.client.assert_any_call("braket", config=aws_session._config, endpoint_url=None)
 
 
-def test_user_supplied_braket_client():
+def test_user_supplied_braket_client(boto_config):
     boto_session = Mock()
     boto_session.region_name = "foobar"
     braket_client = Mock()
     braket_client.meta.region_name = "foobar"
+    braket_client._client_config = boto_config
     aws_session = AwsSession(boto_session=boto_session, braket_client=braket_client)
     assert aws_session.braket_client == braket_client
 
 
 @patch.dict("os.environ", {"BRAKET_ENDPOINT": "some-endpoint"})
-def test_config(boto_session):
-    config = Mock()
-    AwsSession(boto_session=boto_session, config=config)
+def test_config(boto_session, boto_config):
+    aws_session = AwsSession(boto_session=boto_session, config=boto_config)
     boto_session.client.assert_any_call(
         "braket",
-        config=config,
+        config=aws_session._config,
         endpoint_url="some-endpoint",
     )
 
 
-def test_region():
+def test_region(boto_config):
     boto_region = "boto-region"
     braket_region = "braket-region"
 
@@ -199,6 +208,7 @@ def test_region():
     boto_session.region_name = boto_region
     braket_client = Mock()
     braket_client.meta.region_name = braket_region
+    braket_client._client_config = boto_config
 
     assert (
         AwsSession(
@@ -270,40 +280,27 @@ def test_ecr(aws_session):
 
 
 @patch("os.path.exists")
-@pytest.mark.parametrize(
-    "metadata_file_exists, initial_user_agent",
-    [
-        (True, None),
-        (False, None),
-        (True, ""),
-        (False, ""),
-        (True, "Boto3/1.17.18 Python/3.7.10"),
-        (False, "Boto3/1.17.18 Python/3.7.10 exec-env/AWS_Lambda_python3.7"),
-    ],
-)
-def test_populates_user_agent(os_path_exists_mock, metadata_file_exists, initial_user_agent):
+@pytest.mark.parametrize("metadata_file_exists", [True, False])
+def test_populates_user_agent(os_path_exists_mock, metadata_file_exists, boto_config):
     request = Mock()
     request.headers = HTTPMessage()
     boto_session = Mock()
     boto_session.region_name = "foobar"
     braket_client = Mock()
     braket_client.meta.region_name = "foobar"
+    braket_client._client_config = boto_config
+
     nbi_metadata_path = "/opt/ml/metadata/resource-metadata.json"
     os_path_exists_mock.return_value = metadata_file_exists
     aws_session = AwsSession(boto_session=boto_session, braket_client=braket_client)
+    os_path_exists_mock.assert_called_with(nbi_metadata_path)
+
     expected_user_agent = (
         f"BraketSdk/{braket_sdk.__version__} "
         f"BraketSchemas/{braket_schemas.__version__} "
         f"NotebookInstance/{0 if metadata_file_exists else None}"
     )
-    os_path_exists_mock.assert_called_with(nbi_metadata_path)
-
-    if initial_user_agent is not None:
-        request.headers.add_header("User-Agent", initial_user_agent)
-        expected_user_agent = f"{initial_user_agent} {expected_user_agent}"
-
-    aws_session._add_braket_user_agents_handler(request)
-    assert request.headers.get("User-Agent") == expected_user_agent
+    assert aws_session._braket_user_agents == expected_user_agent
 
 
 @patch("braket.aws.aws_session.active_trackers")
@@ -317,7 +314,7 @@ def test_add_cost_tracker_count(active_trackers_mock, aws_session):
     request.headers.add_header.assert_called_with("Braket-Trackers", "0")
 
 
-def test_retrieve_s3_object_body_success(boto_session):
+def test_retrieve_s3_object_body_success(boto_session, boto_config):
     bucket_name = "braket-integ-test"
     filename = "tasks/test_task_1.json"
 
@@ -332,16 +329,14 @@ def test_retrieve_s3_object_body_success(boto_session):
     mock_read_object.decode.return_value = json.dumps(TEST_S3_OBJ_CONTENTS)
     json.dumps(TEST_S3_OBJ_CONTENTS)
 
-    aws_session = AwsSession(boto_session=boto_session)
+    aws_session = AwsSession(boto_session=boto_session, config=None)
     return_value = aws_session.retrieve_s3_object_body(bucket_name, filename)
     assert return_value == json.dumps(TEST_S3_OBJ_CONTENTS)
-    boto_session.resource.assert_called_with("s3", config=None)
+    boto_session.resource.assert_called_with("s3", config=aws_session._config)
 
-    config = Mock()
-    AwsSession(boto_session=boto_session, config=config).retrieve_s3_object_body(
-        bucket_name, filename
-    )
-    boto_session.resource.assert_called_with("s3", config=config)
+    aws_session = AwsSession(boto_session=boto_session, config=boto_config)
+    aws_session.retrieve_s3_object_body(bucket_name, filename)
+    boto_session.resource.assert_called_with("s3", config=aws_session._config)
 
 
 @pytest.mark.xfail(raises=ClientError)
@@ -1324,13 +1319,13 @@ def test_get_log_events(aws_session, next_token):
 @patch("boto3.Session")
 def test_copy_session(boto_session_init, aws_session):
     boto_session_init.return_value = Mock()
-    aws_session._braket_user_agents = "foo/bar"
+    aws_session.add_braket_user_agent("foo/bar")
     copied_session = AwsSession.copy_session(aws_session, "us-west-2")
     boto_session_init.assert_called_with(
         region_name="us-west-2",
         profile_name="test-profile",
     )
-    assert copied_session._braket_user_agents == "foo/bar"
+    assert "foo/bar" in copied_session._braket_user_agents
     assert copied_session._default_bucket is None
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
A change in botocore v1.37.4 (https://github.com/boto/botocore/pull/3389) results in the Braket custom user agent strings being overwritten. This change sets the Braket custom user agent strings in the Boto3 config object, which prevents it from getting overwritten when Boto3 rebuilds its user agent string.

*Testing done:*
`tox`. Also verified that user agent integration tests, which were failing before this change, are now passing.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
