### PR TITLE
deprecation: change Circuit.to_ir default to OPENQASM and warn on JAQCD (MCM-150287739)

### DIFF
--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -13,6 +13,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections import Counter
 from collections.abc import Callable, Iterable, Sequence
 from numbers import Number
@@ -1311,12 +1312,23 @@ class Circuit:
 
     def to_ir(
         self,
-        ir_type: IRType = IRType.JAQCD,
+        ir_type: IRType = IRType.OPENQASM,
         serialization_properties: SerializationProperties | None = None,
         gate_definitions: dict[tuple[Gate, QubitSet], PulseSequence] | None = None,
     ) -> OpenQasmProgram | JaqcdProgram:
         """Converts the circuit into the canonical intermediate representation.
         If the circuit is sent over the wire, this method is called before it is sent.
+
+        .. versionchanged:: 1.117.4
+            The default ``ir_type`` is now :attr:`IRType.OPENQASM` (previously
+            :attr:`IRType.JAQCD`). Amazon Braket service devices no longer
+            accept JAQCD program submissions; see MCM-150287739.
+
+        .. deprecated:: 1.117.4
+            Passing ``ir_type=IRType.JAQCD`` is deprecated and emits a
+            ``UserWarning``. Use :attr:`IRType.OPENQASM` instead. The
+            ``IRType.JAQCD`` enum member and the JAQCD conversion path are
+            retained so historical task results continue to deserialize.
 
         Args:
             ir_type (IRType): The IRType to use for converting the circuit object to its
@@ -1337,6 +1349,12 @@ class Circuit:
         """
         gate_definitions = gate_definitions or {}
         if ir_type == IRType.JAQCD:
+            warnings.warn(
+                "JAQCD IR is deprecated and will be removed in a future release. "
+                "Use IRType.OPENQASM instead. Amazon Braket service devices no "
+                "longer accept JAQCD program submissions. See MCM-150287739.",
+                stacklevel=2,
+            )
             return self._to_jaqcd()
         if ir_type == IRType.OPENQASM:
             if serialization_properties and not isinstance(

--- a/src/braket/circuits/serialization.py
+++ b/src/braket/circuits/serialization.py
@@ -17,7 +17,15 @@ from enum import StrEnum
 
 
 class IRType(StrEnum):
-    """Defines the available IRTypes for circuit serialization."""
+    """Defines the available IRTypes for circuit serialization.
+
+    .. deprecated:: 1.117.4
+        ``JAQCD`` is deprecated. Amazon Braket service devices no longer accept
+        JAQCD program submissions; use ``OPENQASM`` instead. The ``JAQCD``
+        enum member is retained so circuits can still be converted to JAQCD
+        for legacy code paths and historical task-result parsing. See
+        MCM-150287739.
+    """
 
     OPENQASM = "OPENQASM"
     JAQCD = "JAQCD"

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+import warnings
 from unittest.mock import Mock
 
 import numpy as np
@@ -1184,9 +1185,9 @@ def test_subroutine_nested():
 
 def test_ir_empty_instructions_result_types():
     circ = Circuit()
-    assert circ.to_ir() == jaqcd.Program(
-        instructions=[], results=[], basis_rotation_instructions=[]
-    )
+    with pytest.warns(UserWarning, match="JAQCD"):
+        ir = circ.to_ir(IRType.JAQCD)
+    assert ir == jaqcd.Program(instructions=[], results=[], basis_rotation_instructions=[])
 
 
 def test_ir_non_empty_instructions_result_types():
@@ -1196,7 +1197,9 @@ def test_ir_non_empty_instructions_result_types():
         results=[jaqcd.Probability(targets=[0, 1])],
         basis_rotation_instructions=[],
     )
-    assert circ.to_ir() == expected
+    with pytest.warns(UserWarning, match="JAQCD"):
+        ir = circ.to_ir(IRType.JAQCD)
+    assert ir == expected
 
 
 def test_ir_non_empty_instructions_result_types_basis_rotation_instructions():
