### PR TITLE
fix: Python 3.10 syntax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,8 @@ lint.ignore = [
   "N806",    # Vars will break this rule based on technical names.
   "N815",    # Allowing reviwers to do a per case basis
   "PLC2701", # Allow private function access in code
+  "PLR0904", # Too many public methods
+  "PLR0911", # Too many return statements
   "PLR0913", # Too many variables in function
   "PLR0914", # Too many local variables
   "PLR0917", # Too many positional arguments

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,2 @@
 [aliases]
 test=pytest
-
-

--- a/src/braket/ahs/analog_hamiltonian_simulation.py
+++ b/src/braket/ahs/analog_hamiltonian_simulation.py
@@ -14,7 +14,6 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from functools import singledispatch
 from typing import TYPE_CHECKING
 
 import braket.ir.ahs as ir
@@ -162,48 +161,43 @@ class AnalogHamiltonianSimulation:
         )
 
 
-@singledispatch
 def _get_term_ir(
     term: Hamiltonian,
-) -> tuple[str, dict]:
-    raise TypeError(f"Unable to convert Hamiltonian term type {type(term)}.")
-
-
-@_get_term_ir.register
-def _(term: LocalDetuning) -> tuple[str, ir.LocalDetuning]:
-    return AnalogHamiltonianSimulation.LOCAL_DETUNING_PROPERTY, ir.LocalDetuning(
-        magnitude=ir.PhysicalField(
-            time_series=ir.TimeSeries(
-                times=term.magnitude.time_series.times(),
-                values=term.magnitude.time_series.values(),
-            ),
-            pattern=term.magnitude.pattern.series,
-        )
-    )
-
-
-@_get_term_ir.register
-def _(term: DrivingField) -> tuple[str, ir.DrivingField]:
-    return AnalogHamiltonianSimulation.DRIVING_FIELDS_PROPERTY, ir.DrivingField(
-        amplitude=ir.PhysicalField(
-            time_series=ir.TimeSeries(
-                times=term.amplitude.time_series.times(),
-                values=term.amplitude.time_series.values(),
-            ),
-            pattern="uniform",
-        ),
-        phase=ir.PhysicalField(
-            time_series=ir.TimeSeries(
-                times=term.phase.time_series.times(),
-                values=term.phase.time_series.values(),
-            ),
-            pattern="uniform",
-        ),
-        detuning=ir.PhysicalField(
-            time_series=ir.TimeSeries(
-                times=term.detuning.time_series.times(),
-                values=term.detuning.time_series.values(),
-            ),
-            pattern="uniform",
-        ),
-    )
+) -> tuple[str, ir.LocalDetuning | ir.DrivingField]:
+    match term:
+        case LocalDetuning(magnitude=magnitude):
+            return AnalogHamiltonianSimulation.LOCAL_DETUNING_PROPERTY, ir.LocalDetuning(
+                magnitude=ir.PhysicalField(
+                    time_series=ir.TimeSeries(
+                        times=magnitude.time_series.times(),
+                        values=magnitude.time_series.values(),
+                    ),
+                    pattern=magnitude.pattern.series,
+                )
+            )
+        case DrivingField(amplitude=amplitude, phase=phase, detuning=detuning):
+            return AnalogHamiltonianSimulation.DRIVING_FIELDS_PROPERTY, ir.DrivingField(
+                amplitude=ir.PhysicalField(
+                    time_series=ir.TimeSeries(
+                        times=amplitude.time_series.times(),
+                        values=amplitude.time_series.values(),
+                    ),
+                    pattern="uniform",
+                ),
+                phase=ir.PhysicalField(
+                    time_series=ir.TimeSeries(
+                        times=phase.time_series.times(),
+                        values=phase.time_series.values(),
+                    ),
+                    pattern="uniform",
+                ),
+                detuning=ir.PhysicalField(
+                    time_series=ir.TimeSeries(
+                        times=detuning.time_series.times(),
+                        values=detuning.time_series.values(),
+                    ),
+                    pattern="uniform",
+                ),
+            )
+        case _:
+            raise TypeError(f"Unable to convert Hamiltonian term type {type(term)}.")

--- a/src/braket/aws/aws_device.py
+++ b/src/braket/aws/aws_device.py
@@ -58,7 +58,7 @@ class AwsDeviceType(str, Enum):
     QPU = "QPU"
 
 
