### PR TITLE
feature: add weighted PauliString sums

### DIFF
--- a/src/braket/quantum_information/__init__.py
+++ b/src/braket/quantum_information/__init__.py
@@ -16,4 +16,4 @@ includes the PauliString class for representing and manipulating tensor products
 of Pauli operators.
 """
 
-from braket.quantum_information.pauli_string import PauliString  # noqa: F401
+from braket.quantum_information.pauli_string import PauliString, PauliStringSum  # noqa: F401

--- a/src/braket/quantum_information/pauli_string.py
+++ b/src/braket/quantum_information/pauli_string.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import itertools
+from numbers import Real
 
 from braket.circuits.circuit import Circuit
 from braket.circuits.observables import I, TensorProduct, X, Y, Z
@@ -217,16 +218,34 @@ class PauliString:
             self._nontrivial = out_pauli_string._nontrivial
         return out_pauli_string
 
-    def __mul__(self, other: PauliString) -> PauliString:
-        """Right multiplication operator overload using `dot()`.
+    def __add__(self, other: PauliString | PauliStringSum) -> PauliStringSum:
+        """Adds this Pauli string to another Pauli string or Pauli-string sum."""
+        return PauliStringSum(self) + other
 
-        Returns the result of multiplying the current circuit by the argument on its right.
+    def __radd__(self, other: PauliStringSum) -> PauliStringSum:
+        """Adds this Pauli string to another Pauli-string sum."""
+        return PauliStringSum(self) + other
+
+    def __sub__(self, other: PauliString | PauliStringSum) -> PauliStringSum:
+        """Subtracts another Pauli string or Pauli-string sum from this Pauli string."""
+        return PauliStringSum(self) - other
+
+    def __rsub__(self, other: PauliStringSum) -> PauliStringSum:
+        """Subtracts this Pauli string from another Pauli-string sum."""
+        return other - PauliStringSum(self)
+
+    def __mul__(self, other: PauliString | PauliStringSum | Real) -> PauliString | PauliStringSum:
+        """Right multiplication operator overload.
+
+        Returns the result of multiplying the current Pauli string by the argument on its right.
+        If `other` is real-valued, returns a weighted Pauli-string sum.
 
         Args:
-            other (PauliString): The right multiplicand.
+            other (PauliString | PauliStringSum | Real): The right multiplicand or scalar
+                coefficient.
 
         Returns:
-            PauliString: The resultant circuit from right multiplying `self` with `other`.
+            PauliString | PauliStringSum: The resultant Pauli string or weighted sum.
 
         Raises:
             ValueError: If the lengths of the Pauli strings being multiplied differ.
@@ -234,7 +253,17 @@ class PauliString:
         See Also:
             `braket.quantum_information.PauliString.dot()`
         """
+        if isinstance(other, Real):
+            return PauliStringSum([(float(other), str(self))])
+        if isinstance(other, PauliStringSum):
+            return other.__rmul__(self)
         return self.dot(other)
