### PR TITLE
fix:  Fix applying readout error with ObservableResultType and MeasureCriteria

### DIFF
--- a/src/braket/circuits/angled_gate.py
+++ b/src/braket/circuits/angled_gate.py
@@ -367,7 +367,7 @@ def _angles_equal(
 
 
 @_angles_equal.register
-def _(angle_1: FreeParameterExpression, angle_2: FreeParameterExpression):  # noqa: FURB118
+def _(angle_1: FreeParameterExpression, angle_2: FreeParameterExpression):
     return angle_1 == angle_2
 
 

--- a/src/braket/circuits/noise_model/noise_model.py
+++ b/src/braket/circuits/noise_model/noise_model.py
@@ -25,6 +25,7 @@ from braket.circuits.noise_model.circuit_instruction_criteria import CircuitInst
 from braket.circuits.noise_model.criteria import Criteria, CriteriaKey, CriteriaKeyResult
 from braket.circuits.noise_model.initialization_criteria import InitializationCriteria
 from braket.circuits.noise_model.measure_criteria import MeasureCriteria
+from braket.circuits.noise_model.observable_criteria import ObservableCriteria
 from braket.circuits.noise_model.result_type_criteria import ResultTypeCriteria
 from braket.circuits.result_types import ObservableResultType
 from braket.registers.qubit_set import QubitSetInput
@@ -421,7 +422,10 @@ def _apply_noise_on_observable_result_types(
         if isinstance(result_type, ObservableResultType):
             target_qubits = list(result_type.target)
             for item_index, item in enumerate(readout_noise_instructions):
-                if item.criteria.result_type_matches(result_type):
+                item_criteria = item.criteria
+                if isinstance(
+                    item_criteria, ObservableCriteria
+                ) and item_criteria.result_type_matches(result_type):
                     for target_qubit in target_qubits:
                         noise_to_apply[target_qubit].add(item_index)
     for qubit in noise_to_apply:

--- a/test/unit_tests/braket/circuits/noise/test_noise_model.py
+++ b/test/unit_tests/braket/circuits/noise/test_noise_model.py
@@ -574,3 +574,13 @@ def test_apply_readout_noise_result_type_only():
     # Also test that result types on other qubits are not affected
     for instr in noisy_circuit.instructions:
         assert not (isinstance(instr.operator, BitFlip) and instr.target == [1])
+
+def test_measurecriteria_for_circuit_with_observable_resulttype():
+    noise_model = NoiseModel()
+    noise_model.add_noise(BitFlip(0.1), MeasureCriteria(qubits=[0]))
+
+    circ = Circuit().h(0).sample(observable=Observable.Z())
+    print(circ)
+    noisy_circuit = noise_model.apply(circ)
+
+    assert noisy_circuit == circ  # no effect

--- a/test/unit_tests/braket/circuits/noise/test_noise_model.py
+++ b/test/unit_tests/braket/circuits/noise/test_noise_model.py
@@ -580,7 +580,6 @@ def test_measurecriteria_for_circuit_with_observable_resulttype():
     noise_model.add_noise(BitFlip(0.1), MeasureCriteria(qubits=[0]))
 
     circ = Circuit().h(0).sample(observable=Observable.Z())
-    print(circ)
     noisy_circuit = noise_model.apply(circ)
 
     assert noisy_circuit == circ  # no effect


### PR DESCRIPTION
*Issue #, if available:*
Today, when a noise model with MeasureCriteria is applied to a circuit with ObservableResultType, we got an error

```
from braket.circuits import Circuit, Observable
from braket.circuits.noise_model import NoiseModel, MeasureCriteria
from braket.circuits.noises import BitFlip

noise_model = NoiseModel()
noise_model.add_noise(BitFlip(0.1), MeasureCriteria(qubits=[0]))

circ = Circuit().h(0).sample(observable=Observable.Z())
print(circ)
noisy_circuit = noise_model.apply(circ)
```
gives
```
T  : │  0  │Result Types │
      ┌───┐ ┌───────────┐ 
q0 : ─┤ H ├─┤ Sample(Z) ├─
      └───┘ └───────────┘ 
T  : │  0  │Result Types │

...
AttributeError: 'MeasureCriteria' object has no attribute 'result_type_matches'
```


*Description of changes:*
In the function "noise_model._apply_noise_on_observable_result_types", we add a line to check if the criteria is a ObservableCriteria before applying the noise model to the ObservableResultType

*Testing done:*
yeah

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
