### PR TITLE
feature: support math functions in FreeParameterExpression

### DIFF
--- a/src/braket/parametric/__init__.py
+++ b/src/braket/parametric/__init__.py
@@ -14,10 +14,24 @@
 """You can define a circuit with gates that depend on free parameters and specify
 the values of these parameters when submitting the circuit as a quantum task.
 This module provides FreeParameter for defining symbolic parameters,
-FreeParameterExpression for mathematical expressions, and Parameterizable
-interface for parameter binding.
+FreeParameterExpression for mathematical expressions, math helper functions,
+and Parameterizable interface for parameter binding.
 """
 
 from braket.parametric.free_parameter import FreeParameter  # noqa: F401
 from braket.parametric.free_parameter_expression import FreeParameterExpression  # noqa: F401
+from braket.parametric.functions import (
+    arccos,  # noqa: F401
+    arcsin,  # noqa: F401
+    arctan,  # noqa: F401
+    ceiling,  # noqa: F401
+    cos,  # noqa: F401
+    exp,  # noqa: F401
+    floor,  # noqa: F401
+    log,  # noqa: F401
+    mod,  # noqa: F401
+    sin,  # noqa: F401
+    sqrt,  # noqa: F401
+    tan,  # noqa: F401
+)
 from braket.parametric.parameterizable import Parameterizable  # noqa: F401

--- a/src/braket/parametric/free_parameter_expression.py
+++ b/src/braket/parametric/free_parameter_expression.py
@@ -17,11 +17,39 @@ import ast
 import operator
 from functools import reduce
 from numbers import Number
-from typing import Any
+from typing import Any, ClassVar
 
 import sympy
 from oqpy.base import OQPyExpression
 from oqpy.classical_types import FloatVar
+from sympy.printing.str import StrPrinter
+
+
+class _OpenQASMExpressionPrinter(StrPrinter):
+    _FN_MAP: ClassVar[dict[type, str]] = {
+        sympy.sin: "sin",
+        sympy.cos: "cos",
+        sympy.tan: "tan",
+        sympy.asin: "arcsin",
+        sympy.acos: "arccos",
+        sympy.atan: "arctan",
+        sympy.exp: "exp",
+        sympy.log: "log",
+        sympy.Mod: "mod",
+        sympy.ceiling: "ceiling",
+        sympy.floor: "floor",
+    }
+
+    def _print_Function(self, expr: sympy.Function) -> str:
+        function_name = self._FN_MAP.get(expr.func)
+        if not function_name:
+            raise ValueError(f"No OpenQASM 3 equivalent for {expr.func.__name__}")
+        args = ", ".join(self._print(arg) for arg in expr.args)
+        return f"{function_name}({args})"
+
+
+def _openqasm_doprint(expression: Number | sympy.Expr) -> str:
+    return _OpenQASMExpressionPrinter().doprint(expression)
 
 
 class FreeParameterExpression:
@@ -31,6 +59,8 @@ class FreeParameterExpression:
     FreeParametersExpressions can hold FreeParameters that can later be
     swapped out for a number. Circuits or PulseSequences with FreeParameters
     present will NOT run. Values must be substituted prior to execution.
+    String representations of supported SymPy functions use OpenQASM-compatible
+    names.
     """
 
     def __init__(self, expression: FreeParameterExpression | Number | sympy.Expr | str):
@@ -177,9 +207,17 @@ class FreeParameterExpression:
         """The representation of the :class:'FreeParameterExpression'.
 
         Returns:
-            str: The expression of the class:'FreeParameterExpression' to represent the class.
+            str: The OpenQASM-compatible string for the expression.
         """
-        return repr(self.expression)
+        return str(self)
+
+    def __str__(self) -> str:
+        """The string representation of the :class:'FreeParameterExpression'.
+
+        Returns:
+            str: The OpenQASM-compatible string for the expression.
+        """
+        return _openqasm_doprint(self.expression)
 
     def _to_oqpy_expression(self) -> OQPyExpression:
         """Transforms into an OQPyExpression.

--- a/src/braket/parametric/free_parameter_expression.py
+++ b/src/braket/parametric/free_parameter_expression.py
@@ -42,7 +42,7 @@ class _OpenQASMExpressionPrinter(StrPrinter):
 
     def _print_Function(self, expr: sympy.Function) -> str:
         function_name = self._FN_MAP.get(expr.func)
-        if not function_name:
+        if function_name is None:
             raise ValueError(f"No OpenQASM 3 equivalent for {expr.func.__name__}")
         args = ", ".join(self._print(arg) for arg in expr.args)
         return f"{function_name}({args})"