@@ -1206,7 +1209,41 @@ def test_ir_non_empty_instructions_result_types_basis_rotation_instructions():
         results=[jaqcd.Sample(observable=["x"], targets=[0])],
         basis_rotation_instructions=[jaqcd.H(target=0)],
     )
-    assert circ.to_ir() == expected
+    with pytest.warns(UserWarning, match="JAQCD"):
+        ir = circ.to_ir(IRType.JAQCD)
+    assert ir == expected
+
+
+def test_to_ir_default_is_openqasm():
+    """Calling Circuit.to_ir() with no ir_type argument should return an
+    OpenQASM program (after the JAQCD-deprecation default flip)."""
+    circ = Circuit().h(0).cnot(0, 1)
+    assert isinstance(circ.to_ir(), OpenQasmProgram)
+
+
+def test_to_ir_jaqcd_emits_warning():
+    """Passing IRType.JAQCD explicitly should emit a UserWarning that
+    references JAQCD and points the customer at the migration path."""
+    circ = Circuit().h(0)
+    with pytest.warns(UserWarning, match="JAQCD"):
+        out = circ.to_ir(IRType.JAQCD)
+    # The actual JAQCD program is still produced — only the warning is new.
+    assert out == jaqcd.Program(
+        instructions=[jaqcd.H(target=0)], results=[], basis_rotation_instructions=[]
+    )
+
+
+def test_to_ir_default_emits_no_jaqcd_warning():
+    """The new default (OpenQASM) must not emit the JAQCD deprecation
+    warning. We assert specifically on JAQCD-message warnings rather than
+    erroring on all UserWarnings, since other unrelated warnings may fire
+    legitimately."""
+    circ = Circuit().h(0)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        circ.to_ir()
+    jaqcd_warnings = [x for x in w if "JAQCD" in str(x.message)]
+    assert jaqcd_warnings == []
 
 
 @pytest.mark.parametrize(
@@ -3815,5 +3852,8 @@ def test_barrier_openqasm_export_all_qubits():
 
 def test_barrier_jaqcd_export_fails():
     circ = Circuit().h(0).barrier([0, 1])
-    with pytest.raises(NotImplementedError, match="Barrier is not supported in JAQCD"):
+    with (
+        pytest.warns(UserWarning, match="JAQCD"),
+        pytest.raises(NotImplementedError, match="Barrier is not supported in JAQCD"),
+    ):
         circ.to_ir(IRType.JAQCD)

--- a/test/unit_tests/braket/devices/test_local_simulator.py
+++ b/test/unit_tests/braket/devices/test_local_simulator.py
@@ -692,7 +692,11 @@ def test_run_program_model_inputs():
 def test_run_jaqcd_only():
     dummy = DummyJaqcdSimulator()
     sim = LocalSimulator(dummy)
-    task = sim.run(Circuit().h(0).cnot(0, 1), 10)
+    # When the local simulator advertises only JAQCD (no OpenQASM), the
+    # LocalSimulator payload constructor falls back to converting the
+    # circuit to JAQCD, which (per the JAQCD deprecation) emits a UserWarning.
+    with pytest.warns(UserWarning, match="JAQCD"):
+        task = sim.run(Circuit().h(0).cnot(0, 1), 10)
     dummy.assert_shots(10)
     dummy.assert_qubits(None)
     assert task.result() == GateModelQuantumTaskResult.from_object(GATE_MODEL_RESULT)


### PR DESCRIPTION
## Issue, if available

Internal: MCM-150287739 (Simulators broker migration removes JAQCD from Braket service device capabilities).

Coordinated deprecation across three Braket OSS Python packages:
- amazon-braket-schemas-python: https://github.com/amazon-braket/amazon-braket-schemas-python/pull/221
- **amazon-braket-sdk-python: this PR**
- amazon-braket-default-simulator-python: https://github.com/amazon-braket/amazon-braket-default-simulator-python/pull/380

## Description of changes

Amazon Braket service devices no longer accept JAQCD program submissions. This PR moves the customer-facing default off JAQCD and adds a runtime warning when callers explicitly request JAQCD.

### Code changes

- `src/braket/circuits/circuit.py`:
  - **Default change**: `Circuit.to_ir(ir_type=IRType.JAQCD)` → `Circuit.to_ir(ir_type=IRType.OPENQASM)`. Calls to ``circuit.to_ir()`` (no arg) now return an OpenQASM program instead of a JAQCD program.
  - **Runtime warning**: when ``ir_type=IRType.JAQCD`` is passed explicitly, emit a ``UserWarning`` pointing the caller at OpenQASM 3 and referencing MCM-150287739.
  - Docstring: added ``.. versionchanged:: 1.117.4`` and ``.. deprecated:: 1.117.4`` directives.
- `src/braket/circuits/serialization.py`: added ``.. deprecated:: 1.117.4`` note to the ``IRType`` enum docstring. ``IRType.JAQCD`` itself is **not removed** — historical task results, the JAQCD conversion path, and external callers that need to produce JAQCD continue to function.

### Why ``UserWarning`` and not ``DeprecationWarning``

`DeprecationWarning` is suppressed by default (PEP 565) for any warning attributed outside `__main__`. That hides it from customer code that wraps Braket calls in helper functions or libraries — exactly the cases we need to reach. `UserWarning` is visible by default and matches every existing `warnings.warn` call site in the BDK (`aws_device.py:388,683`, `quantum_job_creation.py:275`, `circuit_binding.py:221`).

### Why no symbols are removed

Two hard constraints:

1. **Historical task results must keep parsing.** Customer S3 buckets contain `GateModelTaskResult` JSON with `additionalMetadata.action` of type `JaqcdProgram`. `task.result()` deserializing those into Pydantic models cannot break.
2. **External callers may need to produce JAQCD** for tooling, debugging, or integration with the local simulator's JAQCD path.

So this PR is purely additive: warning + default flip + docstring.

### Internal-caller audit

Verified that internal BDK callers of `Circuit.to_ir()` already pass `ir_type` explicitly:

- `src/braket/aws/aws_quantum_task.py` — uses `IRType.OPENQASM` (line 669 area).
- `src/braket/devices/local_simulator.py` — explicit `IRType.OPENQASM` and `IRType.JAQCD` branches based on the simulator's advertised actions.

Therefore the default flip does not silently change service-bound payloads.

## Testing done

```
tox -e unit-tests   # 3299 passed, 131 xfailed, 28 warnings
tox -e linters      # ruff format + ruff check, all clean
```

Test changes:
- Existing tests that asserted JAQCD shape via the no-arg default (`test_ir_empty_instructions_result_types`, `test_ir_non_empty_instructions_result_types`, `test_ir_non_empty_instructions_result_types_basis_rotation_instructions`) now pass `IRType.JAQCD` explicitly and wrap in `pytest.warns(UserWarning, match=\"JAQCD\")`. The shape assertions are unchanged.
- `test_barrier_jaqcd_export_fails` likewise wrapped.
- `test_run_jaqcd_only` (`test/unit_tests/braket/devices/test_local_simulator.py`) wrapped in `pytest.warns` — the LocalSimulator's JAQCD-fallback payload constructor now correctly emits the deprecation warning when the simulator advertises only JAQCD.
- New tests in `test_circuit.py`:
  - `test_to_ir_default_is_openqasm`
  - `test_to_ir_jaqcd_emits_warning`
  - `test_to_ir_default_emits_no_jaqcd_warning`

Manual verification (visible-by-default warning, customer-facing migration):

```python
# In a fresh interpreter, no warnings filters set:
from braket.circuits import Circuit
from braket.circuits.serialization import IRType
Circuit().h(0).to_ir(IRType.JAQCD)
# stderr: <string>:4: UserWarning: JAQCD IR is deprecated and will be removed
# in a future release. Use IRType.OPENQASM instead. ...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
