### PR TITLE
fix: support single circuits with noise in run_batch

### DIFF
--- a/src/braket/devices/local_simulator.py
+++ b/src/braket/devices/local_simulator.py
@@ -161,19 +161,21 @@ class LocalSimulator(Device):
             raise NotImplementedError("LocalSimulator.run_batch does not support per-task shots.")
         inputs = inputs or {}
 
-        if self._noise_model:
-            task_specifications = [
-                self._noise_model.apply(task_specification)
-                for task_specification in task_specifications
-            ]
-
-        if not max_parallel:
-            max_parallel = cpu_count()
-
         single_task = isinstance(
             task_specifications,
             Circuit | OpenQASMProgram | Problem | AnalogHamiltonianSimulation,
         )
+
+        if self._noise_model:
+            if single_task:
+                task_specifications = self._noise_model.apply(task_specifications)
+            else:
+                task_specifications = [
+                    self._noise_model.apply(task_specification)
+                    for task_specification in task_specifications
+                ]
+
+        max_parallel = max_parallel or cpu_count()
 
         single_input = isinstance(inputs, dict)
 

--- a/src/braket/devices/local_simulator.py
+++ b/src/braket/devices/local_simulator.py
@@ -167,15 +167,14 @@ class LocalSimulator(Device):
         )
 
         if self._noise_model:
-            if single_task:
-                task_specifications = self._noise_model.apply(task_specifications)
-            else:
-                task_specifications = [
+            task_specifications = (
+                self._noise_model.apply(task_specifications)
+                if single_task
+                else [
                     self._noise_model.apply(task_specification)
                     for task_specification in task_specifications
                 ]
-
-        max_parallel = max_parallel or cpu_count()
+            )
 
         single_input = isinstance(inputs, dict)
 
@@ -202,7 +201,7 @@ class LocalSimulator(Device):
             payloads.append(self._construct_payload(task_specification, input_map, shots))
 
         results = self._delegate.run_multiple(
-            payloads, *args, shots=shots, max_parallel=max_parallel, **kwargs
+            payloads, *args, shots=shots, max_parallel=max_parallel or cpu_count(), **kwargs
         )
         return LocalQuantumTaskBatch([self._to_result_object(result) for result in results])
 

--- a/test/unit_tests/braket/devices/test_local_simulator.py
+++ b/test/unit_tests/braket/devices/test_local_simulator.py
@@ -920,6 +920,22 @@ def test_run_batch_with_noise_model(mock_run_multiple, noise_model):
         assert mock_apply.call_count == 2
 
 
+@patch.object(DummyProgramDensityMatrixSimulator, "run_multiple")
+def test_run_batch_single_circuit_with_noise_model(mock_run_multiple, noise_model):
+    mock_run_multiple.return_value = [GATE_MODEL_RESULT]
+    device = LocalSimulator("dummy_oq3_dm", noise_model=noise_model)
+    circuit = Circuit().h(0).cnot(0, 1)
+
+    with patch.object(device._noise_model, "apply", wraps=device._noise_model.apply) as mock_apply:
+        results = device.run_batch(circuit, shots=4).results()
+
+    assert len(results) == 1
+    mock_apply.assert_called_once_with(circuit)
+    payloads = mock_run_multiple.call_args.args[0]
+    assert len(payloads) == 1
+    assert "#pragma braket noise bit_flip(0.05) q[0]" in payloads[0].source
+
+
 @patch.object(DummyProgramDensityMatrixSimulator, "run")
 def test_run_noisy_circuit_with_noise_model(mock_run, noise_model):
     mock_run.return_value = GATE_MODEL_RESULT


### PR DESCRIPTION
*Issue #, if available:*

Fixes #1337

*Description of changes:*

Detect a single task specification before applying the configured noise model. Apply the noise model once for a single circuit while preserving the existing behavior for a list of circuits.

Add a regression test that verifies a single circuit is accepted, receives the noise instructions, and produces one result.

*Testing done:*

- `python -m pytest -o addopts="" -q test/unit_tests`
- `ruff check src`
- `ruff format --check .`

## Merge Checklist

#### General

- [x] I have read the CONTRIBUTING doc
- [x] I used the PR title format described in CONTRIBUTING
- [x] I have updated any necessary documentation, including READMEs and API docs, if appropriate

#### Tests

- [x] I have added tests that prove my fix is effective
- [x] I have checked that my tests are not configured for a specific region or account

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.