### PR TITLE
fix: honor HTTP(S)_PROXY when fetching the price list

### DIFF
--- a/src/braket/tracking/pricing.py
+++ b/src/braket/tracking/pricing.py
@@ -17,6 +17,8 @@ import csv
 import io
 import os
 from functools import lru_cache
+from urllib.parse import urlparse
+from urllib.request import getproxies, proxy_bypass
 
 import urllib3
 
@@ -30,11 +32,11 @@ class Pricing:
         # Using AWS Pricing Bulk API. Format for the response is described at
         # https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/reading-an-offer.html
 
-        http = urllib3.PoolManager()
         price_url = os.environ.get(
             "BRAKET_PRICE_OFFERS_URL",
             "https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonBraket/current/index.csv",
         )
+        http = _http_client(price_url)
         response = http.request(
             "GET",
             price_url,
@@ -68,6 +70,22 @@ class Pricing:
         return [
             entry for entry in self._price_list if all(entry[k] == v for k, v in kwargs.items())
         ]
+
+
+def _http_client(url: str) -> urllib3.PoolManager:
+    """Creates an HTTP client honoring the standard proxy environment variables.
+
+    Args:
+        url (str): The URL the client will be used to request.
+
+    Returns:
+        PoolManager: A proxy-aware client if a proxy applies to `url`, otherwise a direct one.
+    """
+    parsed = urlparse(url)
+    proxy = getproxies().get(parsed.scheme)
+    if proxy and not proxy_bypass(parsed.netloc):
+        return urllib3.ProxyManager(proxy)
+    return urllib3.PoolManager()
 
 
 _pricing = Pricing()

--- a/test/unit_tests/braket/tracking/test_pricing.py
+++ b/test/unit_tests/braket/tracking/test_pricing.py
@@ -16,7 +16,7 @@ from unittest.mock import patch
 
 import pytest
 
-from braket.tracking.pricing import Pricing
+from braket.tracking.pricing import Pricing, _http_client
 
 
 @pytest.fixture
@@ -49,3 +49,40 @@ def test_price_offer_env_var(mock_http):
     pricer.get_prices()
 
     mock_http.request.assert_called_with("GET", "https://myurl", preload_content=False)
+
+
+@patch.dict("os.environ", {"HTTPS_PROXY": "http://proxy.internal:8080"}, clear=True)
+def test_http_client_uses_proxy():
+    with patch("urllib3.ProxyManager") as proxy_manager:
+        assert _http_client("https://pricing.us-east-1.amazonaws.com/index.csv") is (
+            proxy_manager.return_value
+        )
+    proxy_manager.assert_called_once_with("http://proxy.internal:8080")
+
+
+@patch.dict(
+    "os.environ",
+    {"HTTPS_PROXY": "http://proxy.internal:8080", "NO_PROXY": "pricing.us-east-1.amazonaws.com"},
+    clear=True,
+)
+def test_http_client_honors_no_proxy():
+    with patch("urllib3.PoolManager") as pool_manager:
+        assert _http_client("https://pricing.us-east-1.amazonaws.com/index.csv") is (
+            pool_manager.return_value
+        )
+
+
+@patch.dict("os.environ", {"HTTP_PROXY": "http://proxy.internal:8080"}, clear=True)
+def test_http_client_ignores_proxy_for_other_scheme():
+    with patch("urllib3.PoolManager") as pool_manager:
+        assert _http_client("https://pricing.us-east-1.amazonaws.com/index.csv") is (
+            pool_manager.return_value
+        )
+
+
+@patch("braket.tracking.pricing.getproxies", return_value={})
+def test_http_client_without_proxy(_getproxies):
+    with patch("urllib3.PoolManager") as pool_manager:
+        assert _http_client("https://pricing.us-east-1.amazonaws.com/index.csv") is (
+            pool_manager.return_value
+        )


### PR DESCRIPTION
### Problem

`Pricing.get_prices()` downloads the AWS Pricing Bulk API offer file with a bare
`urllib3.PoolManager()`, which never consults the proxy environment variables. On a
machine that can only reach the internet through a proxy the cost tracker fails, even
though the rest of the SDK works there because botocore honors `HTTP(S)_PROXY`.

Fixes #465.

### Fix

Pick the client based on the proxy configuration for the offer file's scheme: a
`ProxyManager` when a proxy applies, the existing direct `PoolManager` otherwise.
`NO_PROXY` is respected via `urllib.request.proxy_bypass`.

### Verification

- Repro with two local HTTP servers (one standing in for the proxy) and
  `BRAKET_PRICE_OFFERS_URL` pointing at the other: before the change the request hit the
  origin directly; after it goes through the proxy, and setting `NO_PROXY=127.0.0.1`
  sends it direct again with the CSV parsed correctly.
- With no proxy configured, `_http_client` still returns a plain `PoolManager`.
- 4 new unit tests; `pytest test/unit_tests` → 3472 passed, 131 xfailed.
- `ruff check src` and `ruff format --check .` clean.

AI disclosure: this PR was prepared with the assistance of Claude Code (Anthropic's Claude); I review and test all changes.