### PR TITLE
fix: allow computing MeasuredEntry expectation from program set measurements

### DIFF
--- a/src/braket/tasks/program_set_quantum_task_result.py
+++ b/src/braket/tasks/program_set_quantum_task_result.py
@@ -138,13 +138,21 @@ class MeasuredEntry:
 
     @property
     def expectation(self) -> float | None:
-        """
-        float | None: The expectation value of this entry's observable if there is one.
-        """
-        # TODO: Use program set payload to calculate expectation
+        """float | None: The expectation value of this entry's observable, if there is one."""
         if self._expectation is None:
-            warnings.warn("No observable was measured", stacklevel=1)
+            warnings.warn(
+                "No observable was measured; the raw measurements are still available. "
+                "Use compute_expectation(observable) to compute an expectation value from "
+                "them.",
+                stacklevel=1,
+            )
         return self._expectation
+
+    def compute_expectation(self, observable: Observable) -> float:
+        """float: The expectation of ``observable`` computed from this entry's measurements."""
+        return expectation_from_measurements(
+            self.measurements, self.measured_qubits, observable, observable.targets
+        )
 
 
 class CompositeEntry:

--- a/test/unit_tests/braket/tasks/test_program_set_quantum_task_result.py
+++ b/test/unit_tests/braket/tasks/test_program_set_quantum_task_result.py
@@ -13,6 +13,7 @@
 
 import json
 import warnings
+from collections import Counter
 from unittest.mock import Mock, patch
 
 import numpy as np
@@ -283,6 +284,26 @@ def test_local(result_local, metadata, execution_failure):
         assert success.expectation is None
     assert entry[1] == BraketSchemaBase.parse_raw_schema(json.dumps(execution_failure))
     assert result.task_metadata == BraketSchemaBase.parse_raw_schema(json.dumps(metadata))
+
+
+def test_expectation_from_measurements_without_attached_observable():
+    """Regression test for #1316: expectation is recoverable from measurements per observable."""
+    # wire 0 always 0 (<Z> = +1); wire 1 always 1 (<Z> = -1)
+    entry = MeasuredEntry(
+        measurements=np.array([[0, 1]] * 10),
+        counts=Counter({"01": 10}),
+        probabilities={"01": 1.0},
+        measured_qubits=[0, 1],
+        measurements_from_device=True,
+        probabilities_from_device=False,
+        program="",
+        inputs=None,
+        observable=None,
+    )
+    with pytest.warns(UserWarning):
+        assert entry.expectation is None
+    assert np.isclose(entry.compute_expectation(Z(0)), 1.0)
+    assert np.isclose(entry.compute_expectation(Z(1)), -1.0)
 
 
 @patch("braket.tasks.program_set_quantum_task_result.boto3.client")


### PR DESCRIPTION
*Issue #, if available:*
Resolves #1316.

*Description of changes:*
In cases where the `MeasuredEntry` did not have an `observable` set, the `expectation` property returns `None`. However, the consumer may know which observable should be computed. This PR adds a `compute_expectation` function to `MeasuredEntry` which accepts an observable and computes the corresponding expectation.

*Testing done:*
Test added for new functionality. tox passes.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the PR title format described in [CONTRIBUTING](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#PR-title-format)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/README.md) and [API docs](https://github.com/amazon-braket/amazon-braket-sdk-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
