### PR TITLE
fix: make TrackingContext thread-safe

### DIFF
--- a/src/braket/tracking/tracking_context.py
+++ b/src/braket/tracking/tracking_context.py
@@ -13,10 +13,13 @@
 
 from __future__ import annotations
 
+import threading
+
 
 class TrackingContext:
     def __init__(self):
         self._trackers = set()
+        self._lock = threading.Lock()
 
     def register_tracker(self, tracker: Tracker) -> None:  # noqa: F821
         """Registers a tracker.
@@ -24,7 +27,8 @@ class TrackingContext:
         Args:
             tracker (Tracker): The tracker.
         """
-        self._trackers.add(tracker)
+        with self._lock:
+            self._trackers.add(tracker)
 
     def deregister_tracker(self, tracker: Tracker) -> None:  # noqa: F821
         """Deregisters a tracker.
@@ -32,7 +36,8 @@ class TrackingContext:
         Args:
             tracker (Tracker): The tracker.
         """
-        self._trackers.remove(tracker)
+        with self._lock:
+            self._trackers.remove(tracker)
 
     def broadcast_event(self, event: _TrackingEvent) -> None:  # noqa: F821
         """Broadcasts an event to all trackers.
@@ -40,7 +45,11 @@ class TrackingContext:
         Args:
             event (_TrackingEvent): The event to broadcast.
         """
-        for tracker in self._trackers:
+        # Iterate over a snapshot so that trackers registering or deregistering
+        # concurrently (or from receive_event) cannot mutate the set mid-iteration.
+        with self._lock:
+            trackers = list(self._trackers)
+        for tracker in trackers:
             tracker.receive_event(event)
 
     def active_trackers(self) -> set:

--- a/test/unit_tests/braket/tracking/test_tracking_context.py
+++ b/test/unit_tests/braket/tracking/test_tracking_context.py
@@ -42,3 +42,20 @@ def test_broadcast_event():
     broadcast_event("EVENT")
     tracker.receive_event.assert_called_with("EVENT")
     deregister_tracker(tracker)
+
+
+def test_broadcast_event_tracker_deregisters_during_broadcast():
+    class SelfDeregisteringTracker:
+        def __init__(self):
+            self.events = []
+
+        def receive_event(self, event):
+            self.events.append(event)
+            deregister_tracker(self)
+
+    trackers = [SelfDeregisteringTracker() for _ in range(2)]
+    for tracker in trackers:
+        register_tracker(tracker)
+    broadcast_event("EVENT")
+    assert all(tracker.events == ["EVENT"] for tracker in trackers)
+    assert active_trackers() == set()


### PR DESCRIPTION
*Issue #, if available:* Fixes #1319

*Description of changes:*

`TrackingContext` shares one process-global `set` of trackers; `broadcast_event()` (called on every `get_quantum_task()`) iterates it while `Tracker` context managers on other threads add/remove entries, which intermittently raises `RuntimeError: Set changed size during iteration`. This change guards the set with a `threading.Lock` and has `broadcast_event` iterate over a snapshot, so the lock is never held across tracker callbacks.

*Testing done:*
- New unit test where a tracker deregisters itself during a broadcast; it fails on `main` with the `RuntimeError` above and passes with this change.
- Ran the threaded reproduction script from #1319 (1,000,000 broadcasts under concurrent `Tracker` enter/exit churn): no error after the fix.
- `pytest test/unit_tests/braket/tracking test/unit_tests/braket/aws/test_aws_session.py`: 110 passed, 4 xfailed. `ruff format --check` and `ruff check src` clean.

AI disclosure: this PR was prepared with the assistance of Claude Code (Anthropic's Claude); I review and test all changes.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#pr-title-format)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.