--- a/src/braket/parametric/functions.py
+++ b/src/braket/parametric/functions.py
@@ -1,0 +1,192 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+"""Math helper functions for free parameter expressions.
+
+These helpers let you build symbolic OpenQASM math expressions without importing
+SymPy or touching the internal expression attribute.
+
+Examples:
+    >>> from braket.parametric import FreeParameter, cos, sin
+    >>> alpha = FreeParameter("alpha")
+    >>> expr = sin(alpha / 2) ** 2 + cos(alpha / 2) ** 2
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from numbers import Number
+
+import sympy
+
+from braket.parametric.free_parameter_expression import FreeParameterExpression
+
+
+def _expression(value: FreeParameterExpression | Number) -> Number | sympy.Expr:
+    return value.expression if isinstance(value, FreeParameterExpression) else value
+
+
+def _wrap(
+    function: Callable[..., Number | sympy.Expr],
+    *args: FreeParameterExpression | Number,
+) -> FreeParameterExpression:
+    sympy_args = [_expression(arg) for arg in args]
+    return FreeParameterExpression(function(*sympy_args))
+
+
+def sin(x: FreeParameterExpression | Number) -> FreeParameterExpression:
+    """Returns the sine of a free parameter expression.
+
+    Args:
+        x (FreeParameterExpression | FreeParameter | Number): The expression.
+
+    Returns:
+        FreeParameterExpression: The symbolic sine expression.
+    """
+    return _wrap(sympy.sin, x)
+
+
+def cos(x: FreeParameterExpression | Number) -> FreeParameterExpression:
+    """Returns the cosine of a free parameter expression.
+
+    Args:
+        x (FreeParameterExpression | FreeParameter | Number): The expression.
+
+    Returns:
+        FreeParameterExpression: The symbolic cosine expression.
+    """
+    return _wrap(sympy.cos, x)
+
+
+def tan(x: FreeParameterExpression | Number) -> FreeParameterExpression:
+    """Returns the tangent of a free parameter expression.
+
+    Args:
+        x (FreeParameterExpression | FreeParameter | Number): The expression.
+
+    Returns:
+        FreeParameterExpression: The symbolic tangent expression.
+    """
+    return _wrap(sympy.tan, x)
+
+
+def arcsin(x: FreeParameterExpression | Number) -> FreeParameterExpression:
+    """Returns the arcsine (inverse sine) of a free parameter expression.
+
+    Args:
+        x (FreeParameterExpression | FreeParameter | Number): The expression.
+
+    Returns:
+        FreeParameterExpression: The symbolic arcsine expression.
+    """
+    return _wrap(sympy.asin, x)
+
+
+def arccos(x: FreeParameterExpression | Number) -> FreeParameterExpression:
+    """Returns the arccosine (inverse cosine) of a free parameter expression.
+
+    Args:
+        x (FreeParameterExpression | FreeParameter | Number): The expression.
+
+    Returns:
+        FreeParameterExpression: The symbolic arccosine expression.
+    """
+    return _wrap(sympy.acos, x)
+
+
+def arctan(x: FreeParameterExpression | Number) -> FreeParameterExpression:
+    """Returns the arctangent (inverse tangent) of a free parameter expression.
+
+    Args:
+        x (FreeParameterExpression | FreeParameter | Number): The expression.
+
+    Returns:
+        FreeParameterExpression: The symbolic arctangent expression.
+    """
+    return _wrap(sympy.atan, x)
+
+
+def exp(x: FreeParameterExpression | Number) -> FreeParameterExpression:
+    """Returns the exponential of a free parameter expression.
+
+    Args:
+        x (FreeParameterExpression | FreeParameter | Number): The expression.
+
+    Returns:
+        FreeParameterExpression: The symbolic exponential expression.
+    """
+    return _wrap(sympy.exp, x)
+
+
+def log(x: FreeParameterExpression | Number) -> FreeParameterExpression:
+    """Returns the natural logarithm of a free parameter expression.
+
+    Args:
+        x (FreeParameterExpression | FreeParameter | Number): The expression.
+
+    Returns:
+        FreeParameterExpression: The symbolic natural logarithm expression.
+    """
+    return _wrap(sympy.log, x)
+
+
+def sqrt(x: FreeParameterExpression | Number) -> FreeParameterExpression:
+    """Returns the square root of a free parameter expression.
+
+    Args:
+        x (FreeParameterExpression | FreeParameter | Number): The expression.
+
+    Returns:
+        FreeParameterExpression: The symbolic square root expression.
+    """
+    return _wrap(sympy.sqrt, x)
+
+
+def mod(
+    x: FreeParameterExpression | Number,
+    m: FreeParameterExpression | Number,
+) -> FreeParameterExpression:
+    """Returns the remainder of a free parameter expression divided by ``m``.
+
+    Args:
+        x (FreeParameterExpression | FreeParameter | Number): The dividend expression.
+        m (FreeParameterExpression | FreeParameter | Number): The divisor expression.
+
+    Returns:
+        FreeParameterExpression: The symbolic modulo expression.
+    """
+    return _wrap(sympy.Mod, x, m)
+
+
+def ceiling(x: FreeParameterExpression | Number) -> FreeParameterExpression:
+    """Returns the ceiling of a free parameter expression.
+
+    Args:
+        x (FreeParameterExpression | FreeParameter | Number): The expression.
+
+    Returns:
+        FreeParameterExpression: The symbolic ceiling expression.
+    """
+    return _wrap(sympy.ceiling, x)
+
+
+def floor(x: FreeParameterExpression | Number) -> FreeParameterExpression:
+    """Returns the floor of a free parameter expression.
+
+    Args:
+        x (FreeParameterExpression | FreeParameter | Number): The expression.
+
+    Returns:
+        FreeParameterExpression: The symbolic floor expression.
+    """
+    return _wrap(sympy.floor, x)

--- a/src/braket/parametric/functions.py
+++ b/src/braket/parametric/functions.py
@@ -17,9 +17,13 @@ These helpers let you build symbolic OpenQASM math expressions without importing
 SymPy or touching the internal expression attribute.
 
 Examples:
-    >>> from braket.parametric import FreeParameter, cos, sin
+    >>> from braket.circuits import Circuit
+    >>> from braket.parametric import FreeParameter, arcsin
     >>> alpha = FreeParameter("alpha")
-    >>> expr = sin(alpha / 2) ** 2 + cos(alpha / 2) ** 2
+    >>> circuit = Circuit().rx(0, arcsin(alpha))
+    >>> source = circuit.to_ir("OPENQASM").source
+    >>> "rx(arcsin(alpha)) q[0];" in source
+    True
 """
 
 from __future__ import annotations
@@ -48,7 +52,7 @@ def sin(x: FreeParameterExpression | Number) -> FreeParameterExpression:
     """Returns the sine of a free parameter expression.
 
     Args:
-        x (FreeParameterExpression | FreeParameter | Number): The expression.
+        x (FreeParameterExpression | Number): The expression.
 
     Returns:
         FreeParameterExpression: The symbolic sine expression.
@@ -60,7 +64,7 @@ def cos(x: FreeParameterExpression | Number) -> FreeParameterExpression:
     """Returns the cosine of a free parameter expression.
 
     Args:
-        x (FreeParameterExpression | FreeParameter | Number): The expression.
+        x (FreeParameterExpression | Number): The expression.
 
     Returns:
         FreeParameterExpression: The symbolic cosine expression.
@@ -72,7 +76,7 @@ def tan(x: FreeParameterExpression | Number) -> FreeParameterExpression:
     """Returns the tangent of a free parameter expression.
 
     Args:
-        x (FreeParameterExpression | FreeParameter | Number): The expression.
+        x (FreeParameterExpression | Number): The expression.
 
     Returns:
         FreeParameterExpression: The symbolic tangent expression.
@@ -84,7 +88,7 @@ def arcsin(x: FreeParameterExpression | Number) -> FreeParameterExpression:
     """Returns the arcsine (inverse sine) of a free parameter expression.
 
     Args:
-        x (FreeParameterExpression | FreeParameter | Number): The expression.
+        x (FreeParameterExpression | Number): The expression.
 
     Returns:
         FreeParameterExpression: The symbolic arcsine expression.
@@ -96,7 +100,7 @@ def arccos(x: FreeParameterExpression | Number) -> FreeParameterExpression:
     """Returns the arccosine (inverse cosine) of a free parameter expression.
 
     Args:
-        x (FreeParameterExpression | FreeParameter | Number): The expression.
+        x (FreeParameterExpression | Number): The expression.
 
     Returns:
         FreeParameterExpression: The symbolic arccosine expression.
@@ -108,7 +112,7 @@ def arctan(x: FreeParameterExpression | Number) -> FreeParameterExpression:
     """Returns the arctangent (inverse tangent) of a free parameter expression.
 
     Args:
-        x (FreeParameterExpression | FreeParameter | Number): The expression.
+        x (FreeParameterExpression | Number): The expression.
 
     Returns:
         FreeParameterExpression: The symbolic arctangent expression.
@@ -120,7 +124,7 @@ def exp(x: FreeParameterExpression | Number) -> FreeParameterExpression:
     """Returns the exponential of a free parameter expression.
 
     Args:
-        x (FreeParameterExpression | FreeParameter | Number): The expression.
+        x (FreeParameterExpression | Number): The expression.
 
     Returns:
         FreeParameterExpression: The symbolic exponential expression.
@@ -132,7 +136,7 @@ def log(x: FreeParameterExpression | Number) -> FreeParameterExpression:
     """Returns the natural logarithm of a free parameter expression.
 
     Args:
-        x (FreeParameterExpression | FreeParameter | Number): The expression.
+        x (FreeParameterExpression | Number): The expression.
 
     Returns:
         FreeParameterExpression: The symbolic natural logarithm expression.
@@ -144,7 +148,7 @@ def sqrt(x: FreeParameterExpression | Number) -> FreeParameterExpression:
     """Returns the square root of a free parameter expression.
 
     Args:
-        x (FreeParameterExpression | FreeParameter | Number): The expression.
+        x (FreeParameterExpression | Number): The expression.
 
     Returns:
         FreeParameterExpression: The symbolic square root expression.
@@ -159,8 +163,8 @@ def mod(
     """Returns the remainder of a free parameter expression divided by ``m``.
 
     Args:
-        x (FreeParameterExpression | FreeParameter | Number): The dividend expression.
-        m (FreeParameterExpression | FreeParameter | Number): The divisor expression.
+        x (FreeParameterExpression | Number): The dividend expression.
+        m (FreeParameterExpression | Number): The divisor expression.
 
     Returns:
         FreeParameterExpression: The symbolic modulo expression.
@@ -172,7 +176,7 @@ def ceiling(x: FreeParameterExpression | Number) -> FreeParameterExpression:
     """Returns the ceiling of a free parameter expression.
 
     Args:
-        x (FreeParameterExpression | FreeParameter | Number): The expression.
+        x (FreeParameterExpression | Number): The expression.
 
     Returns:
         FreeParameterExpression: The symbolic ceiling expression.
@@ -184,7 +188,7 @@ def floor(x: FreeParameterExpression | Number) -> FreeParameterExpression:
     """Returns the floor of a free parameter expression.
 
     Args:
-        x (FreeParameterExpression | FreeParameter | Number): The expression.
+        x (FreeParameterExpression | Number): The expression.
 
     Returns:
         FreeParameterExpression: The symbolic floor expression.

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -15,6 +15,7 @@ from unittest.mock import Mock
 
 import numpy as np
 import pytest
+import sympy
 
 import braket.ir.jaqcd as jaqcd
 from braket.circuits import (
@@ -1254,6 +1255,33 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
         )
         == expected_ir
     )
+
+
+def test_circuit_openqasm_uses_openqasm_free_parameter_expression_name():
+    alpha = FreeParameter("alpha")
+    expr = FreeParameterExpression(sympy.asin(alpha.expression))
+    source = Circuit().rx(0, expr).measure(0).to_ir(IRType.OPENQASM).source
+
+    assert "rx(arcsin(alpha)) q[0];" in source
+
+
+@pytest.mark.parametrize(
+    ("function", "extra_args", "expected_parameter"),
+    [
+        (sympy.asin, (), "arcsin(alpha)"),
+        (sympy.acos, (), "arccos(alpha)"),
+        (sympy.atan, (), "arctan(alpha)"),
+        (sympy.Mod, (2,), "mod(alpha, 2)"),
+    ],
+)
+def test_circuit_openqasm_emits_supported_free_parameter_expression_names(
+    function, extra_args, expected_parameter
+):
+    alpha = FreeParameter("alpha")
+    expr = FreeParameterExpression(function(alpha.expression, *extra_args))
+    source = Circuit().rx(0, expr).measure(0).to_ir(IRType.OPENQASM).source
+
+    assert f"rx({expected_parameter}) q[0];" in source
 
 
 @pytest.mark.parametrize(

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -15,7 +15,6 @@ from unittest.mock import Mock
 
 import numpy as np
 import pytest
-import sympy
 
 import braket.ir.jaqcd as jaqcd
 from braket.circuits import (
@@ -45,20 +44,6 @@ from braket.circuits.serialization import (
 )
 from braket.circuits.translations import braket_result_to_result_type
 from braket.ir.openqasm import Program as OpenQasmProgram
-from braket.parametric import (
-    arccos,
-    arcsin,
-    arctan,
-    ceiling,
-    cos,
-    exp,
-    floor,
-    log,
-    mod,
-    sin,
-    sqrt,
-    tan,
-)
 from braket.pulse import DragGaussianWaveform, Frame, GaussianWaveform, Port, PulseSequence
 
 
@@ -1269,67 +1254,6 @@ def test_circuit_to_ir_openqasm(circuit, serialization_properties, expected_ir):
         )
         == expected_ir
     )
