### PR TITLE
infra: ignore linter error PLC0207 to unblock CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ lint.ignore = [
   "N803",    # Allow uppercase
   "N806",    # Vars will break this rule based on technical names.
   "N815",    # Allowing reviwers to do a per case basis
+  "PLC0207", # Accessing only the first or last element of `str.split()` without setting `maxsplit=1`
   "PLC2701", # Allow private function access in code
   "PLR0913", # Too many variables in function
   "PLR0914", # Too many local variables


### PR DESCRIPTION
*Issue #, if available:*
`ruff` has started failing on `main` with these errors:
```
src/braket/aws/aws_session.py:871:20: PLC0207 Accessing only the first or last element of `str.split()` without setting `maxsplit=1`
    |
869 |             str: Verbose image tag for given image.
870 |         """
871 |         registry = image_uri.split(".")[0]
    |                    ^^^^^^^^^^^^^^^^^^^^^^^ PLC0207
872 |         repository, tag = image_uri.split("/")[-1].split(":")
    |

src/braket/aws/aws_session.py:872:27: PLC0207 Accessing only the first or last element of `str.split()` without setting `maxsplit=1`
    |
870 |         """
871 |         registry = image_uri.split(".")[0]
872 |         repository, tag = image_uri.split("/")[-1].split(":")
    |                           ^^^^^^^^^^^^^^^^^^^^^^^^ PLC0207
873 |
874 |         # get image digest of latest image
    |
```

*Description of changes:*
Ignore that error, since it was not introduced by any recent code change.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
