### PR TITLE
fix: validate each factor of a tensor product observable in the emulator

### DIFF
--- a/src/braket/emulation/passes/circuit_passes/result_type_validator.py
+++ b/src/braket/emulation/passes/circuit_passes/result_type_validator.py
@@ -16,6 +16,7 @@ from collections.abc import Iterable, Mapping
 from braket.device_schema.result_type import ResultType
 
 from braket.circuits import Circuit
+from braket.circuits.observables import TensorProduct
 from braket.circuits.result_type import ObservableResultType
 from braket.emulation.passes import ValidationPass
 
@@ -74,13 +75,20 @@ class ResultTypeValidator(ValidationPass):
                 )
 
             if isinstance(result_type, ObservableResultType):
-                observable_name = result_type.observable.name.lower()
-                if observable_name not in self._supported_result_types[result_type.name]:
-                    raise ValueError(
-                        f"Observable {observable_name} is not supported for result type "
-                        f"{result_type.name} on this device. Supported observables are: "
-                        f"{self._supported_result_types[result_type.name]}."
-                    )
+                observable = result_type.observable
+                # Devices only report the primitive observables they support, so a tensor
+                # product is supported when each of its factors is.
+                factors = (
+                    observable.factors if isinstance(observable, TensorProduct) else (observable,)
+                )
+                for factor in factors:
+                    observable_name = factor.name.lower()
+                    if observable_name not in self._supported_result_types[result_type.name]:
+                        raise ValueError(
+                            f"Observable {observable_name} is not supported for result type "
+                            f"{result_type.name} on this device. Supported observables are: "
+                            f"{self._supported_result_types[result_type.name]}."
+                        )
 
             # Check if target qubits are valid qubits in the device
             target = result_type.target

--- a/test/unit_tests/braket/emulation/passes/test_result_type_validator.py
+++ b/test/unit_tests/braket/emulation/passes/test_result_type_validator.py
@@ -101,12 +101,20 @@ def test_invalid_qubit_target():
         ).validate(circuit)
 
 
-def test_observables(supported_result_types, connectivity_graph):
-    circuit = Circuit().h(0).cnot(0, 1).sample(Observable.Z(0) @ Observable.Z(1))
-    observable_name = circuit.result_types[0].observable.name.lower()
+def test_tensor_product_observable(supported_result_types, connectivity_graph):
+    """
+    A tensor product is supported when each of its factors is.
+    """
+    circuit = Circuit().h(0).cnot(0, 1).sample(Observable.Z(0) @ Observable.X(1))
+    ResultTypeValidator(supported_result_types, connectivity_graph).validate(circuit)
+
+
+def test_observables(connectivity_graph):
+    supported_result_types = [ResultType(name="Sample", observables=["z"])]
+    circuit = Circuit().h(0).cnot(0, 1).sample(Observable.Z(0) @ Observable.X(1))
     error_messasge = re.escape(
-        f"Observable {observable_name} is not supported for result type Sample on this device. "
-        f"Supported observables are: ['x', 'y', 'z', 'h', 'i']."
+        "Observable x is not supported for result type Sample on this device. "
+        "Supported observables are: ['z']."
     )
     with pytest.raises(
         ValueError,


### PR DESCRIPTION
### Problem

`ResultTypeValidator` compares the observable's own name against the device's supported observables:

```python
observable_name = result_type.observable.name.lower()
if observable_name not in self._supported_result_types[result_type.name]:
```

For a tensor product like `Observable.Z() @ Observable.Z()` that name is `"TensorProduct"`, which can never appear in a device's `supportedResultTypes` since devices only report primitive observables (`["x", "y", "z", "h", "i"]`). So the local emulator rejects every result type with a tensor product observable, even though those run fine on the device:

```
EmulatorValidationError: Observable tensorproduct is not supported for result type
Expectation on this device. Supported observables are: ['x', 'y', 'z', 'h', 'i'].
```

### Fix

Validate each factor of a tensor product individually, so the product is accepted when all its factors are supported, and the error message names the factor that is not.

### Verification

- New `test_tensor_product_observable` and the updated `test_observables` both fail on `main` and pass with the fix.
- End to end against a `LocalEmulator.from_json(...)` built from IQM-style device properties: `Expectation(Z @ Z)` inside a verbatim box now validates and runs (`emulator.run(circuit, shots=100).result()`), while `Z @ Hermitian` is still rejected with `Observable hermitian is not supported ...`. Both raised `tensorproduct` before the change.
- `pytest test/unit_tests` — 3491 passed, 131 xfailed; `ruff format --check .` and `ruff check src` clean; `mypy` clean.

AI disclosure: this PR was prepared with the assistance of Claude Code (Anthropic's Claude); I review and test all changes.