### PR TITLE
deprecation: change Circuit.to_ir default to OpenQASM, warn on JAQCD

### DIFF
--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -13,6 +13,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections import Counter
 from collections.abc import Callable, Iterable, Sequence
 from numbers import Number
@@ -1311,7 +1312,7 @@ class Circuit:
 
     def to_ir(
         self,
-        ir_type: IRType = IRType.JAQCD,
+        ir_type: IRType = IRType.OPENQASM,
         serialization_properties: SerializationProperties | None = None,
         gate_definitions: dict[tuple[Gate, QubitSet], PulseSequence] | None = None,
     ) -> OpenQasmProgram | JaqcdProgram:
@@ -1337,6 +1338,10 @@ class Circuit:
         """
         gate_definitions = gate_definitions or {}
         if ir_type == IRType.JAQCD:
+            warnings.warn(
+                "The JAQCD action type is deprecated. Please use OpenQASM 3 programs instead.",
+                stacklevel=2,
+            )
             return self._to_jaqcd()
         if ir_type == IRType.OPENQASM:
             if serialization_properties and not isinstance(

--- a/src/braket/devices/local_simulator.py
+++ b/src/braket/devices/local_simulator.py
@@ -262,9 +262,6 @@ class LocalSimulator(Device):
             program = circuit.to_ir(ir_type=IRType.OPENQASM)
             program.inputs.update(inputs or {})
             return program
-        if DeviceActionType.JAQCD in simulator.properties.action:
-            validate_circuit_and_shots(circuit, shots)
-            return circuit.to_ir(ir_type=IRType.JAQCD)
         raise NotImplementedError(f"{type(simulator)} does not support qubit gate-based programs")
 
     @_construct_payload.register

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -1184,9 +1184,9 @@ def test_subroutine_nested():
 
 def test_ir_empty_instructions_result_types():
     circ = Circuit()
-    assert circ.to_ir() == jaqcd.Program(
-        instructions=[], results=[], basis_rotation_instructions=[]
-    )
+    with pytest.warns(UserWarning, match="JAQCD"):
+        ir = circ.to_ir(IRType.JAQCD)
+    assert ir == jaqcd.Program(instructions=[], results=[], basis_rotation_instructions=[])
 
 
 def test_ir_non_empty_instructions_result_types():
@@ -1196,7 +1196,9 @@ def test_ir_non_empty_instructions_result_types():
         results=[jaqcd.Probability(targets=[0, 1])],
         basis_rotation_instructions=[],
     )
-    assert circ.to_ir() == expected
+    with pytest.warns(UserWarning, match="JAQCD"):
+        ir = circ.to_ir(IRType.JAQCD)
+    assert ir == expected
 
 
 def test_ir_non_empty_instructions_result_types_basis_rotation_instructions():
@@ -1206,7 +1208,16 @@ def test_ir_non_empty_instructions_result_types_basis_rotation_instructions():
         results=[jaqcd.Sample(observable=["x"], targets=[0])],
         basis_rotation_instructions=[jaqcd.H(target=0)],
     )
-    assert circ.to_ir() == expected
+    with pytest.warns(UserWarning, match="JAQCD"):
+        ir = circ.to_ir(IRType.JAQCD)
+    assert ir == expected
+
+
+def test_to_ir_default_is_openqasm():
+    """Calling Circuit.to_ir() with no ir_type argument should return an
+    OpenQASM program (after the JAQCD-deprecation default flip)."""
+    circ = Circuit().h(0).cnot(0, 1)
+    assert isinstance(circ.to_ir(), OpenQasmProgram)
 
 
 @pytest.mark.parametrize(
@@ -3815,5 +3826,8 @@ def test_barrier_openqasm_export_all_qubits():
 
 def test_barrier_jaqcd_export_fails():
     circ = Circuit().h(0).barrier([0, 1])
-    with pytest.raises(NotImplementedError, match="Barrier is not supported in JAQCD"):
+    with (
+        pytest.warns(UserWarning, match="JAQCD"),
+        pytest.raises(NotImplementedError, match="Barrier is not supported in JAQCD"),
+    ):
         circ.to_ir(IRType.JAQCD)

--- a/test/unit_tests/braket/devices/test_local_simulator.py
+++ b/test/unit_tests/braket/devices/test_local_simulator.py
@@ -689,13 +689,11 @@ def test_run_program_model_inputs():
     assert task.result() == GateModelQuantumTaskResult.from_object(GATE_MODEL_RESULT)
 
 
-def test_run_jaqcd_only():
+def test_run_jaqcd_only_raises():
     dummy = DummyJaqcdSimulator()
     sim = LocalSimulator(dummy)
-    task = sim.run(Circuit().h(0).cnot(0, 1), 10)
-    dummy.assert_shots(10)
-    dummy.assert_qubits(None)
-    assert task.result() == GateModelQuantumTaskResult.from_object(GATE_MODEL_RESULT)
+    with pytest.raises(NotImplementedError, match="does not support qubit gate-based programs"):
+        sim.run(Circuit().h(0).cnot(0, 1), 10)
 
 
 def test_run_program_model():


### PR DESCRIPTION
JAQCD is being deprecated in favor of OpenQASM 3.

*Issue #, if available:*

*Description of changes:*

Changed default for `Circuit.to_ir` to OpenQASM instead of JAQCD. Added a deprecation warning on the local sim for jaqcd programs 

*Testing done:*

Unit tests passing.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
