### PR TITLE
fix: raise DiscretizationError when rydbergLocal params missing

### DIFF
--- a/src/braket/ahs/local_detuning.py
+++ b/src/braket/ahs/local_detuning.py
@@ -13,7 +13,7 @@
 
 from __future__ import annotations
 
-from braket.ahs.discretization_types import DiscretizationProperties
+from braket.ahs.discretization_types import DiscretizationError, DiscretizationProperties
 from braket.ahs.field import Field
 from braket.ahs.hamiltonian import Hamiltonian
 from braket.ahs.pattern import Pattern
@@ -149,12 +149,19 @@ class LocalDetuning(Hamiltonian):
 
         Returns:
             LocalDetuning: A new discretized LocalDetuning.
+
+        Raises:
+            DiscretizationError: If local detuning parameters are not available from
+                the device properties.
         """
         local_detuning_parameters = properties.rydberg.rydbergLocal
-        time_resolution = (
-            local_detuning_parameters.timeResolution if local_detuning_parameters else None
-        )
+        if not local_detuning_parameters:
+            raise DiscretizationError(
+                "Local detuning parameters (rydbergLocal) are not available from the device "
+                "properties. Ensure that the device supports local detuning and that the "
+                "rydbergLocal capability data is returned by GetDevice."
+            )
         discretized_magnitude = self.magnitude.discretize(
-            time_resolution=time_resolution,
+            time_resolution=local_detuning_parameters.timeResolution,
         )
         return LocalDetuning(discretized_magnitude)

--- a/test/unit_tests/braket/ahs/test_local_detuning.py
+++ b/test/unit_tests/braket/ahs/test_local_detuning.py
@@ -15,6 +15,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from braket.ahs.discretization_types import DiscretizationError
 from braket.ahs.hamiltonian import Hamiltonian
 from braket.ahs.local_detuning import LocalDetuning
 from braket.timings.time_series import StitchBoundaryCondition
@@ -132,6 +133,15 @@ def test_discretize():
     )
     assert field is not discretized_field
     assert discretized_field.magnitude == magnitude_mock.discretize.return_value
+
+
+def test_discretize_raises_when_rydberg_local_missing():
+    magnitude_mock = Mock()
+    mock_properties = Mock()
+    mock_properties.rydberg.rydbergLocal = None
+    field = LocalDetuning(magnitude=magnitude_mock)
+    with pytest.raises(DiscretizationError, match="rydbergLocal"):
+        field.discretize(mock_properties)
 
 
 @pytest.mark.xfail(raises=ValueError)


### PR DESCRIPTION
The discretize() function on LocalDetuning previously silently fell through with no time resolution when rydbergLocal was unavailable from GetDevice, producing invalid output that failed downstream validation. Now raises DiscretizationError with a clear message.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
