### PR TITLE
documentation: add llms.txt generation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,11 +1,14 @@
 """Sphinx configuration."""
 
 import datetime
+import os
 import shutil
 import subprocess
 import sys
 from importlib.metadata import version
 from pathlib import Path
+
+from sphinx.application import Sphinx
 
 DOC_DIR = Path(__file__).parent
 SCRIPT_PATH = DOC_DIR / "update_examples.py"
@@ -84,3 +87,61 @@ apidoc_template_dir = "_templates"
 typehints_fully_qualified = False
 always_document_param_types = True
 typehints_document_rtype = True
+
+LLMS_TXT_TITLE = "Amazon Braket Python SDK"
+LLMS_TXT_SUMMARY = (
+    "Open source Python SDK to design and build quantum circuits, submit them to "
+    "Amazon Braket devices as quantum tasks, and monitor their execution."
+)
+LLMS_TXT_BASE_URL = "https://amazon-braket-sdk-python.readthedocs.io/en/stable/"
+LLMS_TXT_SECTIONS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("Docs", ()),
+    ("Examples", ("examples",)),
+    ("API Reference", (f"{apidoc_output_dir}/",)),
+)
+
+
+def _llms_txt_section(docname: str) -> str:
+    """Return the llms.txt section heading a document belongs under."""
+    for heading, prefixes in LLMS_TXT_SECTIONS:
+        if any(docname.startswith(prefix) for prefix in prefixes):
+            return heading
+    return LLMS_TXT_SECTIONS[0][0]
+
+
+def _write_llms_txt(app: Sphinx, exception: Exception | None) -> None:
+    """Write llms.txt, a manifest of every built page for LLM discoverability.
+
+    The format follows https://llmstxt.org: an H1 name, a blockquote summary, then
+    one file list per H2 section. Pages are grouped so that an agent can tell
+    narrative docs, runnable examples and generated API reference apart.
+    """
+    if exception or app.builder.name != "html":
+        return
+
+    # Read the Docs passes the canonical URL to every build automatically, so this
+    # is set in any RTD build and the default only applies elsewhere. See
+    # https://docs.readthedocs.com/platform/stable/canonical-urls.html#how-to-specify-the-canonical-url
+    base_url = os.environ.get("READTHEDOCS_CANONICAL_URL", LLMS_TXT_BASE_URL)
+    if base_url and not base_url.endswith("/"):
+        base_url += "/"
+
+    env = app.env
+    sections: dict[str, list[str]] = {heading: [] for heading, _ in LLMS_TXT_SECTIONS}
+    for docname in sorted(env.all_docs):
+        url = f"{base_url}{app.builder.get_target_uri(docname)}"
+        sections[_llms_txt_section(docname)].append(f"- [{env.titles[docname].astext()}]({url})")
+
+    lines = [f"# {LLMS_TXT_TITLE}", "", f"> {LLMS_TXT_SUMMARY}"]
+    for heading, _ in LLMS_TXT_SECTIONS:
+        if sections[heading]:
+            lines += ["", f"## {heading}", "", *sections[heading]]
+
+    out = Path(app.outdir) / "llms.txt"
+    out.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(f"--> Wrote {out.name}")
+
+
+def setup(app: Sphinx) -> None:
+    """Register build hooks."""
+    app.connect("build-finished", _write_llms_txt)

--- a/tox.ini
+++ b/tox.ini
@@ -78,6 +78,10 @@ extras = docs
 deps =
     {[test-deps]deps}
     m2r2
+# Read the Docs sets this automatically in its own builds; declaring it here lets
+# a local build inject the base URL used in llms.txt.
+pass_env =
+    READTHEDOCS_CANONICAL_URL
 commands =
     sphinx-build -E -T -b html doc build/documentation/html -j auto
 


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Add llms.txt to the root of readthedocs.io domain for LLM discoverability.

*Testing done:* manual `READTHEDOCS_CANONICAL_URL='https://amazon-braket-sdk-python.readthedocs.io/en/stable/' tox -e docs` produces the desired `llms.txt` file.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
