### PR TITLE
feature: add outputs to GateModelQuantumTaskResult

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "amazon-braket-schemas>=1.27.0",
+    "amazon-braket-schemas>=1.30.0",
     "amazon-braket-default-simulator>=1.32.0",
     "oqpy~=0.3.7",
     "backoff",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,8 @@ test = [
 ]
 type-check = [
     "mypy==2.3.0",
+    # numpy>=2.5 stubs use PEP 695 syntax, unsupported on Python 3.11
+    "numpy==2.4.6",
 ]
 docs = [
     "sphinx",

--- a/src/braket/tasks/gate_model_quantum_task_result.py
+++ b/src/braket/tasks/gate_model_quantum_task_result.py
@@ -88,6 +88,10 @@ class GateModelQuantumTaskResult:
             `measurement_probabilities` were copied from device. If false,
             `measurement_probabilities` are calculated from device data. Default is None.
             Only available when shots > 0.
+        outputs (list[dict[str, Any]] | None): The per-shot values of the OpenQASM ``output``
+            variables declared by the program. Each entry is one shot, mapping output
+            variable name to its value for that shot. Default is None. Only available
+            when shots > 0 and the program declares at least one ``output`` variable.
     """
 
     task_metadata: TaskMetadata
@@ -101,6 +105,7 @@ class GateModelQuantumTaskResult:
     measurements_copied_from_device: bool = None
     measurement_counts_copied_from_device: bool = None
     measurement_probabilities_copied_from_device: bool = None
+    outputs: list[dict[str, Any]] = None
 
     _result_types_indices: dict[str, int] = None
 
@@ -316,6 +321,7 @@ class GateModelQuantumTaskResult:
             measurements_copied_from_device=measurements_copied_from_device,
             measurement_counts_copied_from_device=m_counts_copied_from_device,
             measurement_probabilities_copied_from_device=m_probabilities_copied_from_device,
+            outputs=result.outputs,
         )
 
     @classmethod


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds an `outputs` field to `GateModelQuantumTaskResult` that surfaces the per-shot values of a program's OpenQASM output variables. Corresponds to https://github.com/amazon-braket/amazon-braket-default-simulator-python/pull/399. Requires `amazon-braket-schemas>=1.30.0` for the underlying schema field.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [ ] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
