### PR TITLE
fix the bug of not validating out programset

### DIFF
--- a/src/braket/emulation/emulator.py
+++ b/src/braket/emulation/emulator.py
@@ -129,6 +129,8 @@ class Emulator(Device):
             exists for this emulator and apply_noise_model is true.
         """
 
+        program = self._pass_manager.transform(task_specification)
+
         # Apply measurement manually if the circuit has no measurement and no result type.
         # This ensures that the noise model can apply readout error to the circuit, since
         # the readout error is applied if and only if there is measurement or result type
@@ -140,7 +142,6 @@ class Emulator(Device):
         if (not has_measurement) and len(task_specification.result_types) == 0:
             task_specification.measure(target_qubits=task_specification.qubits)
 
-        program = self._pass_manager.transform(task_specification)
         return (
             self._noise_model.apply(program) if apply_noise_model and self.noise_model else program
         )

--- a/test/unit_tests/braket/emulation/test_local_emulator.py
+++ b/test/unit_tests/braket/emulation/test_local_emulator.py
@@ -14,14 +14,14 @@
 import pytest
 import json
 
-from braket.emulation.device_emulator_properties import (
-    DeviceEmulatorProperties,
-)
 from braket.device_schema.iqm.iqm_device_capabilities_v1 import IqmDeviceCapabilities
 from braket.device_schema.ionq.ionq_device_capabilities_v1 import IonqDeviceCapabilities
 from braket.device_schema.rigetti.rigetti_device_capabilities_v1 import RigettiDeviceCapabilities
 
 from braket.emulation.local_emulator import LocalEmulator
+
+from braket.program_sets import ProgramSet
+from braket.circuits import Circuit
 
 from conftest import invalid_device_properties_dict_1, invalid_device_properties_dict_2
 
@@ -94,3 +94,10 @@ def test_validate_valid_verbatim_circ_aria_1_v2(
         IonqDeviceCapabilities.parse_raw(reduced_ionq_device_capabilities_json)
     )
     emulator.validate(valid_verbatim_circ_aria1)
+
+
+def test_program_set(reduced_standardized_json):
+    emulator = LocalEmulator.from_json(reduced_standardized_json)
+    ps = ProgramSet([Circuit()], shots_per_executable=50)
+    with pytest.raises(TypeError):
+        emulator.run(ps)


### PR DESCRIPTION
*Issue #, if available:*
The device emulator didn't properly validate out the program set because it was trying to apply measurement error manually before performing the validation.

*Description of changes:*

Perform validation first before applying the measurement error manually. 

*Testing done:*
A unit test has been added to explicitly check if the program set has been validated out properly. The added unit test would fail without the change. All other unit tests are passed. 

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