-
-
-def test_circuit_openqasm_uses_openqasm_free_parameter_expression_name():
-    alpha = FreeParameter("alpha")
-    expr = FreeParameterExpression(sympy.asin(alpha.expression))
-    source = Circuit().rx(0, expr).measure(0).to_ir(IRType.OPENQASM).source
-
-    assert "rx(arcsin(alpha)) q[0];" in source
-
-
-@pytest.mark.parametrize(
-    ("function", "extra_args", "expected_parameter"),
-    [
-        (sympy.asin, (), "arcsin(alpha)"),
-        (sympy.acos, (), "arccos(alpha)"),
-        (sympy.atan, (), "arctan(alpha)"),
-        (sympy.Mod, (2,), "mod(alpha, 2)"),
-    ],
-)
-def test_circuit_openqasm_emits_supported_free_parameter_expression_names(
-    function, extra_args, expected_parameter
-):
-    alpha = FreeParameter("alpha")
-    expr = FreeParameterExpression(function(alpha.expression, *extra_args))
-    source = Circuit().rx(0, expr).measure(0).to_ir(IRType.OPENQASM).source
-
-    assert f"rx({expected_parameter}) q[0];" in source
-
-
-@pytest.mark.parametrize(
-    ("build_expr", "expected_parameter"),
-    [
-        (lambda alpha: sin(alpha), "sin(alpha)"),
-        (lambda alpha: cos(alpha), "cos(alpha)"),
-        (lambda alpha: tan(alpha), "tan(alpha)"),
-        (lambda alpha: arcsin(alpha), "arcsin(alpha)"),
-        (lambda alpha: arccos(alpha), "arccos(alpha)"),
-        (lambda alpha: arctan(alpha), "arctan(alpha)"),
-        (lambda alpha: exp(alpha), "exp(alpha)"),
-        (lambda alpha: log(alpha), "log(alpha)"),
-        (lambda alpha: sqrt(alpha), "sqrt(alpha)"),
-        (lambda alpha: mod(alpha, 2), "mod(alpha, 2)"),
-        (lambda alpha: ceiling(alpha), "ceiling(alpha)"),
-        (lambda alpha: floor(alpha), "floor(alpha)"),
-    ],
-)
-def test_circuit_openqasm_emits_parametric_math_helpers(build_expr, expected_parameter):
-    alpha = FreeParameter("alpha")
-    source = Circuit().rx(0, build_expr(alpha)).measure(0).to_ir(IRType.OPENQASM).source
-
-    assert f"rx({expected_parameter}) q[0];" in source
-
-
-def test_circuit_openqasm_emits_composed_parametric_math_helper_expression():
-    alpha = FreeParameter("alpha")
-    expr = sin(alpha / 2) ** 2 + cos(alpha / 2) ** 2
-    source = Circuit().rx(0, expr).measure(0).to_ir(IRType.OPENQASM).source
-
-    assert "sin(" in source
-    assert "cos(" in source
-    assert "alpha" in source
 
 
 @pytest.mark.parametrize(

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -45,6 +45,20 @@ from braket.circuits.serialization import (
 )
 from braket.circuits.translations import braket_result_to_result_type
 from braket.ir.openqasm import Program as OpenQasmProgram
+from braket.parametric import (
+    arccos,
+    arcsin,
+    arctan,
+    ceiling,
+    cos,
+    exp,
+    floor,
+    log,
+    mod,
+    sin,
+    sqrt,
+    tan,
+)
 from braket.pulse import DragGaussianWaveform, Frame, GaussianWaveform, Port, PulseSequence
 
 
@@ -1282,6 +1296,40 @@ def test_circuit_openqasm_emits_supported_free_parameter_expression_names(
     source = Circuit().rx(0, expr).measure(0).to_ir(IRType.OPENQASM).source
 
     assert f"rx({expected_parameter}) q[0];" in source
+
+
+@pytest.mark.parametrize(
+    ("build_expr", "expected_parameter"),
+    [
+        (lambda alpha: sin(alpha), "sin(alpha)"),
+        (lambda alpha: cos(alpha), "cos(alpha)"),
+        (lambda alpha: tan(alpha), "tan(alpha)"),
+        (lambda alpha: arcsin(alpha), "arcsin(alpha)"),
+        (lambda alpha: arccos(alpha), "arccos(alpha)"),
+        (lambda alpha: arctan(alpha), "arctan(alpha)"),
+        (lambda alpha: exp(alpha), "exp(alpha)"),
+        (lambda alpha: log(alpha), "log(alpha)"),
+        (lambda alpha: sqrt(alpha), "sqrt(alpha)"),
+        (lambda alpha: mod(alpha, 2), "mod(alpha, 2)"),
+        (lambda alpha: ceiling(alpha), "ceiling(alpha)"),
+        (lambda alpha: floor(alpha), "floor(alpha)"),
+    ],
+)
+def test_circuit_openqasm_emits_parametric_math_helpers(build_expr, expected_parameter):
+    alpha = FreeParameter("alpha")
+    source = Circuit().rx(0, build_expr(alpha)).measure(0).to_ir(IRType.OPENQASM).source
+
+    assert f"rx({expected_parameter}) q[0];" in source
+
+
+def test_circuit_openqasm_emits_composed_parametric_math_helper_expression():
+    alpha = FreeParameter("alpha")
+    expr = sin(alpha / 2) ** 2 + cos(alpha / 2) ** 2
+    source = Circuit().rx(0, expr).measure(0).to_ir(IRType.OPENQASM).source
+
+    assert "sin(" in source
+    assert "cos(" in source
+    assert "alpha" in source
 
 
 @pytest.mark.parametrize(

--- a/test/unit_tests/braket/devices/test_local_simulator.py
+++ b/test/unit_tests/braket/devices/test_local_simulator.py
@@ -697,6 +697,8 @@ def test_local_simulator_runs_sympy_inverse_trig_free_parameter_expression():
     expr = FreeParameterExpression(sympy.asin(alpha.expression))
     circuit = Circuit().rx(0, expr).measure(0)
 
+    assert "arcsin(alpha)" in circuit.to_ir("OPENQASM").source
+
     device = LocalSimulator(StateVectorSimulator())
     result = device.run(circuit, inputs={"alpha": 0.5}, shots=10).result()
 

--- a/test/unit_tests/braket/devices/test_local_simulator.py
+++ b/test/unit_tests/braket/devices/test_local_simulator.py
@@ -693,7 +693,6 @@ def test_run_program_model_inputs():
 
 
 def test_local_simulator_runs_sympy_inverse_trig_free_parameter_expression():
-    # Use StateVectorSimulator directly so OpenQASM validation runs.
     alpha = FreeParameter("alpha")
     expr = FreeParameterExpression(sympy.asin(alpha.expression))
     circuit = Circuit().rx(0, expr).measure(0)
@@ -705,7 +704,6 @@ def test_local_simulator_runs_sympy_inverse_trig_free_parameter_expression():
 
 
 def test_local_simulator_runs_parametric_math_helper_expression():
-    # Use StateVectorSimulator directly so OpenQASM validation runs.
     alpha = FreeParameter("alpha")
     expr = sin(alpha / 2) ** 2 + cos(alpha / 2) ** 2
     circuit = Circuit().rx(0, expr).measure(0)

--- a/test/unit_tests/braket/devices/test_local_simulator.py
+++ b/test/unit_tests/braket/devices/test_local_simulator.py
@@ -20,6 +20,7 @@ from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
+import sympy
 from pydantic.v1 import create_model  # This is temporary for defining properties below
 
 import braket.ir as ir
@@ -27,9 +28,10 @@ from braket.ahs.analog_hamiltonian_simulation import AnalogHamiltonianSimulation
 from braket.ahs.atom_arrangement import AtomArrangement
 from braket.ahs.hamiltonian import Hamiltonian
 from braket.annealing import Problem, ProblemType
-from braket.circuits import Circuit, FreeParameter, Gate, Noise
+from braket.circuits import Circuit, FreeParameter, FreeParameterExpression, Gate, Noise
 from braket.circuits.noise_model import GateCriteria, NoiseModel, NoiseModelInstruction
 from braket.circuits.serialization import IRType, SerializableProgram
+from braket.default_simulator import StateVectorSimulator
 from braket.device_schema import DeviceActionType, DeviceCapabilities
 from braket.device_schema.openqasm_device_action_properties import (
     OpenQASMDeviceActionProperties,
@@ -687,6 +689,18 @@ def test_run_program_model_inputs():
     program.inputs.update(update_inputs)
     dummy.run.assert_called_with(program, shots=10)
     assert task.result() == GateModelQuantumTaskResult.from_object(GATE_MODEL_RESULT)
+
+
+def test_local_simulator_runs_sympy_inverse_trig_free_parameter_expression():
+    # Use StateVectorSimulator directly so OpenQASM validation runs.
+    alpha = FreeParameter("alpha")
+    expr = FreeParameterExpression(sympy.asin(alpha.expression))
+    circuit = Circuit().rx(0, expr).measure(0)
+
+    device = LocalSimulator(StateVectorSimulator())
+    result = device.run(circuit, inputs={"alpha": 0.5}, shots=10).result()
+
+    assert sum(result.measurement_counts.values()) == 10
 
 
 def test_run_jaqcd_only_raises():

--- a/test/unit_tests/braket/devices/test_local_simulator.py
+++ b/test/unit_tests/braket/devices/test_local_simulator.py
@@ -39,6 +39,7 @@ from braket.device_schema.openqasm_device_action_properties import (
 from braket.devices import LocalSimulator, local_simulator
 from braket.ir.openqasm import Program
 from braket.ir.openqasm.program_set_v1 import ProgramSet as OpenQASMProgramSet
+from braket.parametric import cos, sin
 from braket.program_sets import ProgramSet
 from braket.program_sets.circuit_binding import CircuitBinding
 from braket.simulator import BraketSimulator
@@ -699,6 +700,18 @@ def test_local_simulator_runs_sympy_inverse_trig_free_parameter_expression():
 
     device = LocalSimulator(StateVectorSimulator())
     result = device.run(circuit, inputs={"alpha": 0.5}, shots=10).result()
+
+    assert sum(result.measurement_counts.values()) == 10
+
+
+def test_local_simulator_runs_parametric_math_helper_expression():
+    # Use StateVectorSimulator directly so OpenQASM validation runs.
+    alpha = FreeParameter("alpha")
+    expr = sin(alpha / 2) ** 2 + cos(alpha / 2) ** 2
+    circuit = Circuit().rx(0, expr).measure(0)
+
+    device = LocalSimulator(StateVectorSimulator())
+    result = device.run(circuit, inputs={"alpha": math.pi}, shots=10).result()
 
     assert sum(result.measurement_counts.values()) == 10
 

--- a/test/unit_tests/braket/parametric/test_free_parameter_expression.py
+++ b/test/unit_tests/braket/parametric/test_free_parameter_expression.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 
 import pytest
+import sympy
 
 from braket.parametric import FreeParameter, FreeParameterExpression
 from braket.parametric.free_parameter_expression import subs_if_free_parameter
@@ -50,6 +51,57 @@ def test_equality_str():
     assert expr_1 == expr_2
     assert expr_1.subs(param_values) == expr_2.subs(param_values)
     assert hasattr(expr_1.expression, "free_symbols") and hasattr(expr_2.expression, "free_symbols")
+
+
+@pytest.mark.parametrize(
+    ("function", "extra_args", "expected"),
+    [
+        (sympy.sin, (), "sin(alpha)"),
+        (sympy.cos, (), "cos(alpha)"),
+        (sympy.tan, (), "tan(alpha)"),
+        (sympy.asin, (), "arcsin(alpha)"),
+        (sympy.acos, (), "arccos(alpha)"),
+        (sympy.atan, (), "arctan(alpha)"),
+        (sympy.exp, (), "exp(alpha)"),
+        (sympy.log, (), "log(alpha)"),
+        (sympy.Mod, (2,), "mod(alpha, 2)"),
+        (sympy.ceiling, (), "ceiling(alpha)"),
+        (sympy.floor, (), "floor(alpha)"),
+    ],
+)
+def test_openqasm_function_names(function, extra_args, expected):
+    alpha = FreeParameter("alpha")
+    expr = FreeParameterExpression(function(alpha.expression, *extra_args))
+
+    assert str(expr) == expected
+    assert repr(expr) == expected
+
+
+def test_openqasm_sqrt_function_name():
+    alpha = FreeParameter("alpha")
+    expr = FreeParameterExpression(sympy.sqrt(alpha.expression))
+
+    assert str(expr) == "sqrt(alpha)"
+    assert repr(expr) == "sqrt(alpha)"
+
+
+@pytest.mark.parametrize("stringify", [str, repr])
+@pytest.mark.parametrize("sympy_function", [sympy.Abs, sympy.re, sympy.im, sympy.conjugate])
+def test_unsupported_openqasm_function_raises_value_error(sympy_function, stringify):
+    alpha = FreeParameter("alpha")
+    expr = FreeParameterExpression(sympy_function(alpha.expression))
+
+    with pytest.raises(ValueError, match="No OpenQASM 3 equivalent"):
+        stringify(expr)
+
+
+def test_openqasm_arithmetic_str_and_repr_match():
+    expr = FreeParameter("theta") + 2 * FreeParameter("alpha")
+    expr_str = str(expr)
+
+    assert expr_str == repr(expr)
+    assert "theta" in expr_str
+    assert "alpha" in expr_str
 
 
 @pytest.mark.xfail(raises=ValueError)

--- a/test/unit_tests/braket/parametric/test_functions.py
+++ b/test/unit_tests/braket/parametric/test_functions.py
@@ -80,8 +80,6 @@ def test_sqrt_constructs_expected_expression():
 
     assert isinstance(expr, FreeParameterExpression)
     assert expr == FreeParameterExpression(sympy.sqrt(alpha.expression))
-    assert str(expr) == "sqrt(alpha)"
-    assert repr(expr) == "sqrt(alpha)"
 
 
 def test_helpers_accept_numeric_inputs():
@@ -139,3 +137,22 @@ def test_mod_unwraps_second_operand():
     beta = FreeParameter("beta")
 
     assert str(mod(alpha, beta)) == "mod(alpha, beta)"
+
+
+def test_nested_helper_composition():
+    alpha = FreeParameter("alpha")
+
+    assert str(sin(cos(alpha))) == "sin(cos(alpha))"
+    assert str(arcsin(sqrt(alpha))) == "arcsin(sqrt(alpha))"
+
+
+def test_mixed_function_and_arithmetic_expression():
+    alpha = FreeParameter("alpha")
+    beta = FreeParameter("beta")
+    gamma = FreeParameter("gamma")
+    source = str(sin(alpha) + cos(beta) * sqrt(gamma))
+
+    # SymPy may reorder commutative operands, so check substring containment.
+    assert "sin(alpha)" in source
+    assert "cos(beta)" in source
+    assert "sqrt(gamma)" in source

--- a/test/unit_tests/braket/parametric/test_functions.py
+++ b/test/unit_tests/braket/parametric/test_functions.py
@@ -31,43 +31,21 @@ from braket.parametric import (
     tan,
 )
 
-
-@pytest.mark.parametrize(
-    ("helper", "sympy_function", "extra_args", "expected"),
-    [
-        (sin, sympy.sin, (), "sin(alpha)"),
-        (cos, sympy.cos, (), "cos(alpha)"),
-        (tan, sympy.tan, (), "tan(alpha)"),
-        (arcsin, sympy.asin, (), "arcsin(alpha)"),
-        (arccos, sympy.acos, (), "arccos(alpha)"),
-        (arctan, sympy.atan, (), "arctan(alpha)"),
-        (exp, sympy.exp, (), "exp(alpha)"),
-        (log, sympy.log, (), "log(alpha)"),
-        (mod, sympy.Mod, (2,), "mod(alpha, 2)"),
-        (ceiling, sympy.ceiling, (), "ceiling(alpha)"),
-        (floor, sympy.floor, (), "floor(alpha)"),
-    ],
-)
-def test_helper_constructs_expected_expression(helper, sympy_function, extra_args, expected):
-    alpha = FreeParameter("alpha")
-    expr = helper(alpha, *extra_args)
-    expected_expr = FreeParameterExpression(sympy_function(alpha.expression, *extra_args))
-
-    assert isinstance(expr, FreeParameterExpression)
-    assert expr == expected_expr
-    assert str(expr) == expected
-    assert repr(expr) == expected
-
-
-def test_sqrt_constructs_expected_expression():
-    # SymPy represents sqrt as a Pow expression, so it is verified separately.
-    alpha = FreeParameter("alpha")
-    expr = sqrt(alpha)
-
-    assert isinstance(expr, FreeParameterExpression)
-    assert expr == FreeParameterExpression(sympy.sqrt(alpha.expression))
-    assert str(expr) == "sqrt(alpha)"
-    assert repr(expr) == "sqrt(alpha)"
+# Shared by the parametrized tests below so the helper/SymPy pairing lives in one place.
+HELPER_TO_SYMPY = {
+    sin: sympy.sin,
+    cos: sympy.cos,
+    tan: sympy.tan,
+    arcsin: sympy.asin,
+    arccos: sympy.acos,
+    arctan: sympy.atan,
+    exp: sympy.exp,
+    log: sympy.log,
+    sqrt: sympy.sqrt,
+    mod: sympy.Mod,
+    ceiling: sympy.ceiling,
+    floor: sympy.floor,
+}
 
 
 @pytest.mark.parametrize(
@@ -81,56 +59,53 @@ def test_sqrt_constructs_expected_expression():
         (arctan, ()),
         (exp, ()),
         (log, ()),
-        (sqrt, ()),
         (mod, (2,)),
         (ceiling, ()),
         (floor, ()),
     ],
 )
-def test_helper_expression_round_trip(helper, extra_args):
+def test_helper_constructs_expected_expression(helper, extra_args):
     alpha = FreeParameter("alpha")
-    expr = helper(alpha / 2, *extra_args)
-    rebuilt = FreeParameterExpression(expr.expression)
+    expr = helper(alpha, *extra_args)
+    expected_expr = FreeParameterExpression(HELPER_TO_SYMPY[helper](alpha.expression, *extra_args))
 
-    assert rebuilt == expr
-    assert str(rebuilt) == str(expr)
+    assert isinstance(expr, FreeParameterExpression)
+    assert expr == expected_expr
+
+
+def test_sqrt_constructs_expected_expression():
+    # SymPy represents sqrt as a Pow expression, so it is verified separately.
+    alpha = FreeParameter("alpha")
+    expr = sqrt(alpha)
+
+    assert isinstance(expr, FreeParameterExpression)
+    assert expr == FreeParameterExpression(sympy.sqrt(alpha.expression))
+    assert str(expr) == "sqrt(alpha)"
+    assert repr(expr) == "sqrt(alpha)"
 
 
 def test_helpers_accept_numeric_inputs():
     assert isinstance(sin(0), FreeParameterExpression)
-    assert isinstance(sqrt(4), FreeParameterExpression)
     assert isinstance(mod(5, 2), FreeParameterExpression)
 
 
-def test_sin_partial_and_full_substitution():
-    alpha = FreeParameter("alpha")
-    beta = FreeParameter("beta")
-    expr = sin(alpha + beta)
-
-    partial = expr.subs({"alpha": 0})
-    assert isinstance(partial, FreeParameterExpression)
-    assert str(partial) == "sin(beta)"
-
-    assert expr.subs({"alpha": 0, "beta": 0}) == 0
-
-
 @pytest.mark.parametrize(
-    ("helper", "sympy_function", "bound"),
+    ("helper", "bound"),
     [
-        (sin, sympy.sin, 0),
-        (cos, sympy.cos, 0),
-        (tan, sympy.tan, 0),
-        (arcsin, sympy.asin, 0),
-        (arccos, sympy.acos, 0),
-        (arctan, sympy.atan, 0),
-        (exp, sympy.exp, 0),
-        (log, sympy.log, 1),
-        (sqrt, sympy.sqrt, 4),
-        (ceiling, sympy.ceiling, 0),
-        (floor, sympy.floor, 0),
+        (sin, 0),
+        (cos, 0),
+        (tan, 0),
+        (arcsin, 0),
+        (arccos, 0),
+        (arctan, 0),
+        (exp, 0),
+        (log, 1),
+        (sqrt, 4),
+        (ceiling, 0),
+        (floor, 0),
     ],
 )
-def test_unary_helper_partial_and_full_substitution(helper, sympy_function, bound):
+def test_unary_helper_partial_and_full_substitution(helper, bound):
     alpha = FreeParameter("alpha")
     beta = FreeParameter("beta")
     expr = helper(alpha + beta)
@@ -143,7 +118,7 @@ def test_unary_helper_partial_and_full_substitution(helper, sympy_function, boun
     # symbolic constant (e.g. arccos(0) -> pi/2), so compare through SymPy.
     full = expr.subs({"alpha": bound, "beta": 0})
     assert FreeParameterExpression(full) == FreeParameterExpression(
-        sympy_function(sympy.Integer(bound))
+        HELPER_TO_SYMPY[helper](sympy.Integer(bound))
     )
 
 

--- a/test/unit_tests/braket/parametric/test_functions.py
+++ b/test/unit_tests/braket/parametric/test_functions.py
@@ -1,0 +1,166 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import pytest
+import sympy
+
+from braket.parametric import (
+    FreeParameter,
+    FreeParameterExpression,
+    arccos,
+    arcsin,
+    arctan,
+    ceiling,
+    cos,
+    exp,
+    floor,
+    log,
+    mod,
+    sin,
+    sqrt,
+    tan,
+)
+
+
+@pytest.mark.parametrize(
+    ("helper", "sympy_function", "extra_args", "expected"),
+    [
+        (sin, sympy.sin, (), "sin(alpha)"),
+        (cos, sympy.cos, (), "cos(alpha)"),
+        (tan, sympy.tan, (), "tan(alpha)"),
+        (arcsin, sympy.asin, (), "arcsin(alpha)"),
+        (arccos, sympy.acos, (), "arccos(alpha)"),
+        (arctan, sympy.atan, (), "arctan(alpha)"),
+        (exp, sympy.exp, (), "exp(alpha)"),
+        (log, sympy.log, (), "log(alpha)"),
+        (mod, sympy.Mod, (2,), "mod(alpha, 2)"),
+        (ceiling, sympy.ceiling, (), "ceiling(alpha)"),
+        (floor, sympy.floor, (), "floor(alpha)"),
+    ],
+)
+def test_helper_constructs_expected_expression(helper, sympy_function, extra_args, expected):
+    alpha = FreeParameter("alpha")
+    expr = helper(alpha, *extra_args)
+    expected_expr = FreeParameterExpression(sympy_function(alpha.expression, *extra_args))
+
+    assert isinstance(expr, FreeParameterExpression)
+    assert expr == expected_expr
+    assert str(expr) == expected
+    assert repr(expr) == expected
+
+
+def test_sqrt_constructs_expected_expression():
+    # SymPy represents sqrt as a Pow expression, so it is verified separately.
+    alpha = FreeParameter("alpha")
+    expr = sqrt(alpha)
+
+    assert isinstance(expr, FreeParameterExpression)
+    assert expr == FreeParameterExpression(sympy.sqrt(alpha.expression))
+    assert str(expr) == "sqrt(alpha)"
+    assert repr(expr) == "sqrt(alpha)"
+
+
+@pytest.mark.parametrize(
+    ("helper", "extra_args"),
+    [
+        (sin, ()),
+        (cos, ()),
+        (tan, ()),
+        (arcsin, ()),
+        (arccos, ()),
+        (arctan, ()),
+        (exp, ()),
+        (log, ()),
+        (sqrt, ()),
+        (mod, (2,)),
+        (ceiling, ()),
+        (floor, ()),
+    ],
+)
+def test_helper_expression_round_trip(helper, extra_args):
+    alpha = FreeParameter("alpha")
+    expr = helper(alpha / 2, *extra_args)
+    rebuilt = FreeParameterExpression(expr.expression)
+
+    assert rebuilt == expr
+    assert str(rebuilt) == str(expr)
+
+
+def test_helpers_accept_numeric_inputs():
+    assert isinstance(sin(0), FreeParameterExpression)
+    assert isinstance(sqrt(4), FreeParameterExpression)
+    assert isinstance(mod(5, 2), FreeParameterExpression)
+
+
+def test_sin_partial_and_full_substitution():
+    alpha = FreeParameter("alpha")
+    beta = FreeParameter("beta")
+    expr = sin(alpha + beta)
+
+    partial = expr.subs({"alpha": 0})
+    assert isinstance(partial, FreeParameterExpression)
+    assert str(partial) == "sin(beta)"
+
+    assert expr.subs({"alpha": 0, "beta": 0}) == 0
+
+
+@pytest.mark.parametrize(
+    ("helper", "sympy_function", "bound"),
+    [
+        (sin, sympy.sin, 0),
+        (cos, sympy.cos, 0),
+        (tan, sympy.tan, 0),
+        (arcsin, sympy.asin, 0),
+        (arccos, sympy.acos, 0),
+        (arctan, sympy.atan, 0),
+        (exp, sympy.exp, 0),
+        (log, sympy.log, 1),
+        (sqrt, sympy.sqrt, 4),
+        (ceiling, sympy.ceiling, 0),
+        (floor, sympy.floor, 0),
+    ],
+)
+def test_unary_helper_partial_and_full_substitution(helper, sympy_function, bound):
+    alpha = FreeParameter("alpha")
+    beta = FreeParameter("beta")
+    expr = helper(alpha + beta)
+
+    partial = expr.subs({"alpha": 0})
+    assert isinstance(partial, FreeParameterExpression)
+    assert partial == helper(beta)
+
+    # A fully bound result may be a Python number, a SymPy number, or an exact
+    # symbolic constant (e.g. arccos(0) -> pi/2), so compare through SymPy.
+    full = expr.subs({"alpha": bound, "beta": 0})
+    assert FreeParameterExpression(full) == FreeParameterExpression(
+        sympy_function(sympy.Integer(bound))
+    )
+
+
+def test_mod_substitution():
+    alpha = FreeParameter("alpha")
+    beta = FreeParameter("beta")
+    expr = mod(alpha + beta, 2)
+
+    partial = expr.subs({"alpha": 0})
+    assert isinstance(partial, FreeParameterExpression)
+    assert str(partial) == "mod(beta, 2)"
+
+    assert expr.subs({"alpha": 1, "beta": 2}) == 1
+
+
+def test_mod_unwraps_second_operand():
+    alpha = FreeParameter("alpha")
+    beta = FreeParameter("beta")
+
+    assert str(mod(alpha, beta)) == "mod(alpha, beta)"


### PR DESCRIPTION
*Issue #, if available:*
Closes [#1252](https://github.com/amazon-braket/amazon-braket-sdk-python/issues/1252)

*Description of changes:*
Adds support for math functions in `FreeParameterExpression`.

- Adds `braket.parametric` helpers for `sin`, `cos`, `tan`, `arcsin`, `arccos`, `arctan`, `exp`, `log`, `sqrt`, `mod`, `ceiling`, and `floor`, returning `FreeParameterExpression` values without requiring direct SymPy use.
- Updates `str`/`repr` so supported SymPy functions serialize with OpenQASM names (`arcsin`, `arccos`, `arctan`, `mod`). Functions without an OpenQASM equivalent (`Abs`, `re`, `im`, `conjugate`) now raise `ValueError` instead of emitting invalid QASM.
  
*Testing done:*
`tox -e unit-tests`, `tox -e linters_check`, and `tox -e docs`.

**AI disclosure:** I used GPT-5.5 from OpenAI Codex as a support tool while working through the printer and helper tests. The implementation choices, final edits, and verification are mine. I reviewed the code and ran the tests listed above.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
