### PR TITLE
fix: parse division in free parameter expressions

### DIFF
--- a/src/braket/parametric/free_parameter_expression.py
+++ b/src/braket/parametric/free_parameter_expression.py
@@ -54,6 +54,7 @@ class FreeParameterExpression:
             ast.Add: self.__add__,
             ast.Sub: self.__sub__,
             ast.Mult: self.__mul__,
+            ast.Div: self.__truediv__,
             ast.Pow: self.__pow__,
             ast.USub: self.__neg__,
         }

--- a/test/unit_tests/braket/parametric/test_free_parameter_expression.py
+++ b/test/unit_tests/braket/parametric/test_free_parameter_expression.py
@@ -52,9 +52,16 @@ def test_equality_str():
     assert hasattr(expr_1.expression, "free_symbols") and hasattr(expr_2.expression, "free_symbols")
 
 
+def test_truediv_str():
+    FreeParameterExpression("theta/1")
+    expr_1 = FreeParameterExpression("theta/alpha")
+    expr_2 = FreeParameterExpression(FreeParameter("theta") / FreeParameter("alpha"))
+    assert expr_1 == expr_2
+
+
 @pytest.mark.xfail(raises=ValueError)
 def test_unsupported_bin_op_str():
-    FreeParameterExpression("theta/1")
+    FreeParameterExpression("theta//1")
 
 
 @pytest.mark.xfail(raises=ValueError)


### PR DESCRIPTION
*Issue #1251*

*Description of changes:*
- Adds support for parsing `/` in `FreeParameterExpression` string constructors by mapping `ast.Div` to the existing true-division implementation.
- Updates the parameter expression unit tests so `FreeParameterExpression("theta/alpha")` matches the equivalent expression built with `FreeParameter("theta") / FreeParameter("alpha")`.
- Keeps unsupported division-like operations, such as `//`, covered by the unsupported binary operation test.

*Testing done:*
- `python -m pytest -o addopts='' test\unit_tests\braket\parametric\test_free_parameter_expression.py`
- Result: 27 passed, 4 xfailed

## Merge Checklist

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
