### PR TITLE
fix: treat scalar observables as one observable

### DIFF
--- a/src/braket/program_sets/circuit_binding.py
+++ b/src/braket/program_sets/circuit_binding.py
@@ -112,7 +112,9 @@ class CircuitBinding:
         self,
         circuit: Circuit | str,
         input_sets: ParameterSetsLike | None = None,
-        observables: Sequence[Observable | PauliString | str] | Sum | None = None,
+        observables: (
+            Observable | PauliString | str | Sum | Sequence[Observable | PauliString | str] | None
+        ) = None,
     ):
         """
         A single parametrized circuit and multiple parameter sets and observables.
@@ -132,8 +134,10 @@ class CircuitBinding:
             circuit (Circuit | str): The parametrized circuit, either as a Circuit object or as
                 an OpenQASM string.
             input_sets (ParameterSetsLike | None): The inputs to the circuit, if specified.
-            observables (Sequence[Observable | PauliString | str] | Sum | None): The observables
-                or Hamiltonian to measure, if specified.
+            observables (Observable | PauliString | str | Sum |
+                Sequence[Observable | PauliString | str] | None): A single observable, Pauli
+                string, Pauli word, Sum Hamiltonian, or a sequence of observables to measure,
+                if specified.
 
         Examples:
             >>> circuit = Circuit().rx(0, FreeParameter("theta")).cnot(0, 1)
@@ -141,6 +145,7 @@ class CircuitBinding:
             >>> # observable = [X(0) @ Z(1), Z(0) @ Y(1)]  # Or a list of single-term observables
             >>> binding = CircuitBinding(circuit, {"theta": [1.23, 1.73, 0.73]}, observable)
         """
+        observables = CircuitBinding._to_observables(observables)
         if not input_sets and not observables:
             raise ValueError("At least one of input_sets and observables must be specified")
         if (
@@ -153,19 +158,23 @@ class CircuitBinding:
             raise ValueError("Circuit cannot have result types")
         self._circuit = circuit
         self._input_sets = ParameterSets(input_sets) if input_sets else None
-        self._observables = CircuitBinding._to_observables(observables)
+        self._observables = observables
         self._injection_plan = (
             _plan_injection(circuit) if isinstance(circuit, str) and self._observables else None
         )
 
     @staticmethod
     def _to_observables(
-        observables: Sequence[Observable | PauliString | str] | Sum | None,
+        observables: (
+            Observable | PauliString | str | Sum | Sequence[Observable | PauliString | str] | None
+        ),
     ) -> Sequence[Observable] | Sum | None:
         if not observables:
             return None
         if isinstance(observables, Sum):
             return observables
+        if isinstance(observables, (Observable, PauliString, str)):
+            observables = [observables]
         obs = []
         for o in observables:
             if isinstance(o, Observable):

--- a/src/braket/program_sets/program_set.py
+++ b/src/braket/program_sets/program_set.py
@@ -23,6 +23,7 @@ from braket.circuits.observables import Sum
 from braket.circuits.serialization import IRType
 from braket.program_sets.circuit_binding import CircuitBinding
 from braket.pulse import PulseSequence
+from braket.quantum_information import PauliString
 from braket.registers import QubitSet
 
 
@@ -316,7 +317,9 @@ class ProgramSet:
     @staticmethod
     def product(
         circuits: Sequence[Circuit | CircuitBinding],
-        observables: Sum | Sequence[Observable],
+        observables: (
+            Observable | PauliString | str | Sum | Sequence[Observable | PauliString | str]
+        ),
         shots_per_executable: int | None = None,
     ) -> ProgramSet:
         """
@@ -330,8 +333,9 @@ class ProgramSet:
         Args:
             circuits (Sequence[Circuit] | CircuitBinding): The parametrized circuit with parameters
                 or set of fixed circuits to run with multiple observables.
-            observables (Sum | Sequence[Observable]): A set of observables to measure
-                with the circuits.
+            observables (Observable | PauliString | str | Sum |
+                Sequence[Observable | PauliString | str]): A single observable, Pauli string,
+                Pauli word, or a sequence of observables to measure with the circuits.
             shots_per_executable (int | None): The number of shots to run each executable;
                 this will be used to enforce the total shots on task creation. If not provided,
                 the only validation at task creation will be divisibility by number of executables.

--- a/test/unit_tests/braket/program_sets/test_circuit_binding.py
+++ b/test/unit_tests/braket/program_sets/test_circuit_binding.py
@@ -117,6 +117,22 @@ def test_string_in_list():
     )
 
 
+@pytest.mark.parametrize(
+    ("observable", "expected"),
+    [
+        ("-XZ", -1 * X() @ Z()),
+        (PauliString("-XZ"), -1 * X() @ Z()),
+        (X(0) @ Z(1), X(0) @ Z(1)),
+    ],
+)
+def test_single_observable(observable, expected):
+    circuit = Circuit().h(0).cnot(0, 1)
+    binding = CircuitBinding(circuit, observables=observable)
+
+    assert binding.observables == [expected]
+    assert len(binding) == 1
+
+
 def test_sum_in_observable_list():
     with pytest.raises(TypeError):
         CircuitBinding(Circuit().h(0), observables=[X(0) + Y(0)])

--- a/test/unit_tests/braket/program_sets/test_program_set.py
+++ b/test/unit_tests/braket/program_sets/test_program_set.py
@@ -451,6 +451,13 @@ def test_product_observables(circuit_rx_parametrized):
     )
 
 
+def test_product_single_pauli_word():
+    program_set = ProgramSet.product([Circuit().h(0).cnot(0, 1)], observables="XZ")
+
+    assert program_set.total_executables == 1
+    assert program_set[0].observables == [X() @ Z()]
+
+
 def test_product_sum(circuit_rx_parametrized):
     ghz2 = ghz(2)
     ghz3 = ghz(3)


### PR DESCRIPTION
*Issue #, if available:*

Closes #1341

*Description of changes:*

`CircuitBinding` now accepts a single `Observable`, `PauliString`, or Pauli word string and treats it as one observable. This keeps multi-qubit Pauli words intact and preserves signed Pauli strings.

`ProgramSet.product()` accepts the same scalar inputs. `ProgramSet.zip()` is unchanged because its observables are matched positionally to circuits.

*Testing done:*

- `pytest -n 0 -q test/unit_tests/braket/program_sets`
- `ruff format --check src/braket/program_sets/circuit_binding.py src/braket/program_sets/program_set.py test/unit_tests/braket/program_sets/test_circuit_binding.py test/unit_tests/braket/program_sets/test_program_set.py`
- `ruff check src`
- `mypy`

## Merge Checklist

#### General

- [x] I have read the contributing guide
- [x] I used the required PR title format
- [x] I updated the relevant type hints and API documentation

#### Tests

- [x] I added tests that prove the fix works
- [x] The tests do not depend on a specific region or account

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.