-class AwsDevice(Device):  # noqa: PLR0904
+class AwsDevice(Device):
     """Amazon Braket implementation of a device.
     Use this class to retrieve the latest metadata about the device and to run a quantum task on the
     device.

--- a/src/braket/aws/aws_quantum_task.py
+++ b/src/braket/aws/aws_quantum_task.py
@@ -891,37 +891,21 @@ def _create_program_set_task(aws_session: AwsSession, **create_task_kwargs: dict
         raise ClientError(response, e.operation_name) from e
 
 
-@singledispatch
 def _format_result(
     result: GateModelTaskResult | ProgramSetTaskResult | AnalogHamiltonianSimulationTaskResult,
     task_specification: TaskSpecification,
 ) -> TaskResult:
-    raise TypeError("Invalid result specification type")
-
-
-@_format_result.register
-def _(result: GateModelTaskResult, _: TaskSpecification) -> GateModelQuantumTaskResult:
-    GateModelQuantumTaskResult.cast_result_types(result)
-    return GateModelQuantumTaskResult.from_object(result)
-
-
-@_format_result.register
-def _(result: ProgramSetTaskResult, program_set: ProgramSet) -> ProgramSetQuantumTaskResult:
-    return ProgramSetQuantumTaskResult.from_object(result, program_set=program_set)
-
-
-@_format_result.register
-def _(result: AnnealingTaskResult, _: TaskSpecification) -> AnnealingQuantumTaskResult:
-    return AnnealingQuantumTaskResult.from_object(result)
-
-
-@_format_result.register
-def _(result: PhotonicModelTaskResult, _: TaskSpecification) -> PhotonicModelQuantumTaskResult:
-    return PhotonicModelQuantumTaskResult.from_object(result)
-
-
-@_format_result.register
-def _(
-    result: AnalogHamiltonianSimulationTaskResult, _: TaskSpecification
-) -> AnalogHamiltonianSimulationQuantumTaskResult:
-    return AnalogHamiltonianSimulationQuantumTaskResult.from_object(result)
+    match result:
+        case GateModelTaskResult():
+            GateModelQuantumTaskResult.cast_result_types(result)
+            return GateModelQuantumTaskResult.from_object(result)
+        case ProgramSetTaskResult():
+            return ProgramSetQuantumTaskResult.from_object(result, program_set=task_specification)
+        case AnalogHamiltonianSimulationTaskResult():
+            return AnalogHamiltonianSimulationQuantumTaskResult.from_object(result)
+        case AnnealingTaskResult():
+            return AnnealingQuantumTaskResult.from_object(result)
+        case PhotonicModelTaskResult():
+            return PhotonicModelQuantumTaskResult.from_object(result)
+        case _:
+            raise TypeError("Invalid result specification type")

--- a/src/braket/aws/aws_session.py
+++ b/src/braket/aws/aws_session.py
@@ -34,7 +34,7 @@ from braket.tracking.tracking_context import active_trackers, broadcast_event
 from braket.tracking.tracking_events import _TaskCreationEvent, _TaskStatusEvent
 
 
-class AwsSession:  # noqa: PLR0904
+class AwsSession:
     """Manage interactions with AWS services."""
 
     class S3DestinationFolder(NamedTuple):

--- a/src/braket/circuits/angled_gate.py
+++ b/src/braket/circuits/angled_gate.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import copy
 import math
 from collections.abc import Sequence
-from functools import singledispatch
 
 from sympy import Float
 
@@ -358,16 +357,12 @@ class TripleAngledGate(Gate, Parameterizable):
         return hash((self.name, self.angle_1, self.angle_2, self.angle_3, self.qubit_count))
 
 
-@singledispatch
 def _angles_equal(
     angle_1: FreeParameterExpression | float, angle_2: FreeParameterExpression | float
 ) -> bool:
+    if isinstance(angle_1, FreeParameterExpression):
+        return angle_1 == angle_2
     return isinstance(angle_2, float) and math.isclose(angle_1, angle_2)
-
-
-@_angles_equal.register
-def _(angle_1: FreeParameterExpression, angle_2: FreeParameterExpression):
-    return angle_1 == angle_2
 
 
 def angled_ascii_characters(gate: str, angle: FreeParameterExpression | float) -> str:

--- a/src/braket/circuits/basis_state.py
+++ b/src/braket/circuits/basis_state.py
@@ -1,3 +1,16 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 from __future__ import annotations
 
 from functools import singledispatch

--- a/src/braket/circuits/basis_state.py
+++ b/src/braket/circuits/basis_state.py
@@ -13,8 +13,6 @@
 
 from __future__ import annotations
 
-from functools import singledispatch
-
 import numpy as np
 
 
@@ -63,34 +61,29 @@ class BasisState:
 BasisStateInput = int | list[int] | str | BasisState
 
 
-@singledispatch
 def _as_tuple(state: BasisStateInput, size: int) -> tuple:
-    size = size if size is not None else len(state)
-    if state and len(state) > size:
-        raise ValueError(
-            "State value represents a binary sequence of length greater "
-            "than the specified number of qubits."
-        )
-    return (0,) * (size - len(state)) + tuple(state)
-
-
-@_as_tuple.register
-def _(state: int, size: int):
-    if size is not None and state >= 2**size:
-        raise ValueError(
-            "State value represents a binary sequence of length greater "
-            "than the specified number of qubits."
-        )
-    return tuple(int(x) for x in np.binary_repr(state, size))
-
-
-@_as_tuple.register
-def _(state: str, size: int):
-    size = size if size is not None else len(state)
-    if len(state) > size:
-        raise ValueError(
-            "State value represents a binary sequence of length greater "
-            "than the specified number of qubits."
-        )
-    # left-pad to match state size
-    return (0,) * (size - len(state)) + tuple(int(x) for x in state)
+    match state:
+        case int():
+            if size is not None and state >= 2**size:
+                raise ValueError(
+                    "State value represents a binary sequence of length greater "
+                    "than the specified number of qubits."
+                )
+            return tuple(int(x) for x in np.binary_repr(state, size))
+        case str():
+            size = size if size is not None else len(state)
+            if len(state) > size:
+                raise ValueError(
+                    "State value represents a binary sequence of length greater "
+                    "than the specified number of qubits."
+                )
+            # left-pad to match state size
+            return (0,) * (size - len(state)) + tuple(int(x) for x in state)
+        case _:
+            size = size if size is not None else len(state)
+            if state and len(state) > size:
+                raise ValueError(
+                    "State value represents a binary sequence of length greater "
+                    "than the specified number of qubits."
+                )
+            return (0,) * (size - len(state)) + tuple(state)

--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -72,7 +72,7 @@ SubroutineCallable = TypeVar("SubroutineCallable", bound=Callable[..., Subroutin
 AddableTypes = TypeVar("AddableTypes", SubroutineReturn, SubroutineCallable)
 
 
-class Circuit:  # noqa: PLR0904
+class Circuit:
     """A representation of a quantum circuit that contains the instructions to be performed on a
     quantum device and the requested result types.
 

