### PR TITLE
documentation: fix hybrid job example reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,16 +109,17 @@ from braket.aws import AwsQuantumJob
 
 job = AwsQuantumJob.create(
     device="arn:aws:braket:::device/quantum-simulator/amazon/sv1",
-    source_module="job.py",
-    entry_point="job:run_job",
+    source_module="examples/hybrid_job_script.py",
+    entry_point="hybrid_job_script:run_hybrid_job",
+    hyperparameters={"num_tasks": 5},
     wait_until_complete=True,
 )
 print(job.result())
 ```
-where `run_job` is a function in the file `job.py`.
+where `run_hybrid_job` is a function in `examples/hybrid_job_script.py`.
 
 
-The code sample imports the Amazon Braket framework, then creates a hybrid job with the entry point being the `run_job` function. The hybrid job creates quantum tasks against the SV1 AWS Simulator. The hybrid job runs synchronously, and prints logs until it completes. The complete example can be found in `../examples/job.py`.
+The code sample imports the Amazon Braket framework, then creates a hybrid job with the entry point being the `run_hybrid_job` function. The hybrid job creates quantum tasks against the SV1 AWS Simulator. The hybrid job runs synchronously, and prints logs until it completes. The complete example can be found in [`examples/hybrid_job_script.py`](examples/hybrid_job_script.py).
 
 ### Available Simulators
 Amazon Braket provides access to two types of simulators: fully managed simulators, available through the Amazon Braket service, and the local simulators that are part of the Amazon Braket SDK.


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Update the hybrid-job README example to use the maintained `examples/hybrid_job_script.py` source file, its `run_hybrid_job` entry point, and the required `num_tasks` hyperparameter. Replace the nonexistent `../examples/job.py` reference with a working repository-relative link.

*Testing done:*

- Ran `git diff --check`.
- Compiled `examples/hybrid_job_script.py` with Python successfully.
- Confirmed the documented source path, entry point, function signature, and hyperparameter match the maintained example.

## Merge Checklist

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [x] I have updated any necessary documentation, including READMEs and API docs (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (not applicable: documentation-only correction)
- [ ] I have checked that my tests are not configured for a specific region or account (not applicable: no tests added)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
