### PR TITLE
fix: caching measured qubits

### DIFF
--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -840,6 +840,19 @@ def test_measure_gate_after_measurement():
     assert circ == expected
 
 
+def test_measure_add_circuit_target_mapping():
+    circuit = Circuit().h(0).cnot(0, 1).measure(0).measure(1)
+    circuit = Circuit().add_circuit(circuit, target_mapping={0: 1, 1: 0})
+    expected = (
+        Circuit()
+        .add_instruction(Instruction(Gate.H(), 1))
+        .add_instruction(Instruction(Gate.CNot(), [1, 0]))
+        .add_instruction(Instruction(Measure(), 1))
+        .add_instruction(Instruction(Measure(), 0))
+    )
+    assert circuit == expected
+
+
 def test_to_ir_with_measure():
     circ = Circuit().h(0).cnot(0, 1).cnot(1, 2).measure([0, 2])
     expected_ir = OpenQasmProgram(


### PR DESCRIPTION
*Description of changes:*

`Circuit._map_target_qubits` is used to stored the measured qubits of the circuit. The stored measured qubits is incorrect if adding measure instruction with `target_mapping`.

*Testing done:*
tox

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
