### PR TITLE
feature: support division in FreeParameterExpression string constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Bug Fixes and Other Changes
 
  * raise DiscretizationError when rydbergLocal params missing
- * support division in FreeParameterExpression string constructor, fixing QBP#153
 
 ## v1.117.3 (2026-05-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes and Other Changes
 
  * raise DiscretizationError when rydbergLocal params missing
+ * support division in FreeParameterExpression string constructor, fixing QBP#153
 
 ## v1.117.3 (2026-05-14)
 

--- a/src/braket/parametric/free_parameter_expression.py
+++ b/src/braket/parametric/free_parameter_expression.py
@@ -54,6 +54,7 @@ class FreeParameterExpression:
             ast.Add: self.__add__,
             ast.Sub: self.__sub__,
             ast.Mult: self.__mul__,
+            ast.Div: self.__truediv__,
             ast.Pow: self.__pow__,
             ast.USub: self.__neg__,
         }

--- a/test/unit_tests/braket/parametric/test_free_parameter_expression.py
+++ b/test/unit_tests/braket/parametric/test_free_parameter_expression.py
@@ -54,7 +54,7 @@ def test_equality_str():
 
 @pytest.mark.xfail(raises=ValueError)
 def test_unsupported_bin_op_str():
-    FreeParameterExpression("theta/1")
+    FreeParameterExpression("theta//1")
 
 
 @pytest.mark.xfail(raises=ValueError)
@@ -115,6 +115,14 @@ def test_r_truediv():
     r_truediv_expr = 1 / FreeParameter("theta")
     expected = FreeParameterExpression(1 / FreeParameter("theta"))
     assert r_truediv_expr == expected
+
+
+def test_truediv_str():
+    truediv_str_expr = FreeParameterExpression("theta/alpha") 
+    expected = FreeParameterExpression(FreeParameter("theta")) / FreeParameterExpression(
+        FreeParameter("alpha"))
+    
+    assert truediv_str_expr == expected
 
 
 def test_pow():

--- a/test/unit_tests/braket/parametric/test_free_parameter_expression.py
+++ b/test/unit_tests/braket/parametric/test_free_parameter_expression.py
@@ -118,11 +118,26 @@ def test_r_truediv():
 
 
 def test_truediv_str():
-    truediv_str_expr = FreeParameterExpression("theta/alpha") 
+    truediv_str_expr = FreeParameterExpression("theta/alpha")
     expected = FreeParameterExpression(FreeParameter("theta")) / FreeParameterExpression(
-        FreeParameter("alpha"))
-    
+        FreeParameter("alpha")
+    )
+
     assert truediv_str_expr == expected
+
+
+@pytest.mark.parametrize(
+    ("string_expression", "operator_expression"),
+    [
+        ("theta+alpha", FreeParameter("theta") + FreeParameter("alpha")),
+        ("theta-alpha", FreeParameter("theta") - FreeParameter("alpha")),
+        ("theta*alpha", FreeParameter("theta") * FreeParameter("alpha")),
+        ("theta/alpha", FreeParameter("theta") / FreeParameter("alpha")),
+        ("theta**alpha", FreeParameter("theta") ** FreeParameter("alpha")),
+    ],
+)
+def test_basic_operator_str_matches_python_operator(string_expression, operator_expression):
+    assert FreeParameterExpression(string_expression) == operator_expression
 
 
 def test_pow():


### PR DESCRIPTION
*Issue #1251:*

*Description of changes:*
- Added ast.Div: self.__truediv__, to the FreeParameterExpression string parser operation whitelist so expressions like FreeParameterExpression("alpha/beta") are accepted.
- Added a unit test for the string-constructor division path, matching the existing test_truediv operator-path behavior.
- Updated the unsupported binary-operator string test to use //, since / is now supported.
- Added a CHANGELOG.md bug-fix entry referencing QBP#153.

*Testing done:*
- Ran targeted unit tests:
  `.\.venv\Scripts\python.exe -m pytest -o addopts='' test/unit_tests/braket/parametric/test_free_parameter_expression.py -v`
and verified that new and existing test still passes.
- Verified the QBP reproducer succeeds locally:
  `to_braket(qc)` with `qc.rx(x / y, 0)` completed without raising `ValueError: Unsupported binary operation: <class 'ast.Div'>`.


*AI assistance disclosure:*

I used ChatGPT/Codex to help understand the failing test path, discuss where to add the regression test, and review local pytest output. I manually applied the changes, verified the behavior, and ran the targeted unit tests locally.

## Merge Checklist


#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Closes #1251