--- a/src/braket/circuits/moments.py
+++ b/src/braket/circuits/moments.py
@@ -172,39 +172,43 @@ class Moments(Mapping[MomentsKey, Instruction]):
             self._add(instruction, noise_index)
 
     def _add(self, instruction: Instruction, noise_index: int = 0) -> None:
-        operator = instruction.operator
-        if isinstance(operator, CompilerDirective):
-            time = self._update_qubit_times(self._qubits)
-            self._moments[MomentsKey(time, None, MomentType.COMPILER_DIRECTIVE, 0)] = instruction
-            self._depth = time + 1
-            self._time_all_qubits = time
-        elif isinstance(operator, Noise):
-            self.add_noise(instruction)
-        elif isinstance(operator, Gate) and operator.name == "GPhase":
-            time = self._get_qubit_times(self._max_times.keys()) + 1
-            self._number_gphase_in_current_moment += 1
-            key = MomentsKey(
-                time,
-                QubitSet([]),
-                MomentType.GLOBAL_PHASE,
-                0,
-                self._number_gphase_in_current_moment,
-            )
-            self._moments[key] = instruction
-        elif isinstance(operator, Measure):
-            qubit_range = instruction.target.union(instruction.control)
-            time = self._get_qubit_times(self._max_times.keys()) + 1
-            self._moments[MomentsKey(time, qubit_range, MomentType.MEASURE, noise_index)] = (
-                instruction
-            )
-            self._qubits.update(qubit_range)
-            self._depth = max(self._depth, time + 1)
-        else:
-            qubit_range = instruction.target.union(instruction.control)
-            time = self._update_qubit_times(qubit_range)
-            self._moments[MomentsKey(time, qubit_range, MomentType.GATE, noise_index)] = instruction
-            self._qubits.update(qubit_range)
-            self._depth = max(self._depth, time + 1)
+        match operator := instruction.operator:
+            case CompilerDirective():
+                time = self._update_qubit_times(self._qubits)
+                self._moments[MomentsKey(time, None, MomentType.COMPILER_DIRECTIVE, 0)] = (
+                    instruction
+                )
+                self._depth = time + 1
+                self._time_all_qubits = time
+            case Noise():
+                self.add_noise(instruction)
+            case Gate() if operator.name == "GPhase":
+                time = self._get_qubit_times(self._max_times.keys()) + 1
+                self._number_gphase_in_current_moment += 1
+                key = MomentsKey(
+                    time,
+                    QubitSet([]),
+                    MomentType.GLOBAL_PHASE,
+                    0,
+                    self._number_gphase_in_current_moment,
+                )
+                self._moments[key] = instruction
+            case Measure():
+                qubit_range = instruction.target.union(instruction.control)
+                time = self._get_qubit_times(self._max_times.keys()) + 1
+                self._moments[MomentsKey(time, qubit_range, MomentType.MEASURE, noise_index)] = (
+                    instruction
+                )
+                self._qubits.update(qubit_range)
+                self._depth = max(self._depth, time + 1)
+            case _:
+                qubit_range = instruction.target.union(instruction.control)
+                time = self._update_qubit_times(qubit_range)
+                self._moments[MomentsKey(time, qubit_range, MomentType.GATE, noise_index)] = (
+                    instruction
+                )
+                self._qubits.update(qubit_range)
+                self._depth = max(self._depth, time + 1)
 
     def _get_qubit_times(self, qubits: QubitSet) -> int:
         return max([self._max_time_for_qubit(qubit) for qubit in qubits] + [self._time_all_qubits])
