### PR TITLE
feature: count circuit instructions

### DIFF
--- a/src/braket/circuits/circuit.py
+++ b/src/braket/circuits/circuit.py
@@ -172,6 +172,33 @@ class Circuit:
         """Iterable[Instruction]: Get an `iterable` of instructions in the circuit."""
         return list(self._moments.values())
 
+    def count(
+        self, operator: str | None = None, target: QubitSetInput | None = None
+    ) -> int | Counter[str]:
+        """Count circuit instructions by operator name.
+
+        Args:
+            operator (str | None): Optional operator name to count. Matching is case-insensitive.
+                If omitted, all instruction operators are counted.
+            target (QubitSetInput | None): Optional target qubit or qubits. When provided, only
+                instructions that include every requested target qubit are counted.
+
+        Returns:
+            int | Counter[str]: Count for `operator`, or a counter of all operator names when
+            `operator` is omitted.
+        """
+        target_qubits = QubitSet(target) if target is not None else None
+        counts = Counter(
+            instruction.operator.name.lower()
+            for instruction in self.instructions
+            if target_qubits is None or all(qubit in instruction.target for qubit in target_qubits)
+        )
+
+        if operator is not None:
+            return counts[operator.lower()]
+
+        return counts
+
     @property
     def result_types(self) -> list[ResultType]:
         """list[ResultType]: Get a list of requested result types in the circuit."""

--- a/test/unit_tests/braket/circuits/test_circuit.py
+++ b/test/unit_tests/braket/circuits/test_circuit.py
@@ -202,6 +202,29 @@ def test_str(h):
     assert str(h) == expected
 
 
+def test_count_operator() -> None:
+    circ = Circuit().h(0).cnot(0, 1).x(1).cnot(1, 2)
+
+    assert circ.count("cnot") == 2
+    assert circ.count("CNOT") == 2
+    assert circ.count("h") == 1
+    assert circ.count("rx") == 0
+
+
+def test_count_all_operators() -> None:
+    circ = Circuit().h(0).cnot(0, 1).x(1).cnot(1, 2)
+
+    assert dict(circ.count()) == {"h": 1, "cnot": 2, "x": 1}
+
+
+def test_count_by_target() -> None:
+    circ = Circuit().h(0).cnot(0, 1).x(2).cnot(1, 2)
+
+    assert dict(circ.count(target=1)) == {"cnot": 2}
+    assert circ.count("cnot", target=[1, 2]) == 1
+    assert circ.count("x", target=0) == 0
+
+
 def test_equality():
     circ_1 = Circuit().h(0).probability([0, 1])
     circ_2 = Circuit().h(0).probability([0, 1])


### PR DESCRIPTION
*Issue #, if available:*
Closes #1235

*Description of changes:*
Adds `Circuit.count()` for instruction operator counts. It returns the case-insensitive count for a requested operator, for example `circuit.count("cnot")`, and returns counts for all operators when no operator is provided. It can also limit counts to instructions touching a requested target qubit set.

*Testing done:*
- `uv run --extra test python -m pytest -n 0 test/unit_tests/braket/circuits/test_circuit.py`
- `uv run --with ruff ruff check src/braket/circuits/circuit.py`
- `git diff --check`

unitaryHACK:
- Registered GitHub user: @jamilahmadzai
- Payout: unitaryHACK event registration for @jamilahmadzai; no PR-specific public wallet/payment rail is requested in the issue.
- Tooling disclosure: LLM assistance was used while preparing this patch; the final diff and validation are included above.

## Merge Checklist

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.