### PR TITLE
fix: accept division in FreeParameterExpression strings

### DIFF
--- a/src/braket/parametric/free_parameter_expression.py
+++ b/src/braket/parametric/free_parameter_expression.py
@@ -54,6 +54,7 @@ class FreeParameterExpression:
             ast.Add: self.__add__,
             ast.Sub: self.__sub__,
             ast.Mult: self.__mul__,
+            ast.Div: self.__truediv__,
             ast.Pow: self.__pow__,
             ast.USub: self.__neg__,
         }

--- a/test/unit_tests/braket/parametric/test_free_parameter_expression.py
+++ b/test/unit_tests/braket/parametric/test_free_parameter_expression.py
@@ -52,9 +52,21 @@ def test_equality_str():
     assert hasattr(expr_1.expression, "free_symbols") and hasattr(expr_2.expression, "free_symbols")
 
 
+@pytest.mark.parametrize(
+    ("string_expr", "operator_expr"),
+    [
+        ("theta/alpha", FreeParameter("theta") / FreeParameter("alpha")),
+        ("theta/2", FreeParameter("theta") / 2),
+        ("2/theta", 2 / FreeParameter("theta")),
+    ],
+)
+def test_truediv_str(string_expr: str, operator_expr: FreeParameterExpression) -> None:
+    assert FreeParameterExpression(string_expr) == operator_expr
+
+
 @pytest.mark.xfail(raises=ValueError)
 def test_unsupported_bin_op_str():
-    FreeParameterExpression("theta/1")
+    FreeParameterExpression("theta//1")
 
 
 @pytest.mark.xfail(raises=ValueError)


### PR DESCRIPTION
## Summary
- Add `ast.Div` to the string-expression parser operation map so `FreeParameterExpression(alpha/beta)` follows the same path as `FreeParameter(alpha) / FreeParameter(beta)`.
- Add regression coverage for parameter/parameter, parameter/constant, and constant/parameter string division.
- Keep unsupported binary operations covered by switching the negative parser test to floor division.

Closes #1251

## Verification
- `python -m pytest test/unit_tests/braket/parametric/test_free_parameter_expression.py -q`
- `python -m ruff format --check src/braket/parametric/free_parameter_expression.py test/unit_tests/braket/parametric/test_free_parameter_expression.py`
- `python -m ruff check src/braket/parametric/free_parameter_expression.py`
- `git diff --check`
- Manual sanity check: `FreeParameterExpression(alpha/beta) == FreeParameter(alpha) / FreeParameter(beta)`

## AI assistance disclosure
I used OpenAI Codex to inspect the relevant parser/test paths and run local validation. The final patch is a focused two-file change that I reviewed against the issue acceptance criteria before submission.

## Merge Checklist

#### General
- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (not needed for this parser regression)

#### Tests
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my tests are not configured for a specific region or account

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.