@@ -258,15 +262,16 @@ class Moments(Mapping[MomentsKey, Instruction]):
 
         for key, instruction in self._moments.items():
             moment_copy[key] = instruction
-            if key.moment_type == MomentType.READOUT_NOISE:
-                key_readout_noise.append(key)
-            elif key.moment_type == MomentType.INITIALIZATION_NOISE:
-                key_initialization_noise.append(key)
-            elif key.moment_type == MomentType.MEASURE:
-                last_measure = key.time
-                key_noise.append(key)
-            else:
-                key_noise.append(key)
+            match key.moment_type:
+                case MomentType.READOUT_NOISE:
+                    key_readout_noise.append(key)
+                case MomentType.INITIALIZATION_NOISE:
+                    key_initialization_noise.append(key)
+                case MomentType.MEASURE:
+                    last_measure = key.time
+                    key_noise.append(key)
+                case _:
+                    key_noise.append(key)
 
         for key in key_initialization_noise:
             sorted_moment[key] = moment_copy[key]

--- a/src/braket/circuits/noise_model/noise_model.py
+++ b/src/braket/circuits/noise_model/noise_model.py
@@ -185,9 +185,11 @@ class NoiseModel:
             match item.criteria:
                 case InitializationCriteria():
                     init_noise.append(item)
+                case MeasureCriteria():
+                    readout_noise.append(item)
                 case CircuitInstructionCriteria():
                     gate_noise.append(item)