+
+    def __rmul__(self, other: Real) -> PauliStringSum:
+        """Left scalar multiplication operator overload."""
+        if isinstance(other, Real):
+            return PauliStringSum([(float(other), str(self))])
+        return NotImplemented
 
     def __imul__(self, other: PauliString) -> PauliString:
         """Operator overload for right-multiplication assignment (`*=`) using `dot()`.
@@ -408,3 +437,143 @@ class PauliString:
             elif state == -2:
                 circ.h(qubit).si(qubit)
         return circ
+
+
+class PauliStringSum:
+    """A weighted sum of Pauli strings."""
+
+    def __init__(self, terms: PauliString | PauliStringSum | list[tuple[float, str]] | None = None):
+        """Initializes a `PauliStringSum`.
+
+        Args:
+            terms (PauliString | PauliStringSum | list[tuple[float, str]] | None): The terms to
+                populate the sum with. Tuple terms have the form `(coefficient, pauli_string)`.
+        """
+        self._terms: dict[str, tuple[float, PauliString]] = {}
+        self._qubit_count: int | None = None
+
+        if terms is None:
+            return
+        if isinstance(terms, PauliString):
+            self._add_term(1.0, terms)
+            return
+        if isinstance(terms, PauliStringSum):
+            self._terms = dict(terms._terms)
+            self._qubit_count = terms._qubit_count
+            return
+        for coefficient, pauli_string in terms:
+            self._add_term(coefficient, PauliString(pauli_string))
+
+    @property
+    def qubit_count(self) -> int | None:
+        """int | None: The qubit count of contained Pauli strings, or `None` for empty sums."""
+        return self._qubit_count
+
+    @property
+    def terms(self) -> tuple[tuple[float, PauliString], ...]:
+        """tuple[tuple[float, PauliString], ...]: The weighted Pauli-string terms."""
+        return tuple(self._terms.values())
+
+    @classmethod
+    def from_terms(cls, terms: list[tuple[float, str]]) -> PauliStringSum:
+        """Creates a sum from a list of `(coefficient, pauli_string)` tuples."""
+        return cls(terms)
+
+    def to_terms(self) -> list[tuple[float, str]]:
+        """Returns this sum as a list of `(coefficient, pauli_string)` tuples."""
+        return [(coefficient, str(pauli_string)) for coefficient, pauli_string in self.terms]
+
+    def __add__(self, other: PauliString | PauliStringSum) -> PauliStringSum:
+        out = PauliStringSum(self)
+        if isinstance(other, PauliString):
+            out._add_term(1.0, other)
+        elif isinstance(other, PauliStringSum):
+            for coefficient, pauli_string in other.terms:
+                out._add_term(coefficient, pauli_string)
+        else:
+            return NotImplemented
+        return out
+
+    def __radd__(self, other: PauliString) -> PauliStringSum:
+        return self + other
+
+    def __sub__(self, other: PauliString | PauliStringSum) -> PauliStringSum:
+        return self + (-1 * other)
+
+    def __rsub__(self, other: PauliString) -> PauliStringSum:
+        return (-1 * self) + other
+
+    def __mul__(self, other: Real | PauliString) -> PauliStringSum:
+        out = PauliStringSum()
+        if isinstance(other, Real):
+            for coefficient, pauli_string in self.terms:
+                out._add_term(float(other) * coefficient, pauli_string)
+        elif isinstance(other, PauliString):
+            for coefficient, pauli_string in self.terms:
+                out._add_term(coefficient, pauli_string * other)
+        else:
+            return NotImplemented
+        return out
+
+    def __rmul__(self, other: Real | PauliString) -> PauliStringSum:
+        out = PauliStringSum()
+        if isinstance(other, Real):
+            return self * other
+        if isinstance(other, PauliString):
+            for coefficient, pauli_string in self.terms:
+                out._add_term(coefficient, other * pauli_string)
+        else:
+            return NotImplemented
+        return out
+
+    def __neg__(self) -> PauliStringSum:
+        return -1 * self
+
+    def __contains__(self, item: PauliString) -> bool:
+        pauli_string = self._positive_pauli_string(PauliString(item))
+        return str(pauli_string) in self._terms
+
+    def __getitem__(self, index: int) -> tuple[float, PauliString]:
+        return self.terms[index]
+
+    def __len__(self) -> int:
+        return len(self._terms)
+
+    def __iter__(self):
+        return iter(self.terms)
+
+    def __eq__(self, other: PauliStringSum) -> bool:
+        return isinstance(other, PauliStringSum) and self.terms == other.terms
+
+    def __repr__(self) -> str:
+        return f"PauliStringSum({self.to_terms()})"
+
+    def _add_term(self, coefficient: float, pauli_string: PauliString) -> None:
+        if not isinstance(coefficient, Real):
+            raise TypeError("PauliStringSum coefficients must be real numbers")
+        if self._qubit_count is None:
+            self._qubit_count = pauli_string.qubit_count
+        elif self._qubit_count != pauli_string.qubit_count:
+            raise ValueError(
+                f"Pauli string must be of length ({self._qubit_count}), "
+                f"not {pauli_string.qubit_count}"
+            )
+
+        normalized = self._positive_pauli_string(pauli_string)
+        normalized_coefficient = float(coefficient) * pauli_string.phase
+        key = str(normalized)
+        new_coefficient = normalized_coefficient + self._terms.get(key, (0.0, normalized))[0]
+        if new_coefficient:
+            self._terms[key] = (new_coefficient, normalized)
+        else:
+            self._terms.pop(key, None)
+            if not self._terms:
+                self._qubit_count = None
+
+    @staticmethod
+    def _positive_pauli_string(pauli_string: PauliString) -> PauliString:
+        out = PauliString.__new__(PauliString)
+        out._phase = 1
+        out._qubit_count = pauli_string.qubit_count
+        out._nontrivial = dict(pauli_string._nontrivial)
+        return out

--- a/test/unit_tests/braket/quantum_information/test_pauli_string.py
+++ b/test/unit_tests/braket/quantum_information/test_pauli_string.py
@@ -21,7 +21,7 @@ import pytest
 from braket.circuits import gates
 from braket.circuits.circuit import Circuit
 from braket.circuits.observables import I, X, Y, Z
-from braket.quantum_information import PauliString
+from braket.quantum_information import PauliString, PauliStringSum
 
 ORDER = ["I", "X", "Y", "Z"]
 PAULI_INDEX_MATRICES = {
@@ -260,3 +260,48 @@ def test_power_invalid_exp(circ, n, operation):
 )
 def test_to_circuit(circ, circ_res):
     assert circ.to_circuit() == circ_res
+
+
+def test_pauli_string_sum_from_terms_combines_like_terms():
+    pauli_sum = PauliStringSum.from_terms([(1.5, "XI"), (2, "-XI"), (3, "IZ")])
+
+    assert pauli_sum.qubit_count == 2
+    assert pauli_sum.to_terms() == [(-0.5, "+XI"), (3.0, "+IZ")]
+
+
+def test_pauli_string_sum_add_subtract_and_scalar_multiply():
+    first = PauliString("XI")
+    second = PauliString("IZ")
+
+    pauli_sum = 2 * first + second - PauliString("-XI")
+
+    assert isinstance(pauli_sum, PauliStringSum)
+    assert pauli_sum.to_terms() == [(3.0, "+XI"), (1.0, "+IZ")]
+    assert (0.5 * pauli_sum).to_terms() == [(1.5, "+XI"), (0.5, "+IZ")]
+    assert (-pauli_sum).to_terms() == [(-3.0, "+XI"), (-1.0, "+IZ")]
+
+
+def test_pauli_string_sum_multiplies_by_pauli_string_on_right_and_left():
+    pauli_sum = PauliStringSum.from_terms([(2, "XI"), (3, "IZ")])
+
+    assert (pauli_sum * PauliString("ZI")).to_terms() == [(-2.0, "+YI"), (3.0, "+ZZ")]
+    assert (PauliString("ZI") * pauli_sum).to_terms() == [(2.0, "+YI"), (3.0, "+ZZ")]
+
+
+def test_pauli_string_sum_index_and_contains():
+    pauli_sum = PauliStringSum.from_terms([(2, "-XI"), (3, "IZ")])
+
+    assert PauliString("XI") in pauli_sum
+    assert PauliString("-XI") in pauli_sum
+    assert pauli_sum[0] == (-2.0, PauliString("XI"))
+    assert len(pauli_sum) == 2
+
+
+@pytest.mark.xfail(raises=ValueError)
+def test_pauli_string_sum_rejects_unequal_lengths():
+    PauliStringSum.from_terms([(1, "XI"), (1, "Z")])
+
+
+@pytest.mark.xfail(raises=TypeError)
+def test_pauli_string_sum_rejects_non_real_coefficients():
+    PauliStringSum.from_terms([(1j, "X")])

--- a/test/unit_tests/braket/quantum_information/test_pauli_string.py
+++ b/test/unit_tests/braket/quantum_information/test_pauli_string.py
@@ -295,6 +295,47 @@ def test_pauli_string_sum_index_and_contains():
     assert PauliString("-XI") in pauli_sum
     assert pauli_sum[0] == (-2.0, PauliString("XI"))
     assert len(pauli_sum) == 2
+    assert list(pauli_sum) == list(pauli_sum.terms)
+    assert repr(pauli_sum) == "PauliStringSum([(-2.0, '+XI'), (3.0, '+IZ')])"
+
+
+def test_pauli_string_sum_empty_copy_and_cancellation():
+    empty = PauliStringSum()
+    assert empty.qubit_count is None
+    assert empty.to_terms() == []
+
+    original = PauliStringSum(PauliString("XI"))
+    copied = PauliStringSum(original)
+    assert copied == original
+    assert copied != PauliStringSum(PauliString("IZ"))
+    assert copied != PauliString("XI")
+
+    cancelled = original + PauliString("-XI")
+    assert cancelled.to_terms() == []
+    assert cancelled.qubit_count is None
+
+
+def test_pauli_string_and_sum_reverse_arithmetic():
+    first = PauliString("XI")
+    second = PauliString("IZ")
+    pauli_sum = PauliStringSum.from_terms([(2, "XI"), (3, "IZ")])
+
+    assert (first + pauli_sum).to_terms() == [(3.0, "+XI"), (3.0, "+IZ")]
+    assert (pauli_sum + first).to_terms() == [(3.0, "+XI"), (3.0, "+IZ")]
+    assert (first - pauli_sum).to_terms() == [(-1.0, "+XI"), (-3.0, "+IZ")]
+    assert (pauli_sum - first).to_terms() == [(1.0, "+XI"), (3.0, "+IZ")]
+    assert (second - pauli_sum).to_terms() == [(-2.0, "+IZ"), (-2.0, "+XI")]
+
+
+def test_pauli_string_sum_unsupported_operands_return_not_implemented():
+    pauli_string = PauliString("X")
+    pauli_sum = PauliStringSum(pauli_string)
+    unsupported = object()
+
+    assert pauli_string.__rmul__(unsupported) is NotImplemented
+    assert pauli_sum.__add__(unsupported) is NotImplemented
+    assert pauli_sum.__mul__(unsupported) is NotImplemented
+    assert pauli_sum.__rmul__(unsupported) is NotImplemented
 
 
 @pytest.mark.xfail(raises=ValueError)


### PR DESCRIPTION
*Issue #, if available:*
Closes #1256

*Description of changes:*
- Adds a PauliStringSum container for weighted sums of PauliString objects.
- Supports addition, subtraction, scalar multiplication, multiplication by PauliString, iteration, lookup, and coefficient normalization.
- Exports PauliStringSum from braket.quantum_information.

*Testing done:*
- .\.venv\Scripts\python -m pytest -o addopts='' test\unit_tests\braket\quantum_information\test_pauli_string.py -q
- .\.venv\Scripts\python -m ruff check src\braket\quantum_information\pauli_string.py

## Merge Checklist

#### General
- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.