-                case MeasureCriteria() | ResultTypeCriteria():
+                case ResultTypeCriteria():
                     readout_noise.append(item)
         return NoiseModelInstructions(
             initialization_noise=init_noise,

--- a/src/braket/circuits/noise_model/noise_model.py
+++ b/src/braket/circuits/noise_model/noise_model.py
@@ -185,11 +185,9 @@ class NoiseModel:
             match item.criteria:
                 case InitializationCriteria():
                     init_noise.append(item)
-                case MeasureCriteria():
-                    readout_noise.append(item)
                 case CircuitInstructionCriteria():
                     gate_noise.append(item)
-                case ResultTypeCriteria():
+                case MeasureCriteria() | ResultTypeCriteria():
                     readout_noise.append(item)
         return NoiseModelInstructions(
             initialization_noise=init_noise,

--- a/src/braket/circuits/noise_model/noise_model.py
+++ b/src/braket/circuits/noise_model/noise_model.py
@@ -182,14 +182,15 @@ class NoiseModel:
         gate_noise = []
         readout_noise = []
         for item in self._instructions:
-            if isinstance(item.criteria, InitializationCriteria):
-                init_noise.append(item)
-            elif isinstance(item.criteria, MeasureCriteria):
-                readout_noise.append(item)
-            elif isinstance(item.criteria, CircuitInstructionCriteria):
-                gate_noise.append(item)
-            elif isinstance(item.criteria, ResultTypeCriteria):
-                readout_noise.append(item)
+            match item.criteria:
+                case InitializationCriteria():
+                    init_noise.append(item)
+                case MeasureCriteria():
+                    readout_noise.append(item)
+                case CircuitInstructionCriteria():
+                    gate_noise.append(item)
+                case ResultTypeCriteria():
+                    readout_noise.append(item)
         return NoiseModelInstructions(
             initialization_noise=init_noise,
             gate_noise=gate_noise,

--- a/src/braket/circuits/text_diagram_builders/text_circuit_diagram.py
+++ b/src/braket/circuits/text_diagram_builders/text_circuit_diagram.py
@@ -1,3 +1,16 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/src/braket/jobs/local/local_job_container.py
+++ b/src/braket/jobs/local/local_job_container.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+
 from __future__ import annotations
 
 import base64

--- a/src/braket/jobs/metrics.py
+++ b/src/braket/jobs/metrics.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+
 from __future__ import annotations
 
 import time

--- a/src/braket/jobs/metrics_data/definitions.py
+++ b/src/braket/jobs/metrics_data/definitions.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+
 from enum import Enum, unique
 
 

--- a/src/braket/jobs/quantum_job.py
+++ b/src/braket/jobs/quantum_job.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+
 from __future__ import annotations
 
 from abc import ABC, abstractmethod

--- a/src/braket/jobs/quantum_job_creation.py
+++ b/src/braket/jobs/quantum_job_creation.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+
 from __future__ import annotations
 
 import importlib.util

--- a/src/braket/program_sets/parameter_sets.py
+++ b/src/braket/program_sets/parameter_sets.py
@@ -51,14 +51,15 @@ class ParameterSets:
         """
         ParameterSets._validate_combinations(parameter_sets, keys=keys, values=values, **kwargs)
         if parameter_sets:
-            if isinstance(parameter_sets, ParameterSets):
-                self._inputs = parameter_sets._inputs
-            elif isinstance(parameter_sets, Mapping):
-                self._inputs = ParameterSets._mapping_to_dict(parameter_sets)
-            elif isinstance(parameter_sets, Sequence):
-                self._inputs = ParameterSets._sequence_to_dict(parameter_sets)
-            else:
-                raise TypeError(f"Unsupported type {type(parameter_sets)} for ParameterSets")
+            match parameter_sets:
+                case ParameterSets(_inputs=inputs):
+                    self._inputs = inputs
+                case Mapping():
+                    self._inputs = ParameterSets._mapping_to_dict(parameter_sets)
+                case Sequence():
+                    self._inputs = ParameterSets._sequence_to_dict(parameter_sets)
+                case _:
+                    raise TypeError(f"Unsupported type {type(parameter_sets)} for ParameterSets")
         elif keys:
             self._inputs = ParameterSets._mapping_to_dict(dict(zip(keys, values, strict=True)))
         elif kwargs:

--- a/src/braket/pulse/ast/approximation_parser.py
+++ b/src/braket/pulse/ast/approximation_parser.py
@@ -49,7 +49,7 @@ class _ParseState:
     frame_data: dict[str, _FrameState]
 
 
-class _ApproximationParser(QASMVisitor[_ParseState]):  # noqa: PLR0904
+class _ApproximationParser(QASMVisitor[_ParseState]):
     """Walk the AST and build the output signal amplitude, frequency and phases
     for each channel.
     """
@@ -254,7 +254,7 @@ class _ApproximationParser(QASMVisitor[_ParseState]):  # noqa: PLR0904
             return ~self.visit(node.expression, context)
         raise NotImplementedError
 
-    def visit_BinaryExpression(self, node: ast.BinaryExpression, context: _ParseState) -> Any:  # noqa: C901, PLR0911, PLR0912
+    def visit_BinaryExpression(self, node: ast.BinaryExpression, context: _ParseState) -> Any:  # noqa: C901, PLR0912
         """Visit Binary Expression.
             node.lhs, node.rhs, node.op
             1+2

--- a/src/braket/tasks/gate_model_quantum_task_result.py
+++ b/src/braket/tasks/gate_model_quantum_task_result.py
@@ -341,15 +341,14 @@ class GateModelQuantumTaskResult:
         """
         if gate_model_task_result.resultTypes:
             for result_type in gate_model_task_result.resultTypes:
-                type = result_type.type.type
-                if type == "amplitude":
-                    for state in result_type.value:
-                        result_type.value[state] = complex(*result_type.value[state])
-
-                elif type == "probability":
-                    result_type.value = np.array(result_type.value)
-                elif type == "statevector":
-                    result_type.value = np.array(list(starmap(complex, result_type.value)))
+                match result_type.type.type:
+                    case "amplitude":
+                        for state in result_type.value:
+                            result_type.value[state] = complex(*result_type.value[state])
+                    case "probability":
+                        result_type.value = np.array(result_type.value)
+                    case "statevector":
+                        result_type.value = np.array(list(starmap(complex, result_type.value)))
 
     @staticmethod
     def _calculate_result_types(
@@ -363,41 +362,41 @@ class GateModelQuantumTaskResult:
             ir_observable = result_type.get("observable")
             observable = observable_from_ir(ir_observable) if ir_observable else None
             targets = result_type.get("targets")
-            rt_type = result_type["type"]
-            if rt_type == "probability":
-                value = GateModelQuantumTaskResult._probability_from_measurements(
-                    measurements, measured_qubits, targets
-                )
-                casted_result_type = Probability(targets=targets)
-            elif rt_type == "sample":
-                value = GateModelQuantumTaskResult._calculate_for_targets(
-                    samples_from_measurements,
-                    measurements,
-                    measured_qubits,
-                    observable,
-                    targets,
-                )
-                casted_result_type = Sample(targets=targets, observable=ir_observable)
-            elif rt_type == "variance":
-                value = GateModelQuantumTaskResult._calculate_for_targets(
-                    GateModelQuantumTaskResult._variance_from_measurements,
-                    measurements,
-                    measured_qubits,
-                    observable,
-                    targets,
-                )
-                casted_result_type = Variance(targets=targets, observable=ir_observable)
-            elif rt_type == "expectation":
-                value = GateModelQuantumTaskResult._calculate_for_targets(
-                    expectation_from_measurements,
-                    measurements,
-                    measured_qubits,
-                    observable,
-                    targets,
-                )
-                casted_result_type = Expectation(targets=targets, observable=ir_observable)
-            else:
-                raise ValueError(f"Unknown result type {rt_type}")
+            match rt_type := result_type["type"]:
+                case "probability":
+                    value = GateModelQuantumTaskResult._probability_from_measurements(
+                        measurements, measured_qubits, targets
+                    )
+                    casted_result_type = Probability(targets=targets)
+                case "sample":
+                    value = GateModelQuantumTaskResult._calculate_for_targets(
+                        samples_from_measurements,
+                        measurements,
+                        measured_qubits,
+                        observable,
+                        targets,
+                    )
+                    casted_result_type = Sample(targets=targets, observable=ir_observable)
+                case "variance":
+                    value = GateModelQuantumTaskResult._calculate_for_targets(
+                        GateModelQuantumTaskResult._variance_from_measurements,
+                        measurements,
+                        measured_qubits,
+                        observable,
+                        targets,
+                    )
+                    casted_result_type = Variance(targets=targets, observable=ir_observable)
+                case "expectation":
+                    value = GateModelQuantumTaskResult._calculate_for_targets(
+                        expectation_from_measurements,
+                        measurements,
+                        measured_qubits,
+                        observable,
+                        targets,
+                    )
+                    casted_result_type = Expectation(targets=targets, observable=ir_observable)
+                case _:
+                    raise ValueError(f"Unknown result type {rt_type}")
             result_types.append(ResultTypeValue.construct(type=casted_result_type, value=value))
         return result_types
 

--- a/src/braket/tasks/local_quantum_task.py
+++ b/src/braket/tasks/local_quantum_task.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+
 from __future__ import annotations
 
 import asyncio

--- a/src/braket/tracking/tracker.py
+++ b/src/braket/tracking/tracker.py
@@ -176,23 +176,18 @@ class Tracker:
     def _recieve_internal(self, event: _TrackingEvent) -> None:
         resources = self._resources
         match event:
-            case _TaskCreationEvent(arn=arn, shots=shots, is_job_task=is_job_task, device=device):
+            case _TaskCreationEvent(arn, shots, is_job_task, device):
                 resources[arn] = {
                     "shots": shots,
                     "device": device,
                     "status": "CREATED",
                     "job_task": is_job_task,
                 }
-            case _TaskStatusEvent(arn=arn, status=status):
+            case _TaskStatusEvent(arn, status):
                 # Update task data corresponding to the arn only if it exists in resources
                 if arn in resources:
                     resources[arn]["status"] = status
-            case _TaskCompletionEvent(
-                arn=arn,
-                execution_duration=execution_duration,
-                status=status,
-                has_reservation_arn=has_reservation_arn,
-            ):
+            case _TaskCompletionEvent(arn, execution_duration, status, has_reservation_arn):
                 # Update task completion data corresponding to the arn
                 # only if it exists in resources
                 if arn in resources:

--- a/test/integ_tests/gate_model_device_testing_utils.py
+++ b/test/integ_tests/gate_model_device_testing_utils.py
@@ -13,7 +13,7 @@
 
 import concurrent.futures
 import math
-from typing import Any, Union
+from typing import Any
 
 import numpy as np
 
@@ -49,7 +49,7 @@ def qubit_ordering_testing(device: Device, run_kwargs: dict[str, Any]):
 
 
 def no_result_types_testing(
-    program: Union[Circuit, OpenQasmProgram],
+    program: Circuit | OpenQasmProgram,
     device: Device,
     run_kwargs: dict[str, Any],
     expected: dict[str, float],

--- a/test/integ_tests/test_density_matrix_simulator.py
+++ b/test/integ_tests/test_density_matrix_simulator.py
@@ -1,3 +1,16 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 import math
 
 import numpy as np

--- a/test/integ_tests/test_device_creation.py
+++ b/test/integ_tests/test_device_creation.py
@@ -11,7 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-
 import pytest
 
 from braket.aws import AwsDevice

--- a/test/integ_tests/test_pulse.py
+++ b/test/integ_tests/test_pulse.py
@@ -1,3 +1,16 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 import math
 
 import numpy as np

--- a/test/integ_tests/test_queue_information.py
+++ b/test/integ_tests/test_queue_information.py
@@ -11,7 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-
 from braket.aws import AwsDevice
 from braket.aws.queue_information import (
     HybridJobQueueInfo,

--- a/test/integ_tests/test_user_agents.py
+++ b/test/integ_tests/test_user_agents.py
@@ -1,3 +1,16 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 from botocore import awsrequest
 
 import braket._schemas as braket_schemas
@@ -17,7 +30,6 @@ def test_default_user_agent(aws_session):
             assert bytes(agent, "utf8") in user_agent
 
     aws_session.braket_client.meta.events.register("before-send.braket", assert_in_user_agent)
-
     aws_session.search_devices()
 
 
@@ -29,5 +41,4 @@ def test_add_user_agent(aws_session):
         assert b"foo/1.0" in user_agent
 
     aws_session.braket_client.meta.events.register("before-send.braket", assert_in_user_agent)
-
     aws_session.search_devices()

--- a/test/unit_tests/braket/circuits/noise/test_measure_criteria.py
+++ b/test/unit_tests/braket/circuits/noise/test_measure_criteria.py
@@ -1,3 +1,16 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 import pytest
 from unittest.mock import Mock
 

--- a/test/unit_tests/braket/circuits/test_basis_state.py
+++ b/test/unit_tests/braket/circuits/test_basis_state.py
@@ -1,3 +1,16 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 import pytest
 
 from braket.circuits.basis_state import BasisState

--- a/test/unit_tests/braket/circuits/test_result_type.py
+++ b/test/unit_tests/braket/circuits/test_result_type.py
@@ -10,6 +10,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+
 import re
 
 import pytest

--- a/test/unit_tests/braket/devices/test_local_simulator.py
+++ b/test/unit_tests/braket/devices/test_local_simulator.py
@@ -16,7 +16,7 @@ import math
 import sys
 import textwrap
 import warnings
-from typing import Any, Optional
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -224,8 +224,8 @@ class DummyCircuitSimulator(BraketSimulator):
         self,
         program: ir.jaqcd.Program,
         qubits: int,
-        shots: Optional[int],
-        inputs: Optional[dict[str, float]],
+        shots: int | None,
+        inputs: dict[str, float] | None,
         *args,
         **kwargs,
     ) -> dict[str, Any]:
@@ -264,8 +264,8 @@ class DummyJaqcdSimulator(BraketSimulator):
     def run(
         self,
         program: ir.jaqcd.Program,
-        qubits: Optional[int] = None,
-        shots: Optional[int] = None,
+        qubits: int | None = None,
+        shots: int | None = None,
         *args,
         **kwargs,
     ) -> dict[str, Any]:
@@ -385,7 +385,7 @@ class DummySerializableProgramSimulator(DummyProgramSimulator):
 
 class DummyProgramDensityMatrixSimulator(BraketSimulator):
     def run(
-        self, program: ir.openqasm.Program, shots: Optional[int], *args, **kwargs
+        self, program: ir.openqasm.Program, shots: int | None, *args, **kwargs
     ) -> dict[str, Any]:
         self._shots = shots
         return GATE_MODEL_RESULT

--- a/test/unit_tests/braket/emulation/passes/test_connectivity_validator.py
+++ b/test/unit_tests/braket/emulation/passes/test_connectivity_validator.py
@@ -1,3 +1,16 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 import networkx as nx
 import numpy as np
 import pytest

--- a/test/unit_tests/braket/emulation/passes/test_gate_connectivity_validator.py
+++ b/test/unit_tests/braket/emulation/passes/test_gate_connectivity_validator.py
@@ -1,3 +1,16 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 import networkx as nx
 import numpy as np
 import pytest

--- a/test/unit_tests/braket/emulation/passes/test_gate_validator.py
+++ b/test/unit_tests/braket/emulation/passes/test_gate_validator.py
@@ -1,3 +1,16 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 import numpy as np
 import pytest
 

--- a/test/unit_tests/braket/emulation/passes/test_qubit_count_validator.py
+++ b/test/unit_tests/braket/emulation/passes/test_qubit_count_validator.py
@@ -1,3 +1,16 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 import numpy as np
 import pytest
 

--- a/test/unit_tests/braket/emulation/passes/test_result_type_validator.py
+++ b/test/unit_tests/braket/emulation/passes/test_result_type_validator.py
@@ -1,3 +1,16 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 import pytest
 import re
 from braket.circuits import Circuit, Observable

--- a/test/unit_tests/braket/emulation/test_emulator.py
+++ b/test/unit_tests/braket/emulation/test_emulator.py
@@ -1,3 +1,16 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 import re
 from unittest.mock import Mock
 

--- a/test/unit_tests/braket/emulation/test_local_emulator.py
+++ b/test/unit_tests/braket/emulation/test_local_emulator.py
@@ -14,9 +14,6 @@
 import pytest
 import json
 
-from braket.emulation.device_emulator_properties import (
-    DeviceEmulatorProperties,
-)
 from braket.device_schema.iqm.iqm_device_capabilities_v1 import IqmDeviceCapabilities
 from braket.device_schema.ionq.ionq_device_capabilities_v1 import IonqDeviceCapabilities
 from braket.device_schema.rigetti.rigetti_device_capabilities_v1 import RigettiDeviceCapabilities

--- a/test/unit_tests/braket/jobs/test_environment_variables.py
+++ b/test/unit_tests/braket/jobs/test_environment_variables.py
@@ -1,3 +1,16 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 import json
 import os
 import tempfile

--- a/test/unit_tests/braket/jobs/test_hybrid_job.py
+++ b/test/unit_tests/braket/jobs/test_hybrid_job.py
@@ -1,3 +1,16 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 import ast
 import importlib
 import inspect

--- a/test/unit_tests/braket/jobs/test_metrics.py
+++ b/test/unit_tests/braket/jobs/test_metrics.py
@@ -1,3 +1,16 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 from unittest.mock import patch
 
 import pytest

--- a/test/unit_tests/braket/jobs/test_serialization.py
+++ b/test/unit_tests/braket/jobs/test_serialization.py
@@ -11,7 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-
 import pytest
 
 from braket.jobs.serialization import deserialize_values, serialize_values

--- a/test/unit_tests/braket/pulse/ast/test_approximation_parser.py
+++ b/test/unit_tests/braket/pulse/ast/test_approximation_parser.py
@@ -11,7 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-from typing import Union
 from unittest.mock import Mock
 
 import numpy as np
@@ -1158,7 +1157,7 @@ def verify_results(results, expected_amplitudes, expected_frequencies, expected_
         assert _all_close(results.phases[frame_id], expected_phases[frame_id], 1e-10)
 
 
-def to_dict(frames: Union[Frame, list]):
+def to_dict(frames: Frame | list):
     if not isinstance(frames, list):
         frames = [frames]
     frame_dict = dict()

--- a/test/unit_tests/braket/test_imports.py
+++ b/test/unit_tests/braket/test_imports.py
@@ -1,3 +1,16 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 import importlib
 import multiprocessing
 import os

--- a/test/unit_tests/braket/tracking/test_pricing.py
+++ b/test/unit_tests/braket/tracking/test_pricing.py
@@ -11,7 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
-
 import io
 from unittest.mock import patch
 


### PR DESCRIPTION
**NOTE** This PR might look big with the 47 files changed, but the vast majority are newline changes, addition of the header, and removals of all remaining unnecessary usages of `Union` and `Option` (that I was able to find).

The only _logical_ changes come from the introduction of the [`match` statement](https://docs.python.org/3/whatsnew/3.10.html#pep-634-structural-pattern-matching).

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
